### PR TITLE
feat(bq-java): BigQueryFinOpsSink (closes #9)

### DIFF
--- a/data-pipeline-libraries-java/data-pipeline-gcp-bigquery-java/README.md
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-bigquery-java/README.md
@@ -126,7 +126,7 @@ ServiceLoader.load(Warehouse.class).findFirst()
 
 - ✅ `BigQueryWarehouse` — issue [#6](https://github.com/enrichmeai/gcp-pipeline-reference/issues/6) (Warehouse contract)
 - ✅ `BigQueryJobControlRepository` — issue [#8](https://github.com/enrichmeai/gcp-pipeline-reference/issues/8) (JobControlRepository contract); see section below
-- ⏳ `BigQueryFinOpsSink` — issue [#9](https://github.com/enrichmeai/gcp-pipeline-reference/issues/9) (FinOpsSink contract); not yet implemented
+- ✅ `BigQueryFinOpsSink` — issue [#9](https://github.com/enrichmeai/gcp-pipeline-reference/issues/9) (FinOpsSink contract); see section below
 
 All three share this module's `pom.xml`.
 
@@ -188,3 +188,50 @@ mvn -f data-pipeline-libraries-java/pom.xml -pl data-pipeline-gcp-bigquery-java 
 ```
 
 Live-cloud integration tests against a real BigQuery dataset (or the BigQuery emulator) are sprint-2+ scope.
+
+## BigQueryFinOpsSink
+
+Implementation of [`FinOpsSink`](../data-pipeline-core-java/src/main/java/com/enrichmeai/culvert/contracts/FinOpsSink.java) — receives `(CostMetrics, FinOpsTag)` pairs and streams them into the configured `cost_metrics` BigQuery table via `BigQuery.insertAll`.
+
+### Construction
+
+```java
+BigQuery client = BigQueryOptions.newBuilder().setProjectId("my-project").build().getService();
+FinOpsSink sink = new BigQueryFinOpsSink(
+        client,
+        "my-project",
+        "finops",              // dataset
+        "cost_metrics");       // table (the DEFAULT_TABLE constant)
+```
+
+Like its siblings, this class is not `AutoCloseable`; consumer owns the client.
+
+### Row shape
+
+Every `record(metrics, tags)` call writes one row. The columns flatten both records:
+
+| Column | Source | Type |
+|---|---|---|
+| `system`, `environment`, `cost_center`, `owner` | `FinOpsTag` | STRING |
+| `tag_run_id` | `FinOpsTag.runId()` | STRING (separate from `run_id` so analysts can detect attribution drift) |
+| `tag_extra` | `FinOpsTag.extra()` | `ARRAY<STRUCT<key STRING, value STRING>>` |
+| `run_id` | `CostMetrics.runId()` | STRING |
+| `estimated_cost_usd` | `CostMetrics` | FLOAT64 |
+| `billed_bytes_scanned`, `billed_bytes_written`, `billed_bytes_stored`, `billed_messages_count`, `slot_millis` | `CostMetrics` | INT64 |
+| `compute_units` | `CostMetrics` | FLOAT64 |
+| `labels` | `CostMetrics.labels()` | `ARRAY<STRUCT<key STRING, value STRING>>` |
+| `timestamp` | `CostMetrics.timestamp()` | TIMESTAMP (ISO-8601 string) |
+
+The flattened `labels` / `tag_extra` shape avoids BigQuery DDL changes when teams add new tag keys — new keys just appear in the array.
+
+### Streaming buffer + cost
+
+`insertAll` is BigQuery's streaming insert path. Rows are queryable within seconds but are NOT immediately visible to `COPY`/`EXPORT` jobs (streaming buffer flushes on BigQuery's schedule, typically within 90 minutes). Streaming inserts incur a per-GB cost on top of regular storage. For very high-volume cost emission, consider a load-job-based variant in a future sprint.
+
+### Partial failures
+
+`InsertAllResponse` can succeed at the request level while reporting per-row errors. `BigQueryFinOpsSink.FinOpsInsertException` (extends `RuntimeException`) is thrown if `response.hasErrors()` returns true — silently dropping cost rows would defeat the FinOps audit trail. The exception carries the underlying `Map<Long, List<BigQueryError>>` so callers can report specific row failures.
+
+### ServiceLoader registration
+
+`src/main/resources/META-INF/services/com.enrichmeai.culvert.contracts.FinOpsSink` lists the impl. Same no-arg-constructor caveat as the siblings — sprint-4 auto-config will resolve it.

--- a/data-pipeline-libraries-java/data-pipeline-gcp-bigquery-java/src/main/java/com/enrichmeai/culvert/gcp/bigquery/BigQueryFinOpsSink.java
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-bigquery-java/src/main/java/com/enrichmeai/culvert/gcp/bigquery/BigQueryFinOpsSink.java
@@ -1,0 +1,182 @@
+package com.enrichmeai.culvert.gcp.bigquery;
+
+import com.enrichmeai.culvert.contracts.FinOpsSink;
+import com.enrichmeai.culvert.finops.CostMetrics;
+import com.enrichmeai.culvert.finops.FinOpsTag;
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryError;
+import com.google.cloud.bigquery.InsertAllRequest;
+import com.google.cloud.bigquery.InsertAllResponse;
+import com.google.cloud.bigquery.TableId;
+
+import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * {@link FinOpsSink} implementation backed by Google Cloud BigQuery streaming
+ * inserts ({@code insertAll}).
+ *
+ * <p>Each {@link #record(CostMetrics, FinOpsTag)} call streams a single row
+ * into the configured {@code cost_metrics} table. The row carries every field
+ * from both {@link CostMetrics} and {@link FinOpsTag} flattened into the
+ * table's columns; {@link CostMetrics#labels()} and
+ * {@link FinOpsTag#extra()} flatten as {@code RECORD<key STRING, value STRING>}
+ * arrays (BigQuery's only stable way to ship arbitrary map data without DDL
+ * changes per row).
+ *
+ * <h2>Streaming buffer + cost</h2>
+ *
+ * <p>{@code insertAll} writes to BigQuery's streaming buffer. Rows are
+ * queryable within seconds but are NOT immediately visible to
+ * {@code COPY}/{@code EXPORT} jobs (streaming buffer flushes to managed
+ * storage on BigQuery's schedule — usually within 90 minutes). Streaming
+ * inserts also incur a per-GB cost on top of regular storage. For high-volume
+ * cost emission, consider a load-job-based variant in a future sprint.
+ *
+ * <h2>Partial failures</h2>
+ *
+ * <p>{@code InsertAllResponse} can succeed at the request level while
+ * reporting per-row errors. We treat any non-empty
+ * {@link InsertAllResponse#getInsertErrors()} as a hard failure and throw
+ * {@link FinOpsInsertException} — silently dropping cost rows would defeat
+ * the FinOps audit trail.
+ *
+ * <h2>Construction</h2>
+ *
+ * <p>Pass in a pre-built {@link BigQuery} client, the GCP project ID, the
+ * dataset, and the table name (default {@code cost_metrics} convention).
+ * Like {@link BigQueryWarehouse} and {@link BigQueryJobControlRepository},
+ * this class does NOT implement {@link AutoCloseable} — the BigQuery 2.x
+ * client itself is not closeable.
+ *
+ * <p>Sprint-1 deliverable for issue #9.
+ */
+public final class BigQueryFinOpsSink implements FinOpsSink {
+
+    /** Default table name when none specified. Matches the Python convention. */
+    public static final String DEFAULT_TABLE = "cost_metrics";
+
+    private static final DateTimeFormatter BQ_TIMESTAMP =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS");
+
+    private final BigQuery client;
+    private final TableId tableId;
+
+    /**
+     * Primary constructor.
+     *
+     * @param client    Pre-built BigQuery client. Required.
+     * @param projectId GCP project ID. Required.
+     * @param dataset   BigQuery dataset name. Required.
+     * @param table     BigQuery table name. Required.
+     * @throws NullPointerException if any argument is null.
+     */
+    public BigQueryFinOpsSink(BigQuery client, String projectId,
+                              String dataset, String table) {
+        this.client = Objects.requireNonNull(client, "client must not be null");
+        Objects.requireNonNull(projectId, "projectId must not be null");
+        Objects.requireNonNull(dataset, "dataset must not be null");
+        Objects.requireNonNull(table, "table must not be null");
+        this.tableId = TableId.of(projectId, dataset, table);
+    }
+
+    // TODO sprint-4 auto-config: no-arg constructor reading GCP_PROJECT,
+    // FINOPS_DATASET, FINOPS_TABLE. Skipped here because (client, projectId,
+    // dataset, table) bootstrap exceeds the pilot's "no-arg only if <=2 env
+    // vars" rule.
+
+    @Override
+    public void record(CostMetrics metrics, FinOpsTag tags) {
+        Objects.requireNonNull(metrics, "metrics must not be null");
+        Objects.requireNonNull(tags, "tags must not be null");
+
+        InsertAllRequest request = InsertAllRequest.newBuilder(tableId)
+                .addRow(toRow(metrics, tags))
+                .build();
+
+        InsertAllResponse response = client.insertAll(request);
+        if (response.hasErrors()) {
+            throw new FinOpsInsertException(metrics.runId(), response.getInsertErrors());
+        }
+    }
+
+    /**
+     * Build the wire row. Field naming convention: snake_case to match
+     * BigQuery's idiomatic column naming.
+     *
+     * <p>Visible for testing — production callers should use
+     * {@link #record(CostMetrics, FinOpsTag)}.
+     */
+    Map<String, Object> toRow(CostMetrics metrics, FinOpsTag tags) {
+        Map<String, Object> row = new LinkedHashMap<>();
+        // FinOpsTag attribution columns first — they're the cost-allocation key.
+        row.put("system", tags.system());
+        row.put("environment", tags.environment());
+        row.put("cost_center", tags.costCenter());
+        row.put("owner", tags.owner());
+        // tags.runId() and metrics.runId() should match in practice; we ship
+        // both and let the analyst spot any drift.
+        row.put("tag_run_id", tags.runId());
+        row.put("tag_extra", flattenMap(tags.extra()));
+
+        // CostMetrics columns.
+        row.put("run_id", metrics.runId());
+        row.put("estimated_cost_usd", metrics.estimatedCostUsd());
+        row.put("billed_bytes_scanned", metrics.billedBytesScanned());
+        row.put("billed_bytes_written", metrics.billedBytesWritten());
+        row.put("billed_bytes_stored", metrics.billedBytesStored());
+        row.put("billed_messages_count", metrics.billedMessagesCount());
+        row.put("slot_millis", metrics.slotMillis());
+        row.put("compute_units", metrics.computeUnits());
+        row.put("labels", flattenMap(metrics.labels()));
+
+        // BigQuery TIMESTAMP wants either ISO-8601 or "yyyy-MM-dd HH:mm:ss.SSSSSS UTC";
+        // ISO-8601 is widely accepted by insertAll JSON encoding.
+        row.put("timestamp", metrics.timestamp().toString());
+
+        return row;
+    }
+
+    /**
+     * Flatten a {@code Map<String, String>} into a list of
+     * {@code {"key": k, "value": v}} records — BigQuery's stable
+     * representation for arbitrary-key map data without a schema update per
+     * row.
+     */
+    private static List<Map<String, String>> flattenMap(Map<String, String> map) {
+        if (map == null || map.isEmpty()) {
+            return List.of();
+        }
+        List<Map<String, String>> out = new java.util.ArrayList<>(map.size());
+        for (Map.Entry<String, String> e : map.entrySet()) {
+            Map<String, String> entry = new LinkedHashMap<>(2);
+            entry.put("key", e.getKey());
+            entry.put("value", e.getValue());
+            out.add(entry);
+        }
+        return out;
+    }
+
+    /**
+     * Thrown when BigQuery's streaming insert returns per-row errors. The
+     * underlying GCP {@link BigQueryError} list is preserved so callers can
+     * report the specific row failures.
+     */
+    public static final class FinOpsInsertException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+        private final transient Map<Long, List<BigQueryError>> insertErrors;
+
+        FinOpsInsertException(String runId, Map<Long, List<BigQueryError>> insertErrors) {
+            super("BigQuery streaming insert returned errors for runId=" + runId
+                    + " (" + insertErrors.size() + " row(s) failed)");
+            this.insertErrors = insertErrors;
+        }
+
+        public Map<Long, List<BigQueryError>> getInsertErrors() {
+            return insertErrors;
+        }
+    }
+}

--- a/data-pipeline-libraries-java/data-pipeline-gcp-bigquery-java/src/main/resources/META-INF/services/com.enrichmeai.culvert.contracts.FinOpsSink
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-bigquery-java/src/main/resources/META-INF/services/com.enrichmeai.culvert.contracts.FinOpsSink
@@ -1,0 +1,1 @@
+com.enrichmeai.culvert.gcp.bigquery.BigQueryFinOpsSink

--- a/data-pipeline-libraries-java/data-pipeline-gcp-bigquery-java/src/test/java/com/enrichmeai/culvert/gcp/bigquery/BigQueryFinOpsSinkTest.java
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-bigquery-java/src/test/java/com/enrichmeai/culvert/gcp/bigquery/BigQueryFinOpsSinkTest.java
@@ -1,0 +1,208 @@
+package com.enrichmeai.culvert.gcp.bigquery;
+
+import com.enrichmeai.culvert.finops.CostMetrics;
+import com.enrichmeai.culvert.finops.FinOpsTag;
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryError;
+import com.google.cloud.bigquery.InsertAllRequest;
+import com.google.cloud.bigquery.InsertAllResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link BigQueryFinOpsSink}. Mocks the BigQuery client so no
+ * real GCP credentials or network are required.
+ */
+@ExtendWith(MockitoExtension.class)
+class BigQueryFinOpsSinkTest {
+
+    private static final String PROJECT_ID = "my-project";
+    private static final String DATASET = "finops";
+    private static final String TABLE = "cost_metrics";
+
+    @Mock
+    private BigQuery client;
+
+    @Mock
+    private InsertAllResponse response;
+
+    private BigQueryFinOpsSink newSink() {
+        return new BigQueryFinOpsSink(client, PROJECT_ID, DATASET, TABLE);
+    }
+
+    private CostMetrics sampleMetrics() {
+        return CostMetrics.builder("run-1")
+                .estimatedCostUsd(0.42)
+                .billedBytesScanned(1_000_000L)
+                .billedBytesWritten(500_000L)
+                .slotMillis(2_500L)
+                .labels(Map.of("dataset", "warehouse", "team", "platform"))
+                .timestamp(Instant.parse("2026-01-15T10:30:00Z"))
+                .build();
+    }
+
+    private FinOpsTag sampleTag() {
+        return new FinOpsTag(
+                "retail-fdp", "prod", "cc-1234", "platform-team", "run-1",
+                Map.of("business_unit", "retail", "feature_flag", "exp_42"));
+    }
+
+    // --- happy paths -------------------------------------------------------
+
+    @Test
+    void recordCallsInsertAllOnce() {
+        when(response.hasErrors()).thenReturn(false);
+        when(client.insertAll(any(InsertAllRequest.class))).thenReturn(response);
+
+        BigQueryFinOpsSink sink = newSink();
+        sink.record(sampleMetrics(), sampleTag());
+
+        verify(client).insertAll(any(InsertAllRequest.class));
+    }
+
+    @Test
+    void rowCarriesAllCostMetricsAndTagFields() {
+        BigQueryFinOpsSink sink = newSink();
+        Map<String, Object> row = sink.toRow(sampleMetrics(), sampleTag());
+
+        // FinOpsTag columns
+        assertThat(row).containsEntry("system", "retail-fdp");
+        assertThat(row).containsEntry("environment", "prod");
+        assertThat(row).containsEntry("cost_center", "cc-1234");
+        assertThat(row).containsEntry("owner", "platform-team");
+        assertThat(row).containsEntry("tag_run_id", "run-1");
+
+        // CostMetrics columns
+        assertThat(row).containsEntry("run_id", "run-1");
+        assertThat(row).containsEntry("estimated_cost_usd", 0.42);
+        assertThat(row).containsEntry("billed_bytes_scanned", 1_000_000L);
+        assertThat(row).containsEntry("billed_bytes_written", 500_000L);
+        assertThat(row).containsEntry("slot_millis", 2_500L);
+        assertThat(row).containsEntry("timestamp", "2026-01-15T10:30:00Z");
+    }
+
+    @Test
+    void labelsAndExtraTagsFlattenToKeyValueRecords() {
+        BigQueryFinOpsSink sink = newSink();
+        Map<String, Object> row = sink.toRow(sampleMetrics(), sampleTag());
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, String>> labels = (List<Map<String, String>>) row.get("labels");
+        assertThat(labels).hasSize(2);
+        assertThat(labels).allSatisfy(entry ->
+                assertThat(entry).containsKeys("key", "value"));
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, String>> extra = (List<Map<String, String>>) row.get("tag_extra");
+        assertThat(extra).hasSize(2);
+    }
+
+    @Test
+    void emptyLabelsAndExtraProduceEmptyLists() {
+        BigQueryFinOpsSink sink = newSink();
+        CostMetrics zeroMetrics = CostMetrics.zero("run-2");
+        FinOpsTag zeroTag = FinOpsTag.of("sys", "dev", "cc", "owner", "run-2");
+
+        Map<String, Object> row = sink.toRow(zeroMetrics, zeroTag);
+
+        assertThat((List<?>) row.get("labels")).isEmpty();
+        assertThat((List<?>) row.get("tag_extra")).isEmpty();
+    }
+
+    @Test
+    void targetTableMatchesConstructedTriple() {
+        when(response.hasErrors()).thenReturn(false);
+        when(client.insertAll(any(InsertAllRequest.class))).thenReturn(response);
+
+        BigQueryFinOpsSink sink = newSink();
+        sink.record(sampleMetrics(), sampleTag());
+
+        ArgumentCaptor<InsertAllRequest> captor =
+                ArgumentCaptor.forClass(InsertAllRequest.class);
+        verify(client).insertAll(captor.capture());
+
+        InsertAllRequest req = captor.getValue();
+        assertThat(req.getTable().getProject()).isEqualTo(PROJECT_ID);
+        assertThat(req.getTable().getDataset()).isEqualTo(DATASET);
+        assertThat(req.getTable().getTable()).isEqualTo(TABLE);
+        assertThat(req.getRows()).hasSize(1);
+    }
+
+    // --- error paths -------------------------------------------------------
+
+    @Test
+    void partialFailureSurfacesAsFinOpsInsertException() {
+        when(response.hasErrors()).thenReturn(true);
+        when(response.getInsertErrors()).thenReturn(
+                Map.of(0L, List.of(new BigQueryError(
+                        "invalidQuery", "us-central1", "bad column"))));
+        when(client.insertAll(any(InsertAllRequest.class))).thenReturn(response);
+
+        BigQueryFinOpsSink sink = newSink();
+
+        assertThatThrownBy(() -> sink.record(sampleMetrics(), sampleTag()))
+                .isInstanceOf(BigQueryFinOpsSink.FinOpsInsertException.class)
+                .hasMessageContaining("run-1");
+    }
+
+    @Test
+    void nullMetricsRejected() {
+        BigQueryFinOpsSink sink = newSink();
+        assertThatThrownBy(() -> sink.record(null, sampleTag()))
+                .isInstanceOf(NullPointerException.class);
+        verify(client, never()).insertAll(any(InsertAllRequest.class));
+    }
+
+    @Test
+    void nullTagsRejected() {
+        BigQueryFinOpsSink sink = newSink();
+        assertThatThrownBy(() -> sink.record(sampleMetrics(), null))
+                .isInstanceOf(NullPointerException.class);
+        verify(client, never()).insertAll(any(InsertAllRequest.class));
+    }
+
+    @Test
+    void constructorRejectsNullClient() {
+        assertThatThrownBy(() -> new BigQueryFinOpsSink(null, PROJECT_ID, DATASET, TABLE))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void constructorRejectsNullProject() {
+        assertThatThrownBy(() -> new BigQueryFinOpsSink(client, null, DATASET, TABLE))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    // --- multi-call ordering ----------------------------------------------
+
+    @Test
+    void multipleSequentialRecordCallsEachInsertOneRow() {
+        when(response.hasErrors()).thenReturn(false);
+        when(client.insertAll(any(InsertAllRequest.class))).thenReturn(response);
+
+        BigQueryFinOpsSink sink = newSink();
+        sink.record(sampleMetrics(), sampleTag());
+        sink.record(sampleMetrics(), sampleTag());
+        sink.record(sampleMetrics(), sampleTag());
+
+        ArgumentCaptor<InsertAllRequest> captor =
+                ArgumentCaptor.forClass(InsertAllRequest.class);
+        verify(client, org.mockito.Mockito.times(3)).insertAll(captor.capture());
+        assertThat(captor.getAllValues()).allSatisfy(req ->
+                assertThat(req.getRows()).hasSize(1));
+    }
+}


### PR DESCRIPTION
Closes #9. Sprint-1 wave-3 — completes the bigquery module's three-contract set.

## What

- `BigQueryFinOpsSink` — streams `(CostMetrics, FinOpsTag)` pairs to a BigQuery `cost_metrics` table via `insertAll`. Row schema flattens both records; tag/label maps shipped as `ARRAY<STRUCT<key STRING, value STRING>>`.
- Custom `FinOpsInsertException` surfaces per-row partial-failure responses (never silently drops cost rows — defeats the FinOps audit trail).
- ServiceLoader registration at `META-INF/services/com.enrichmeai.culvert.contracts.FinOpsSink`.
- 11 Mockito tests: happy path + row shape + target-table verification + null inputs + empty maps + multi-call sequencing + partial-failure exception.
- README: appended FinOpsSink section; updated sibling-adapter status table.

## Tests

```
mvn -pl data-pipeline-gcp-bigquery-java -am clean test
# 33 (core) + 11 (FinOpsSink) + 12 (Warehouse) + 17 (JobControlRepository) — BUILD SUCCESS
```

Full sprint-1 reactor: 33 + 4 + 12 + 17 + 11 + 17 = **94 tests green** across 4 modules.

## Notes

- Hand-coded by orchestrator (same sub-agent-permission constraint as #19; tracked for triage post-sprint).
- Does not implement `AutoCloseable` — matches the established BigQuery-2.x convention used by the sibling adapters.
- Streaming buffer cost/visibility notes documented in the README — a load-job-based variant is sprint-2+ scope.

Awaiting orchestrator review + merge into `sprint-1`. After merge, sprint-1 is feature-complete; next step is the sprint-1 → main PR.