### PR TITLE
Sprint 1 → main: BigQueryJobControlRepository + BigQueryFinOpsSink + sprint-branch rule docs

### DIFF
--- a/data-pipeline-libraries-java/data-pipeline-gcp-bigquery-java/README.md
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-bigquery-java/README.md
@@ -126,7 +126,7 @@ ServiceLoader.load(Warehouse.class).findFirst()
 
 - ✅ `BigQueryWarehouse` — issue [#6](https://github.com/enrichmeai/gcp-pipeline-reference/issues/6) (Warehouse contract)
 - ✅ `BigQueryJobControlRepository` — issue [#8](https://github.com/enrichmeai/gcp-pipeline-reference/issues/8) (JobControlRepository contract); see section below
-- ⏳ `BigQueryFinOpsSink` — issue [#9](https://github.com/enrichmeai/gcp-pipeline-reference/issues/9) (FinOpsSink contract); not yet implemented
+- ✅ `BigQueryFinOpsSink` — issue [#9](https://github.com/enrichmeai/gcp-pipeline-reference/issues/9) (FinOpsSink contract); see section below
 
 All three share this module's `pom.xml`.
 
@@ -188,3 +188,50 @@ mvn -f data-pipeline-libraries-java/pom.xml -pl data-pipeline-gcp-bigquery-java 
 ```
 
 Live-cloud integration tests against a real BigQuery dataset (or the BigQuery emulator) are sprint-2+ scope.
+
+## BigQueryFinOpsSink
+
+Implementation of [`FinOpsSink`](../data-pipeline-core-java/src/main/java/com/enrichmeai/culvert/contracts/FinOpsSink.java) — receives `(CostMetrics, FinOpsTag)` pairs and streams them into the configured `cost_metrics` BigQuery table via `BigQuery.insertAll`.
+
+### Construction
+
+```java
+BigQuery client = BigQueryOptions.newBuilder().setProjectId("my-project").build().getService();
+FinOpsSink sink = new BigQueryFinOpsSink(
+        client,
+        "my-project",
+        "finops",              // dataset
+        "cost_metrics");       // table (the DEFAULT_TABLE constant)
+```
+
+Like its siblings, this class is not `AutoCloseable`; consumer owns the client.
+
+### Row shape
+
+Every `record(metrics, tags)` call writes one row. The columns flatten both records:
+
+| Column | Source | Type |
+|---|---|---|
+| `system`, `environment`, `cost_center`, `owner` | `FinOpsTag` | STRING |
+| `tag_run_id` | `FinOpsTag.runId()` | STRING (separate from `run_id` so analysts can detect attribution drift) |
+| `tag_extra` | `FinOpsTag.extra()` | `ARRAY<STRUCT<key STRING, value STRING>>` |
+| `run_id` | `CostMetrics.runId()` | STRING |
+| `estimated_cost_usd` | `CostMetrics` | FLOAT64 |
+| `billed_bytes_scanned`, `billed_bytes_written`, `billed_bytes_stored`, `billed_messages_count`, `slot_millis` | `CostMetrics` | INT64 |
+| `compute_units` | `CostMetrics` | FLOAT64 |
+| `labels` | `CostMetrics.labels()` | `ARRAY<STRUCT<key STRING, value STRING>>` |
+| `timestamp` | `CostMetrics.timestamp()` | TIMESTAMP (ISO-8601 string) |
+
+The flattened `labels` / `tag_extra` shape avoids BigQuery DDL changes when teams add new tag keys — new keys just appear in the array.
+
+### Streaming buffer + cost
+
+`insertAll` is BigQuery's streaming insert path. Rows are queryable within seconds but are NOT immediately visible to `COPY`/`EXPORT` jobs (streaming buffer flushes on BigQuery's schedule, typically within 90 minutes). Streaming inserts incur a per-GB cost on top of regular storage. For very high-volume cost emission, consider a load-job-based variant in a future sprint.
+
+### Partial failures
+
+`InsertAllResponse` can succeed at the request level while reporting per-row errors. `BigQueryFinOpsSink.FinOpsInsertException` (extends `RuntimeException`) is thrown if `response.hasErrors()` returns true — silently dropping cost rows would defeat the FinOps audit trail. The exception carries the underlying `Map<Long, List<BigQueryError>>` so callers can report specific row failures.
+
+### ServiceLoader registration
+
+`src/main/resources/META-INF/services/com.enrichmeai.culvert.contracts.FinOpsSink` lists the impl. Same no-arg-constructor caveat as the siblings — sprint-4 auto-config will resolve it.

--- a/data-pipeline-libraries-java/data-pipeline-gcp-bigquery-java/README.md
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-bigquery-java/README.md
@@ -68,17 +68,22 @@ Warehouse warehouse = new BigQueryWarehouse("my-gcp-project", client);
 Warehouse warehouse = new BigQueryWarehouse("my-gcp-project", mockClient);
 ```
 
-The wrapped client is closed when you call `warehouse.close()`. The class implements `AutoCloseable` so it works in try-with-resources:
+**Client lifecycle:** `BigQueryWarehouse` does NOT implement `AutoCloseable`. The google-cloud-bigquery 2.x `BigQuery` interface itself is not `AutoCloseable` (this is the divergence from the `SecretManagerProvider` pilot pattern, where `SecretManagerServiceClient` is closeable). Consumers manage the wrapped client's lifecycle directly; the client is safe to keep alive for the lifetime of the JVM.
 
 ```java
-try (BigQueryWarehouse w = new BigQueryWarehouse("my-project", client)) {
-    Iterator<Map<String, Object>> rows = w.query(
-            "SELECT id, name FROM ds.customers WHERE id = @id",
-            Map.of("id", 42L));
-    while (rows.hasNext()) {
-        System.out.println(rows.next());
-    }
+BigQuery client = BigQueryOptions.newBuilder()
+        .setProjectId("my-project")
+        .build()
+        .getService();
+Warehouse w = new BigQueryWarehouse("my-project", client);
+
+Iterator<Map<String, Object>> rows = w.query(
+        "SELECT id, name FROM ds.customers WHERE id = @id",
+        Map.of("id", 42L));
+while (rows.hasNext()) {
+    System.out.println(rows.next());
 }
+// No explicit close needed; the BigQuery client manages its own gRPC channels.
 ```
 
 ### No no-arg constructor (yet)
@@ -117,12 +122,60 @@ ServiceLoader.load(Warehouse.class).findFirst()
 
 ## Sibling adapters (same module)
 
-`data-pipeline-gcp-bigquery-java` is intentionally a multi-contract module — three GCP services share the same Google Cloud SDK family and `libraries-bom` pin, so they ship together. Sprint-1 lands `BigQueryWarehouse` and pre-wires the module's POM; the other two contracts ship as follow-up issues that only add classes:
+`data-pipeline-gcp-bigquery-java` is a multi-contract module — three GCP services share the same Google Cloud SDK family and `libraries-bom` pin, so they ship together. Sprint-1 status:
 
-- [#8](https://github.com/enrichmeai/gcp-pipeline-reference/issues/8) — `JobControlRepository` (BigQuery-backed job-control table)
-- [#9](https://github.com/enrichmeai/gcp-pipeline-reference/issues/9) — `FinOpsSink` (BigQuery-backed cost/observability sink)
+- ✅ `BigQueryWarehouse` — issue [#6](https://github.com/enrichmeai/gcp-pipeline-reference/issues/6) (Warehouse contract)
+- ✅ `BigQueryJobControlRepository` — issue [#8](https://github.com/enrichmeai/gcp-pipeline-reference/issues/8) (JobControlRepository contract); see section below
+- ⏳ `BigQueryFinOpsSink` — issue [#9](https://github.com/enrichmeai/gcp-pipeline-reference/issues/9) (FinOpsSink contract); not yet implemented
 
-Both sibling issues will share the `pom.xml` defined here; they should only add `.java` sources and (where relevant) extra `META-INF/services` registrations.
+All three share this module's `pom.xml`.
+
+## BigQueryJobControlRepository
+
+Implementation of [`JobControlRepository`](../data-pipeline-core-java/src/main/java/com/enrichmeai/culvert/contracts/JobControlRepository.java) — the pipeline-job state-machine contract. Java port of the Python `gcp_pipeline_core.job_control.repository.JobControlRepository`. Same eleven public methods; SQL patterns inherited but adapted to the richer Java `PipelineJob` record schema (more columns: `pipeline_name`, `source_file`, `target_table`, `record_count`, `error_count`, FinOps fields).
+
+### Construction
+
+```java
+BigQuery client = BigQueryOptions.newBuilder().setProjectId("my-project").build().getService();
+JobControlRepository repo = new BigQueryJobControlRepository(
+        client,
+        "my-project",
+        "job_control",         // dataset
+        "pipeline_jobs");      // table
+```
+
+Like `BigQueryWarehouse`, this class does not implement `AutoCloseable`. Consumers own the `BigQuery` client lifecycle.
+
+### Method → SQL pattern
+
+| Contract method | SQL |
+|---|---|
+| `createJob(PipelineJob)` | `INSERT INTO ` *`fqtn`* ` (...) VALUES (...)` — all 23 PipelineJob fields, `created_at`/`updated_at` use `CURRENT_TIMESTAMP()` |
+| `getJob(String runId)` | `SELECT * FROM ` *`fqtn`* ` WHERE run_id = @run_id` |
+| `updateStatus(runId, status, totalRecords)` | Three flavours: `RUNNING` stamps `started_at`; `SUCCEEDED` stamps `completed_at` + `record_count`; all others bump `status` + `updated_at` |
+| `markFailed(runId, code, msg, stage, errorFile)` | `UPDATE` sets `status = 'failed'`, error fields, `completed_at = CURRENT_TIMESTAMP()` |
+| `markRetrying(runId, retryCount)` | `UPDATE` sets `status = 'retrying'`, `retry_count = @retry_count` |
+| `getPendingJobs(systemId?)` | `SELECT * WHERE status IN ('created', 'running')`, optionally `AND system_id = @system_id`, ordered by `created_at` |
+| `getEntityStatus(systemId, date)` | `SELECT entity_type, status, run_id, record_count, error_count, started_at, completed_at WHERE system_id = ? AND extract_date = ?` |
+| `getFailedJobs(systemId, date)` | Like above but filtered to `status = 'failed'`, returns failure context columns |
+| `getFdpJobStatus(systemId, date, modelName)` | Filtered to `job_type = 'TRANSFORMATION'` and `pipeline_name = @model_name`, ordered DESC LIMIT 1 |
+| `cleanupPartialLoad(runId, tableId)` | `DELETE FROM \`<tableId>\` WHERE _run_id = @run_id` — returns DML affected rows |
+| `updateCostMetrics(runId, cost, scanned, written)` | `UPDATE` sets the three FinOps columns |
+
+### Errors
+
+| Cause | Thrown |
+|---|---|
+| `markRetrying` with negative `retryCount` | `IllegalArgumentException` |
+| `cleanupPartialLoad` affected-row count exceeds `Integer.MAX_VALUE` | `ArithmeticException` (real-world this shouldn't happen — defensive) |
+| Thread interrupted during a `client.query` | `RuntimeException` (interrupt flag restored) |
+| Any BigQuery job error | `com.google.cloud.bigquery.BigQueryException` (propagated) |
+| Null required argument | `NullPointerException` |
+
+### ServiceLoader registration
+
+`src/main/resources/META-INF/services/com.enrichmeai.culvert.contracts.JobControlRepository` lists the impl. Same caveat as `BigQueryWarehouse` — no no-arg constructor (needs `client`, `projectId`, `dataset`, `table` — 4 args, far past the pilot's ≤2-env-var rule), so direct `ServiceLoader.load(JobControlRepository.class).findFirst()` will throw `ServiceConfigurationError` until sprint-4 auto-config arrives. Wire it explicitly until then.
 
 ## Testing
 

--- a/data-pipeline-libraries-java/data-pipeline-gcp-bigquery-java/src/main/java/com/enrichmeai/culvert/gcp/bigquery/BigQueryFinOpsSink.java
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-bigquery-java/src/main/java/com/enrichmeai/culvert/gcp/bigquery/BigQueryFinOpsSink.java
@@ -1,0 +1,182 @@
+package com.enrichmeai.culvert.gcp.bigquery;
+
+import com.enrichmeai.culvert.contracts.FinOpsSink;
+import com.enrichmeai.culvert.finops.CostMetrics;
+import com.enrichmeai.culvert.finops.FinOpsTag;
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryError;
+import com.google.cloud.bigquery.InsertAllRequest;
+import com.google.cloud.bigquery.InsertAllResponse;
+import com.google.cloud.bigquery.TableId;
+
+import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * {@link FinOpsSink} implementation backed by Google Cloud BigQuery streaming
+ * inserts ({@code insertAll}).
+ *
+ * <p>Each {@link #record(CostMetrics, FinOpsTag)} call streams a single row
+ * into the configured {@code cost_metrics} table. The row carries every field
+ * from both {@link CostMetrics} and {@link FinOpsTag} flattened into the
+ * table's columns; {@link CostMetrics#labels()} and
+ * {@link FinOpsTag#extra()} flatten as {@code RECORD<key STRING, value STRING>}
+ * arrays (BigQuery's only stable way to ship arbitrary map data without DDL
+ * changes per row).
+ *
+ * <h2>Streaming buffer + cost</h2>
+ *
+ * <p>{@code insertAll} writes to BigQuery's streaming buffer. Rows are
+ * queryable within seconds but are NOT immediately visible to
+ * {@code COPY}/{@code EXPORT} jobs (streaming buffer flushes to managed
+ * storage on BigQuery's schedule — usually within 90 minutes). Streaming
+ * inserts also incur a per-GB cost on top of regular storage. For high-volume
+ * cost emission, consider a load-job-based variant in a future sprint.
+ *
+ * <h2>Partial failures</h2>
+ *
+ * <p>{@code InsertAllResponse} can succeed at the request level while
+ * reporting per-row errors. We treat any non-empty
+ * {@link InsertAllResponse#getInsertErrors()} as a hard failure and throw
+ * {@link FinOpsInsertException} — silently dropping cost rows would defeat
+ * the FinOps audit trail.
+ *
+ * <h2>Construction</h2>
+ *
+ * <p>Pass in a pre-built {@link BigQuery} client, the GCP project ID, the
+ * dataset, and the table name (default {@code cost_metrics} convention).
+ * Like {@link BigQueryWarehouse} and {@link BigQueryJobControlRepository},
+ * this class does NOT implement {@link AutoCloseable} — the BigQuery 2.x
+ * client itself is not closeable.
+ *
+ * <p>Sprint-1 deliverable for issue #9.
+ */
+public final class BigQueryFinOpsSink implements FinOpsSink {
+
+    /** Default table name when none specified. Matches the Python convention. */
+    public static final String DEFAULT_TABLE = "cost_metrics";
+
+    private static final DateTimeFormatter BQ_TIMESTAMP =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS");
+
+    private final BigQuery client;
+    private final TableId tableId;
+
+    /**
+     * Primary constructor.
+     *
+     * @param client    Pre-built BigQuery client. Required.
+     * @param projectId GCP project ID. Required.
+     * @param dataset   BigQuery dataset name. Required.
+     * @param table     BigQuery table name. Required.
+     * @throws NullPointerException if any argument is null.
+     */
+    public BigQueryFinOpsSink(BigQuery client, String projectId,
+                              String dataset, String table) {
+        this.client = Objects.requireNonNull(client, "client must not be null");
+        Objects.requireNonNull(projectId, "projectId must not be null");
+        Objects.requireNonNull(dataset, "dataset must not be null");
+        Objects.requireNonNull(table, "table must not be null");
+        this.tableId = TableId.of(projectId, dataset, table);
+    }
+
+    // TODO sprint-4 auto-config: no-arg constructor reading GCP_PROJECT,
+    // FINOPS_DATASET, FINOPS_TABLE. Skipped here because (client, projectId,
+    // dataset, table) bootstrap exceeds the pilot's "no-arg only if <=2 env
+    // vars" rule.
+
+    @Override
+    public void record(CostMetrics metrics, FinOpsTag tags) {
+        Objects.requireNonNull(metrics, "metrics must not be null");
+        Objects.requireNonNull(tags, "tags must not be null");
+
+        InsertAllRequest request = InsertAllRequest.newBuilder(tableId)
+                .addRow(toRow(metrics, tags))
+                .build();
+
+        InsertAllResponse response = client.insertAll(request);
+        if (response.hasErrors()) {
+            throw new FinOpsInsertException(metrics.runId(), response.getInsertErrors());
+        }
+    }
+
+    /**
+     * Build the wire row. Field naming convention: snake_case to match
+     * BigQuery's idiomatic column naming.
+     *
+     * <p>Visible for testing — production callers should use
+     * {@link #record(CostMetrics, FinOpsTag)}.
+     */
+    Map<String, Object> toRow(CostMetrics metrics, FinOpsTag tags) {
+        Map<String, Object> row = new LinkedHashMap<>();
+        // FinOpsTag attribution columns first — they're the cost-allocation key.
+        row.put("system", tags.system());
+        row.put("environment", tags.environment());
+        row.put("cost_center", tags.costCenter());
+        row.put("owner", tags.owner());
+        // tags.runId() and metrics.runId() should match in practice; we ship
+        // both and let the analyst spot any drift.
+        row.put("tag_run_id", tags.runId());
+        row.put("tag_extra", flattenMap(tags.extra()));
+
+        // CostMetrics columns.
+        row.put("run_id", metrics.runId());
+        row.put("estimated_cost_usd", metrics.estimatedCostUsd());
+        row.put("billed_bytes_scanned", metrics.billedBytesScanned());
+        row.put("billed_bytes_written", metrics.billedBytesWritten());
+        row.put("billed_bytes_stored", metrics.billedBytesStored());
+        row.put("billed_messages_count", metrics.billedMessagesCount());
+        row.put("slot_millis", metrics.slotMillis());
+        row.put("compute_units", metrics.computeUnits());
+        row.put("labels", flattenMap(metrics.labels()));
+
+        // BigQuery TIMESTAMP wants either ISO-8601 or "yyyy-MM-dd HH:mm:ss.SSSSSS UTC";
+        // ISO-8601 is widely accepted by insertAll JSON encoding.
+        row.put("timestamp", metrics.timestamp().toString());
+
+        return row;
+    }
+
+    /**
+     * Flatten a {@code Map<String, String>} into a list of
+     * {@code {"key": k, "value": v}} records — BigQuery's stable
+     * representation for arbitrary-key map data without a schema update per
+     * row.
+     */
+    private static List<Map<String, String>> flattenMap(Map<String, String> map) {
+        if (map == null || map.isEmpty()) {
+            return List.of();
+        }
+        List<Map<String, String>> out = new java.util.ArrayList<>(map.size());
+        for (Map.Entry<String, String> e : map.entrySet()) {
+            Map<String, String> entry = new LinkedHashMap<>(2);
+            entry.put("key", e.getKey());
+            entry.put("value", e.getValue());
+            out.add(entry);
+        }
+        return out;
+    }
+
+    /**
+     * Thrown when BigQuery's streaming insert returns per-row errors. The
+     * underlying GCP {@link BigQueryError} list is preserved so callers can
+     * report the specific row failures.
+     */
+    public static final class FinOpsInsertException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+        private final transient Map<Long, List<BigQueryError>> insertErrors;
+
+        FinOpsInsertException(String runId, Map<Long, List<BigQueryError>> insertErrors) {
+            super("BigQuery streaming insert returned errors for runId=" + runId
+                    + " (" + insertErrors.size() + " row(s) failed)");
+            this.insertErrors = insertErrors;
+        }
+
+        public Map<Long, List<BigQueryError>> getInsertErrors() {
+            return insertErrors;
+        }
+    }
+}

--- a/data-pipeline-libraries-java/data-pipeline-gcp-bigquery-java/src/main/java/com/enrichmeai/culvert/gcp/bigquery/BigQueryJobControlRepository.java
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-bigquery-java/src/main/java/com/enrichmeai/culvert/gcp/bigquery/BigQueryJobControlRepository.java
@@ -1,0 +1,542 @@
+package com.enrichmeai.culvert.gcp.bigquery;
+
+import com.enrichmeai.culvert.contracts.JobControlRepository;
+import com.enrichmeai.culvert.jobcontrol.EntityStatus;
+import com.enrichmeai.culvert.jobcontrol.FailedJob;
+import com.enrichmeai.culvert.jobcontrol.FailureStage;
+import com.enrichmeai.culvert.jobcontrol.FdpJobStatus;
+import com.enrichmeai.culvert.jobcontrol.JobStatus;
+import com.enrichmeai.culvert.jobcontrol.JobType;
+import com.enrichmeai.culvert.jobcontrol.PipelineJob;
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.FieldValueList;
+import com.google.cloud.bigquery.QueryJobConfiguration;
+import com.google.cloud.bigquery.QueryParameterValue;
+import com.google.cloud.bigquery.TableResult;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * {@link JobControlRepository} implementation backed by Google Cloud BigQuery.
+ *
+ * <p>Java port of the Python
+ * {@code gcp_pipeline_core.job_control.repository.JobControlRepository}. The
+ * eleven contract methods map one-for-one to the Python public surface; the
+ * SQL patterns are inherited but adapted to the richer Java
+ * {@link PipelineJob} record (more columns: pipeline_name, source_file,
+ * target_table, record_count, error_count, FinOps fields).
+ *
+ * <p>Wraps a {@link BigQuery} client. All operations execute as parameterised
+ * queries; the wrapped client is reused for every call. Like
+ * {@link BigQueryWarehouse}, this class does NOT implement
+ * {@link AutoCloseable} — google-cloud-bigquery 2.x's {@code BigQuery}
+ * interface itself is not {@code AutoCloseable}. Consumers manage the
+ * client's lifecycle.
+ *
+ * <p>Constructor injection: pass in a pre-built {@code BigQuery} client, the
+ * GCP project ID, the dataset (default {@code job_control} in the Python
+ * source), and the table (default {@code pipeline_jobs}). The fully-qualified
+ * table is quoted with backticks as {@code `project.dataset.table`} in every
+ * query.
+ *
+ * <p>Sprint-1 deliverable for issue #8.
+ */
+public final class BigQueryJobControlRepository implements JobControlRepository {
+
+    private final BigQuery client;
+    private final String projectId;
+    private final String dataset;
+    private final String table;
+    private final String fqtn;
+
+    /**
+     * Primary constructor.
+     *
+     * @param client    Pre-built BigQuery client. Required.
+     * @param projectId GCP project ID. Required.
+     * @param dataset   BigQuery dataset (e.g. {@code "job_control"}). Required.
+     * @param table     BigQuery table (e.g. {@code "pipeline_jobs"}). Required.
+     * @throws NullPointerException if any argument is null.
+     */
+    public BigQueryJobControlRepository(BigQuery client, String projectId,
+                                        String dataset, String table) {
+        this.client = Objects.requireNonNull(client, "client must not be null");
+        this.projectId = Objects.requireNonNull(projectId, "projectId must not be null");
+        this.dataset = Objects.requireNonNull(dataset, "dataset must not be null");
+        this.table = Objects.requireNonNull(table, "table must not be null");
+        this.fqtn = "`" + projectId + "." + dataset + "." + table + "`";
+    }
+
+    // TODO sprint-4 auto-config: no-arg constructor reading GCP_PROJECT,
+    // JOB_CONTROL_DATASET, JOB_CONTROL_TABLE from env. Skipped here because
+    // the (client, projectId, dataset, table) bootstrap exceeds the pilot's
+    // "no-arg only if <=2 env vars" rule.
+
+    @Override
+    public void createJob(PipelineJob job) {
+        Objects.requireNonNull(job, "job must not be null");
+
+        String sql = "INSERT INTO " + fqtn + " ("
+                + "run_id, system_id, pipeline_name, extract_date, status, job_type, "
+                + "entity_type, source_file, target_table, "
+                + "record_count, error_count, retry_count, "
+                + "failure_stage, error_code, error_message, error_file_path, "
+                + "estimated_cost_usd, billed_bytes_scanned, billed_bytes_written, "
+                + "created_at, updated_at, started_at, completed_at"
+                + ") VALUES ("
+                + "@run_id, @system_id, @pipeline_name, @extract_date, @status, @job_type, "
+                + "@entity_type, @source_file, @target_table, "
+                + "@record_count, @error_count, @retry_count, "
+                + "@failure_stage, @error_code, @error_message, @error_file_path, "
+                + "@estimated_cost_usd, @billed_bytes_scanned, @billed_bytes_written, "
+                + "CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP(), @started_at, @completed_at"
+                + ")";
+
+        QueryJobConfiguration config = QueryJobConfiguration.newBuilder(sql)
+                .addNamedParameter("run_id", QueryParameterValue.string(job.runId()))
+                .addNamedParameter("system_id", QueryParameterValue.string(job.systemId()))
+                .addNamedParameter("pipeline_name", QueryParameterValue.string(job.pipelineName()))
+                .addNamedParameter("extract_date", QueryParameterValue.date(job.extractDate().toString()))
+                .addNamedParameter("status", QueryParameterValue.string(job.status().getValue()))
+                .addNamedParameter("job_type", QueryParameterValue.string(job.jobType().name()))
+                .addNamedParameter("entity_type", QueryParameterValue.string(job.entityType().orElse(null)))
+                .addNamedParameter("source_file", QueryParameterValue.string(job.sourceFile().orElse(null)))
+                .addNamedParameter("target_table", QueryParameterValue.string(job.targetTable().orElse(null)))
+                .addNamedParameter("record_count", QueryParameterValue.int64(job.recordCount()))
+                .addNamedParameter("error_count", QueryParameterValue.int64(job.errorCount()))
+                .addNamedParameter("retry_count", QueryParameterValue.int64((long) job.retryCount()))
+                .addNamedParameter("failure_stage",
+                        QueryParameterValue.string(job.failureStage().map(FailureStage::getValue).orElse(null)))
+                .addNamedParameter("error_code", QueryParameterValue.string(job.errorCode().orElse(null)))
+                .addNamedParameter("error_message", QueryParameterValue.string(job.errorMessage().orElse(null)))
+                .addNamedParameter("error_file_path", QueryParameterValue.string(job.errorFilePath().orElse(null)))
+                .addNamedParameter("estimated_cost_usd",
+                        QueryParameterValue.float64(job.estimatedCostUsd()))
+                .addNamedParameter("billed_bytes_scanned",
+                        QueryParameterValue.int64(job.billedBytesScanned()))
+                .addNamedParameter("billed_bytes_written",
+                        QueryParameterValue.int64(job.billedBytesWritten()))
+                .addNamedParameter("started_at",
+                        QueryParameterValue.timestamp(toTimestampMicros(job.startedAt())))
+                .addNamedParameter("completed_at",
+                        QueryParameterValue.timestamp(toTimestampMicros(job.completedAt())))
+                .build();
+
+        runUpdate(config, "createJob");
+    }
+
+    @Override
+    public Optional<PipelineJob> getJob(String runId) {
+        Objects.requireNonNull(runId, "runId must not be null");
+
+        String sql = "SELECT * FROM " + fqtn + " WHERE run_id = @run_id";
+        QueryJobConfiguration config = QueryJobConfiguration.newBuilder(sql)
+                .addNamedParameter("run_id", QueryParameterValue.string(runId))
+                .build();
+
+        TableResult result = runQuery(config, "getJob");
+        for (FieldValueList row : result.iterateAll()) {
+            return Optional.of(rowToPipelineJob(row));
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public void updateStatus(String runId, JobStatus status, Optional<Long> totalRecords) {
+        Objects.requireNonNull(runId, "runId must not be null");
+        Objects.requireNonNull(status, "status must not be null");
+        Objects.requireNonNull(totalRecords, "totalRecords must not be null");
+
+        // Three SQL flavours per the Python source: RUNNING stamps started_at,
+        // SUCCEEDED stamps completed_at + record_count, everything else just
+        // bumps status + updated_at.
+        String sql;
+        QueryJobConfiguration.Builder builder;
+        if (status == JobStatus.RUNNING) {
+            sql = "UPDATE " + fqtn + " SET status = @status, "
+                    + "started_at = CURRENT_TIMESTAMP(), updated_at = CURRENT_TIMESTAMP() "
+                    + "WHERE run_id = @run_id";
+            builder = QueryJobConfiguration.newBuilder(sql);
+        } else if (status == JobStatus.SUCCEEDED) {
+            sql = "UPDATE " + fqtn + " SET status = @status, "
+                    + "completed_at = CURRENT_TIMESTAMP(), record_count = @record_count, "
+                    + "updated_at = CURRENT_TIMESTAMP() "
+                    + "WHERE run_id = @run_id";
+            builder = QueryJobConfiguration.newBuilder(sql)
+                    .addNamedParameter("record_count",
+                            QueryParameterValue.int64(totalRecords.orElse(0L)));
+        } else {
+            sql = "UPDATE " + fqtn + " SET status = @status, "
+                    + "updated_at = CURRENT_TIMESTAMP() "
+                    + "WHERE run_id = @run_id";
+            builder = QueryJobConfiguration.newBuilder(sql);
+        }
+
+        QueryJobConfiguration config = builder
+                .addNamedParameter("run_id", QueryParameterValue.string(runId))
+                .addNamedParameter("status", QueryParameterValue.string(status.getValue()))
+                .build();
+        runUpdate(config, "updateStatus");
+    }
+
+    @Override
+    public void markFailed(String runId, String errorCode, String errorMessage,
+                           FailureStage failureStage, Optional<String> errorFilePath) {
+        Objects.requireNonNull(runId, "runId must not be null");
+        Objects.requireNonNull(errorCode, "errorCode must not be null");
+        Objects.requireNonNull(errorMessage, "errorMessage must not be null");
+        Objects.requireNonNull(failureStage, "failureStage must not be null");
+        Objects.requireNonNull(errorFilePath, "errorFilePath must not be null");
+
+        String sql = "UPDATE " + fqtn + " SET status = @status, "
+                + "error_code = @error_code, error_message = @error_message, "
+                + "failure_stage = @failure_stage, error_file_path = @error_file_path, "
+                + "completed_at = CURRENT_TIMESTAMP(), updated_at = CURRENT_TIMESTAMP() "
+                + "WHERE run_id = @run_id";
+
+        QueryJobConfiguration config = QueryJobConfiguration.newBuilder(sql)
+                .addNamedParameter("run_id", QueryParameterValue.string(runId))
+                .addNamedParameter("status", QueryParameterValue.string(JobStatus.FAILED.getValue()))
+                .addNamedParameter("error_code", QueryParameterValue.string(errorCode))
+                .addNamedParameter("error_message", QueryParameterValue.string(errorMessage))
+                .addNamedParameter("failure_stage", QueryParameterValue.string(failureStage.getValue()))
+                .addNamedParameter("error_file_path",
+                        QueryParameterValue.string(errorFilePath.orElse(null)))
+                .build();
+        runUpdate(config, "markFailed");
+    }
+
+    @Override
+    public void markRetrying(String runId, int retryCount) {
+        Objects.requireNonNull(runId, "runId must not be null");
+        if (retryCount < 0) {
+            throw new IllegalArgumentException("retryCount must be >= 0, got " + retryCount);
+        }
+
+        String sql = "UPDATE " + fqtn + " SET status = @status, "
+                + "retry_count = @retry_count, updated_at = CURRENT_TIMESTAMP() "
+                + "WHERE run_id = @run_id";
+
+        QueryJobConfiguration config = QueryJobConfiguration.newBuilder(sql)
+                .addNamedParameter("run_id", QueryParameterValue.string(runId))
+                .addNamedParameter("status",
+                        QueryParameterValue.string(JobStatus.RETRYING.getValue()))
+                .addNamedParameter("retry_count", QueryParameterValue.int64((long) retryCount))
+                .build();
+        runUpdate(config, "markRetrying");
+    }
+
+    @Override
+    public List<PipelineJob> getPendingJobs(Optional<String> systemId) {
+        Objects.requireNonNull(systemId, "systemId must not be null");
+
+        String sql;
+        QueryJobConfiguration.Builder builder;
+        if (systemId.isPresent()) {
+            sql = "SELECT * FROM " + fqtn + " "
+                    + "WHERE status IN (@created, @running) AND system_id = @system_id "
+                    + "ORDER BY created_at";
+            builder = QueryJobConfiguration.newBuilder(sql)
+                    .addNamedParameter("system_id", QueryParameterValue.string(systemId.get()));
+        } else {
+            sql = "SELECT * FROM " + fqtn + " "
+                    + "WHERE status IN (@created, @running) "
+                    + "ORDER BY created_at";
+            builder = QueryJobConfiguration.newBuilder(sql);
+        }
+
+        QueryJobConfiguration config = builder
+                .addNamedParameter("created", QueryParameterValue.string(JobStatus.CREATED.getValue()))
+                .addNamedParameter("running", QueryParameterValue.string(JobStatus.RUNNING.getValue()))
+                .build();
+
+        TableResult result = runQuery(config, "getPendingJobs");
+        List<PipelineJob> jobs = new ArrayList<>();
+        for (FieldValueList row : result.iterateAll()) {
+            jobs.add(rowToPipelineJob(row));
+        }
+        return jobs;
+    }
+
+    @Override
+    public List<EntityStatus> getEntityStatus(String systemId, LocalDate extractDate) {
+        Objects.requireNonNull(systemId, "systemId must not be null");
+        Objects.requireNonNull(extractDate, "extractDate must not be null");
+
+        String sql = "SELECT entity_type, status, run_id, record_count, error_count, "
+                + "started_at, completed_at FROM " + fqtn + " "
+                + "WHERE system_id = @system_id AND extract_date = @extract_date";
+
+        QueryJobConfiguration config = QueryJobConfiguration.newBuilder(sql)
+                .addNamedParameter("system_id", QueryParameterValue.string(systemId))
+                .addNamedParameter("extract_date",
+                        QueryParameterValue.date(extractDate.toString()))
+                .build();
+
+        TableResult result = runQuery(config, "getEntityStatus");
+        List<EntityStatus> out = new ArrayList<>();
+        for (FieldValueList row : result.iterateAll()) {
+            String entityType = stringOrEmpty(row, "entity_type");
+            String status = stringOrEmpty(row, "status");
+            String runId = stringOrEmpty(row, "run_id");
+            long recordCount = longOrZero(row, "record_count");
+            long errorCount = longOrZero(row, "error_count");
+            Optional<Instant> startedAt = instantOrEmpty(row, "started_at");
+            Optional<Instant> completedAt = instantOrEmpty(row, "completed_at");
+            out.add(new EntityStatus(entityType, status, runId, recordCount, errorCount,
+                    startedAt, completedAt));
+        }
+        return out;
+    }
+
+    @Override
+    public List<FailedJob> getFailedJobs(String systemId, LocalDate extractDate) {
+        Objects.requireNonNull(systemId, "systemId must not be null");
+        Objects.requireNonNull(extractDate, "extractDate must not be null");
+
+        String sql = "SELECT run_id, entity_type, failure_stage, error_code, error_message, "
+                + "error_file_path, completed_at AS failed_at, retry_count FROM " + fqtn + " "
+                + "WHERE system_id = @system_id AND extract_date = @extract_date "
+                + "AND status = @status";
+
+        QueryJobConfiguration config = QueryJobConfiguration.newBuilder(sql)
+                .addNamedParameter("system_id", QueryParameterValue.string(systemId))
+                .addNamedParameter("extract_date",
+                        QueryParameterValue.date(extractDate.toString()))
+                .addNamedParameter("status", QueryParameterValue.string(JobStatus.FAILED.getValue()))
+                .build();
+
+        TableResult result = runQuery(config, "getFailedJobs");
+        List<FailedJob> out = new ArrayList<>();
+        for (FieldValueList row : result.iterateAll()) {
+            String runId = stringOrEmpty(row, "run_id");
+            String entityType = stringOrEmpty(row, "entity_type");
+            String failureStage = stringOrEmpty(row, "failure_stage");
+            String errorCode = stringOrEmpty(row, "error_code");
+            String errorMessage = stringOrEmpty(row, "error_message");
+            Optional<String> errorFilePath = stringOptional(row, "error_file_path");
+            Instant failedAt = instantOrEmpty(row, "failed_at").orElse(Instant.EPOCH);
+            int retryCount = (int) longOrZero(row, "retry_count");
+            out.add(new FailedJob(runId, entityType, failureStage, errorCode, errorMessage,
+                    errorFilePath, failedAt, retryCount));
+        }
+        return out;
+    }
+
+    @Override
+    public Optional<FdpJobStatus> getFdpJobStatus(String systemId, LocalDate extractDate,
+                                                  String modelName) {
+        Objects.requireNonNull(systemId, "systemId must not be null");
+        Objects.requireNonNull(extractDate, "extractDate must not be null");
+        Objects.requireNonNull(modelName, "modelName must not be null");
+
+        // The Python source filters on job_type = 'FDP_TRANSFORMATION' and
+        // dbt_model_name = @model_name; the Java PipelineJob doesn't carry a
+        // dbt_model_name column, so we use pipeline_name as the model
+        // identifier (the Java schema unifies these). job_type comes from the
+        // JobType enum.
+        String sql = "SELECT run_id, pipeline_name, status, record_count, "
+                + "started_at, completed_at FROM " + fqtn + " "
+                + "WHERE system_id = @system_id AND extract_date = @extract_date "
+                + "AND job_type = @job_type AND pipeline_name = @model_name "
+                + "ORDER BY created_at DESC LIMIT 1";
+
+        QueryJobConfiguration config = QueryJobConfiguration.newBuilder(sql)
+                .addNamedParameter("system_id", QueryParameterValue.string(systemId))
+                .addNamedParameter("extract_date",
+                        QueryParameterValue.date(extractDate.toString()))
+                .addNamedParameter("job_type",
+                        QueryParameterValue.string(JobType.TRANSFORMATION.name()))
+                .addNamedParameter("model_name", QueryParameterValue.string(modelName))
+                .build();
+
+        TableResult result = runQuery(config, "getFdpJobStatus");
+        for (FieldValueList row : result.iterateAll()) {
+            String runId = stringOrEmpty(row, "run_id");
+            String pipelineName = stringOrEmpty(row, "pipeline_name");
+            String status = stringOrEmpty(row, "status");
+            long recordCount = longOrZero(row, "record_count");
+            Optional<Instant> startedAt = instantOrEmpty(row, "started_at");
+            Optional<Instant> completedAt = instantOrEmpty(row, "completed_at");
+            return Optional.of(new FdpJobStatus(runId, pipelineName, status, recordCount,
+                    startedAt, completedAt));
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public int cleanupPartialLoad(String runId, String tableId) {
+        Objects.requireNonNull(runId, "runId must not be null");
+        Objects.requireNonNull(tableId, "tableId must not be null");
+
+        // tableId is an arbitrary FQTN supplied by the caller — must be backtick-
+        // quoted by the caller's convention. Python source wraps it in backticks
+        // verbatim; mirror that.
+        String sql = "DELETE FROM `" + tableId + "` WHERE _run_id = @run_id";
+
+        QueryJobConfiguration config = QueryJobConfiguration.newBuilder(sql)
+                .addNamedParameter("run_id", QueryParameterValue.string(runId))
+                .build();
+
+        TableResult result = runQuery(config, "cleanupPartialLoad");
+        // BigQuery DML returns affected-row count via TableResult.getTotalRows()
+        // for DELETE/UPDATE statements (no projected schema, just row count).
+        long affected = result.getTotalRows();
+        if (affected > Integer.MAX_VALUE) {
+            throw new ArithmeticException(
+                    "DELETE affected rows exceed Integer.MAX_VALUE: " + affected);
+        }
+        return (int) affected;
+    }
+
+    @Override
+    public void updateCostMetrics(String runId, double estimatedCostUsd,
+                                  long billedBytesScanned, long billedBytesWritten) {
+        Objects.requireNonNull(runId, "runId must not be null");
+
+        String sql = "UPDATE " + fqtn + " SET estimated_cost_usd = @cost, "
+                + "billed_bytes_scanned = @scanned, billed_bytes_written = @written, "
+                + "updated_at = CURRENT_TIMESTAMP() "
+                + "WHERE run_id = @run_id";
+
+        QueryJobConfiguration config = QueryJobConfiguration.newBuilder(sql)
+                .addNamedParameter("run_id", QueryParameterValue.string(runId))
+                .addNamedParameter("cost", QueryParameterValue.float64(estimatedCostUsd))
+                .addNamedParameter("scanned", QueryParameterValue.int64(billedBytesScanned))
+                .addNamedParameter("written", QueryParameterValue.int64(billedBytesWritten))
+                .build();
+        runUpdate(config, "updateCostMetrics");
+    }
+
+    // --- helpers -----------------------------------------------------------
+
+    private TableResult runQuery(QueryJobConfiguration config, String op) {
+        try {
+            return client.query(config);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("BigQuery " + op + " interrupted", e);
+        }
+    }
+
+    /**
+     * For UPDATE/INSERT/DELETE statements, we only care that execution
+     * succeeded. {@code client.query} blocks until completion and throws on
+     * job failure; the returned {@link TableResult} is discarded.
+     */
+    private void runUpdate(QueryJobConfiguration config, String op) {
+        runQuery(config, op);
+    }
+
+    private PipelineJob rowToPipelineJob(FieldValueList row) {
+        // Build via the builder — the record has 23 fields and several
+        // Optionals; positional construction would be unreadable.
+        PipelineJob.Builder b = PipelineJob.builder(
+                stringOrEmpty(row, "run_id"),
+                stringOrEmpty(row, "system_id"),
+                stringOrEmpty(row, "pipeline_name"),
+                LocalDate.parse(stringOrEmpty(row, "extract_date")),
+                JobStatus.valueOf(stringOrEmpty(row, "status").toUpperCase()));
+        // jobType is enum.name() in createJob — parse the same way.
+        String jobTypeStr = stringOrEmpty(row, "job_type");
+        if (!jobTypeStr.isEmpty()) {
+            b.jobType(JobType.valueOf(jobTypeStr));
+        }
+        b.entityType(stringOptional(row, "entity_type").orElse(null));
+        b.sourceFile(stringOptional(row, "source_file").orElse(null));
+        b.targetTable(stringOptional(row, "target_table").orElse(null));
+        b.recordCount(longOrZero(row, "record_count"));
+        b.errorCount(longOrZero(row, "error_count"));
+        b.retryCount((int) longOrZero(row, "retry_count"));
+        stringOptional(row, "failure_stage").ifPresent(
+                v -> b.failureStage(FailureStage.valueOf(v.toUpperCase())));
+        b.errorCode(stringOptional(row, "error_code").orElse(null));
+        b.errorMessage(stringOptional(row, "error_message").orElse(null));
+        b.errorFilePath(stringOptional(row, "error_file_path").orElse(null));
+        b.estimatedCostUsd(doubleOrZero(row, "estimated_cost_usd"));
+        b.billedBytesScanned(longOrZero(row, "billed_bytes_scanned"));
+        b.billedBytesWritten(longOrZero(row, "billed_bytes_written"));
+        instantOrEmpty(row, "created_at").ifPresent(b::createdAt);
+        instantOrEmpty(row, "updated_at").ifPresent(b::updatedAt);
+        instantOrEmpty(row, "started_at").ifPresent(b::startedAt);
+        instantOrEmpty(row, "completed_at").ifPresent(b::completedAt);
+        return b.build();
+    }
+
+    private static String stringOrEmpty(FieldValueList row, String name) {
+        try {
+            if (row.get(name).isNull()) {
+                return "";
+            }
+            return row.get(name).getStringValue();
+        } catch (IllegalArgumentException e) {
+            // Column not in result schema.
+            return "";
+        }
+    }
+
+    private static Optional<String> stringOptional(FieldValueList row, String name) {
+        try {
+            if (row.get(name).isNull()) {
+                return Optional.empty();
+            }
+            String v = row.get(name).getStringValue();
+            return v.isEmpty() ? Optional.empty() : Optional.of(v);
+        } catch (IllegalArgumentException e) {
+            return Optional.empty();
+        }
+    }
+
+    private static long longOrZero(FieldValueList row, String name) {
+        try {
+            if (row.get(name).isNull()) {
+                return 0L;
+            }
+            return row.get(name).getLongValue();
+        } catch (IllegalArgumentException e) {
+            return 0L;
+        }
+    }
+
+    private static double doubleOrZero(FieldValueList row, String name) {
+        try {
+            if (row.get(name).isNull()) {
+                return 0.0;
+            }
+            return row.get(name).getDoubleValue();
+        } catch (IllegalArgumentException e) {
+            return 0.0;
+        }
+    }
+
+    private static Optional<Instant> instantOrEmpty(FieldValueList row, String name) {
+        try {
+            if (row.get(name).isNull()) {
+                return Optional.empty();
+            }
+            // BigQuery TIMESTAMP comes back as microseconds-since-epoch.
+            long micros = row.get(name).getTimestampValue();
+            return Optional.of(Instant.ofEpochSecond(micros / 1_000_000L,
+                    (micros % 1_000_000L) * 1_000L));
+        } catch (IllegalArgumentException e) {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Convert an {@code Optional<Instant>} to a BigQuery TIMESTAMP parameter
+     * value, encoded as an ISO-8601 UTC string. {@code null} when empty.
+     */
+    private static String toTimestampMicros(Optional<Instant> instant) {
+        if (instant == null || instant.isEmpty()) {
+            return null;
+        }
+        return instant.get().atOffset(ZoneOffset.UTC).toString();
+    }
+}

--- a/data-pipeline-libraries-java/data-pipeline-gcp-bigquery-java/src/main/resources/META-INF/services/com.enrichmeai.culvert.contracts.FinOpsSink
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-bigquery-java/src/main/resources/META-INF/services/com.enrichmeai.culvert.contracts.FinOpsSink
@@ -1,0 +1,1 @@
+com.enrichmeai.culvert.gcp.bigquery.BigQueryFinOpsSink

--- a/data-pipeline-libraries-java/data-pipeline-gcp-bigquery-java/src/main/resources/META-INF/services/com.enrichmeai.culvert.contracts.JobControlRepository
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-bigquery-java/src/main/resources/META-INF/services/com.enrichmeai.culvert.contracts.JobControlRepository
@@ -1,0 +1,1 @@
+com.enrichmeai.culvert.gcp.bigquery.BigQueryJobControlRepository

--- a/data-pipeline-libraries-java/data-pipeline-gcp-bigquery-java/src/test/java/com/enrichmeai/culvert/gcp/bigquery/BigQueryFinOpsSinkTest.java
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-bigquery-java/src/test/java/com/enrichmeai/culvert/gcp/bigquery/BigQueryFinOpsSinkTest.java
@@ -1,0 +1,208 @@
+package com.enrichmeai.culvert.gcp.bigquery;
+
+import com.enrichmeai.culvert.finops.CostMetrics;
+import com.enrichmeai.culvert.finops.FinOpsTag;
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryError;
+import com.google.cloud.bigquery.InsertAllRequest;
+import com.google.cloud.bigquery.InsertAllResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link BigQueryFinOpsSink}. Mocks the BigQuery client so no
+ * real GCP credentials or network are required.
+ */
+@ExtendWith(MockitoExtension.class)
+class BigQueryFinOpsSinkTest {
+
+    private static final String PROJECT_ID = "my-project";
+    private static final String DATASET = "finops";
+    private static final String TABLE = "cost_metrics";
+
+    @Mock
+    private BigQuery client;
+
+    @Mock
+    private InsertAllResponse response;
+
+    private BigQueryFinOpsSink newSink() {
+        return new BigQueryFinOpsSink(client, PROJECT_ID, DATASET, TABLE);
+    }
+
+    private CostMetrics sampleMetrics() {
+        return CostMetrics.builder("run-1")
+                .estimatedCostUsd(0.42)
+                .billedBytesScanned(1_000_000L)
+                .billedBytesWritten(500_000L)
+                .slotMillis(2_500L)
+                .labels(Map.of("dataset", "warehouse", "team", "platform"))
+                .timestamp(Instant.parse("2026-01-15T10:30:00Z"))
+                .build();
+    }
+
+    private FinOpsTag sampleTag() {
+        return new FinOpsTag(
+                "retail-fdp", "prod", "cc-1234", "platform-team", "run-1",
+                Map.of("business_unit", "retail", "feature_flag", "exp_42"));
+    }
+
+    // --- happy paths -------------------------------------------------------
+
+    @Test
+    void recordCallsInsertAllOnce() {
+        when(response.hasErrors()).thenReturn(false);
+        when(client.insertAll(any(InsertAllRequest.class))).thenReturn(response);
+
+        BigQueryFinOpsSink sink = newSink();
+        sink.record(sampleMetrics(), sampleTag());
+
+        verify(client).insertAll(any(InsertAllRequest.class));
+    }
+
+    @Test
+    void rowCarriesAllCostMetricsAndTagFields() {
+        BigQueryFinOpsSink sink = newSink();
+        Map<String, Object> row = sink.toRow(sampleMetrics(), sampleTag());
+
+        // FinOpsTag columns
+        assertThat(row).containsEntry("system", "retail-fdp");
+        assertThat(row).containsEntry("environment", "prod");
+        assertThat(row).containsEntry("cost_center", "cc-1234");
+        assertThat(row).containsEntry("owner", "platform-team");
+        assertThat(row).containsEntry("tag_run_id", "run-1");
+
+        // CostMetrics columns
+        assertThat(row).containsEntry("run_id", "run-1");
+        assertThat(row).containsEntry("estimated_cost_usd", 0.42);
+        assertThat(row).containsEntry("billed_bytes_scanned", 1_000_000L);
+        assertThat(row).containsEntry("billed_bytes_written", 500_000L);
+        assertThat(row).containsEntry("slot_millis", 2_500L);
+        assertThat(row).containsEntry("timestamp", "2026-01-15T10:30:00Z");
+    }
+
+    @Test
+    void labelsAndExtraTagsFlattenToKeyValueRecords() {
+        BigQueryFinOpsSink sink = newSink();
+        Map<String, Object> row = sink.toRow(sampleMetrics(), sampleTag());
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, String>> labels = (List<Map<String, String>>) row.get("labels");
+        assertThat(labels).hasSize(2);
+        assertThat(labels).allSatisfy(entry ->
+                assertThat(entry).containsKeys("key", "value"));
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, String>> extra = (List<Map<String, String>>) row.get("tag_extra");
+        assertThat(extra).hasSize(2);
+    }
+
+    @Test
+    void emptyLabelsAndExtraProduceEmptyLists() {
+        BigQueryFinOpsSink sink = newSink();
+        CostMetrics zeroMetrics = CostMetrics.zero("run-2");
+        FinOpsTag zeroTag = FinOpsTag.of("sys", "dev", "cc", "owner", "run-2");
+
+        Map<String, Object> row = sink.toRow(zeroMetrics, zeroTag);
+
+        assertThat((List<?>) row.get("labels")).isEmpty();
+        assertThat((List<?>) row.get("tag_extra")).isEmpty();
+    }
+
+    @Test
+    void targetTableMatchesConstructedTriple() {
+        when(response.hasErrors()).thenReturn(false);
+        when(client.insertAll(any(InsertAllRequest.class))).thenReturn(response);
+
+        BigQueryFinOpsSink sink = newSink();
+        sink.record(sampleMetrics(), sampleTag());
+
+        ArgumentCaptor<InsertAllRequest> captor =
+                ArgumentCaptor.forClass(InsertAllRequest.class);
+        verify(client).insertAll(captor.capture());
+
+        InsertAllRequest req = captor.getValue();
+        assertThat(req.getTable().getProject()).isEqualTo(PROJECT_ID);
+        assertThat(req.getTable().getDataset()).isEqualTo(DATASET);
+        assertThat(req.getTable().getTable()).isEqualTo(TABLE);
+        assertThat(req.getRows()).hasSize(1);
+    }
+
+    // --- error paths -------------------------------------------------------
+
+    @Test
+    void partialFailureSurfacesAsFinOpsInsertException() {
+        when(response.hasErrors()).thenReturn(true);
+        when(response.getInsertErrors()).thenReturn(
+                Map.of(0L, List.of(new BigQueryError(
+                        "invalidQuery", "us-central1", "bad column"))));
+        when(client.insertAll(any(InsertAllRequest.class))).thenReturn(response);
+
+        BigQueryFinOpsSink sink = newSink();
+
+        assertThatThrownBy(() -> sink.record(sampleMetrics(), sampleTag()))
+                .isInstanceOf(BigQueryFinOpsSink.FinOpsInsertException.class)
+                .hasMessageContaining("run-1");
+    }
+
+    @Test
+    void nullMetricsRejected() {
+        BigQueryFinOpsSink sink = newSink();
+        assertThatThrownBy(() -> sink.record(null, sampleTag()))
+                .isInstanceOf(NullPointerException.class);
+        verify(client, never()).insertAll(any(InsertAllRequest.class));
+    }
+
+    @Test
+    void nullTagsRejected() {
+        BigQueryFinOpsSink sink = newSink();
+        assertThatThrownBy(() -> sink.record(sampleMetrics(), null))
+                .isInstanceOf(NullPointerException.class);
+        verify(client, never()).insertAll(any(InsertAllRequest.class));
+    }
+
+    @Test
+    void constructorRejectsNullClient() {
+        assertThatThrownBy(() -> new BigQueryFinOpsSink(null, PROJECT_ID, DATASET, TABLE))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void constructorRejectsNullProject() {
+        assertThatThrownBy(() -> new BigQueryFinOpsSink(client, null, DATASET, TABLE))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    // --- multi-call ordering ----------------------------------------------
+
+    @Test
+    void multipleSequentialRecordCallsEachInsertOneRow() {
+        when(response.hasErrors()).thenReturn(false);
+        when(client.insertAll(any(InsertAllRequest.class))).thenReturn(response);
+
+        BigQueryFinOpsSink sink = newSink();
+        sink.record(sampleMetrics(), sampleTag());
+        sink.record(sampleMetrics(), sampleTag());
+        sink.record(sampleMetrics(), sampleTag());
+
+        ArgumentCaptor<InsertAllRequest> captor =
+                ArgumentCaptor.forClass(InsertAllRequest.class);
+        verify(client, org.mockito.Mockito.times(3)).insertAll(captor.capture());
+        assertThat(captor.getAllValues()).allSatisfy(req ->
+                assertThat(req.getRows()).hasSize(1));
+    }
+}

--- a/data-pipeline-libraries-java/data-pipeline-gcp-bigquery-java/src/test/java/com/enrichmeai/culvert/gcp/bigquery/BigQueryJobControlRepositoryTest.java
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-bigquery-java/src/test/java/com/enrichmeai/culvert/gcp/bigquery/BigQueryJobControlRepositoryTest.java
@@ -1,0 +1,379 @@
+package com.enrichmeai.culvert.gcp.bigquery;
+
+import com.enrichmeai.culvert.jobcontrol.EntityStatus;
+import com.enrichmeai.culvert.jobcontrol.FailedJob;
+import com.enrichmeai.culvert.jobcontrol.FailureStage;
+import com.enrichmeai.culvert.jobcontrol.FdpJobStatus;
+import com.enrichmeai.culvert.jobcontrol.JobStatus;
+import com.enrichmeai.culvert.jobcontrol.JobType;
+import com.enrichmeai.culvert.jobcontrol.PipelineJob;
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryException;
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.FieldValue;
+import com.google.cloud.bigquery.FieldValueList;
+import com.google.cloud.bigquery.QueryJobConfiguration;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.TableResult;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link BigQueryJobControlRepository}. Mocks
+ * {@link com.google.cloud.bigquery.BigQuery} so no real GCP credentials or
+ * network are required.
+ *
+ * <p>Each method gets a happy-path test that captures the SQL via
+ * {@link ArgumentCaptor} and verifies key SQL substrings — the SQL is the
+ * contract surface that ports the Python {@code repository.py} semantics, so
+ * regressions there must fail the build.
+ */
+@ExtendWith(MockitoExtension.class)
+class BigQueryJobControlRepositoryTest {
+
+    private static final String PROJECT_ID = "my-project";
+    private static final String DATASET = "job_control";
+    private static final String TABLE = "pipeline_jobs";
+    private static final String FQTN = "`my-project.job_control.pipeline_jobs`";
+
+    @Mock
+    private BigQuery client;
+
+    @Mock
+    private TableResult emptyResult;
+
+    private BigQueryJobControlRepository newRepo() {
+        return new BigQueryJobControlRepository(client, PROJECT_ID, DATASET, TABLE);
+    }
+
+    private PipelineJob sampleJob() {
+        return PipelineJob.builder(
+                        "run-1", "system-A", "customer-ingest",
+                        LocalDate.of(2026, 1, 15), JobStatus.CREATED)
+                .jobType(JobType.INGESTION)
+                .entityType("customer")
+                .sourceFile("gs://bucket/customers.csv")
+                .build();
+    }
+
+    // --- createJob ---------------------------------------------------------
+
+    @Test
+    void createJobIssuesInsertWithAllColumns() throws InterruptedException {
+        when(client.query(any(QueryJobConfiguration.class))).thenReturn(emptyResult);
+        BigQueryJobControlRepository repo = newRepo();
+
+        repo.createJob(sampleJob());
+
+        ArgumentCaptor<QueryJobConfiguration> captor =
+                ArgumentCaptor.forClass(QueryJobConfiguration.class);
+        verify(client).query(captor.capture());
+        String sql = captor.getValue().getQuery();
+        assertThat(sql).contains("INSERT INTO " + FQTN);
+        assertThat(sql).contains("run_id", "system_id", "pipeline_name",
+                "extract_date", "status", "job_type");
+        assertThat(sql).contains("CURRENT_TIMESTAMP()");
+    }
+
+    // --- getJob ------------------------------------------------------------
+
+    @Test
+    void getJobReturnsOptionalEmptyWhenNoRows() throws InterruptedException {
+        when(emptyResult.iterateAll()).thenReturn(List.of());
+        when(client.query(any(QueryJobConfiguration.class))).thenReturn(emptyResult);
+        BigQueryJobControlRepository repo = newRepo();
+
+        Optional<PipelineJob> result = repo.getJob("missing-run");
+
+        assertThat(result).isEmpty();
+        ArgumentCaptor<QueryJobConfiguration> captor =
+                ArgumentCaptor.forClass(QueryJobConfiguration.class);
+        verify(client).query(captor.capture());
+        assertThat(captor.getValue().getQuery()).contains("SELECT * FROM " + FQTN);
+        assertThat(captor.getValue().getQuery()).contains("WHERE run_id = @run_id");
+    }
+
+    @Test
+    void getJobMapsRowFieldsToBuilder() throws InterruptedException {
+        Schema schema = Schema.of(
+                Field.of("run_id", com.google.cloud.bigquery.StandardSQLTypeName.STRING),
+                Field.of("system_id", com.google.cloud.bigquery.StandardSQLTypeName.STRING),
+                Field.of("pipeline_name", com.google.cloud.bigquery.StandardSQLTypeName.STRING),
+                Field.of("extract_date", com.google.cloud.bigquery.StandardSQLTypeName.DATE),
+                Field.of("status", com.google.cloud.bigquery.StandardSQLTypeName.STRING),
+                Field.of("job_type", com.google.cloud.bigquery.StandardSQLTypeName.STRING),
+                Field.of("entity_type", com.google.cloud.bigquery.StandardSQLTypeName.STRING),
+                Field.of("retry_count", com.google.cloud.bigquery.StandardSQLTypeName.INT64));
+        FieldValueList row = FieldValueList.of(List.of(
+                FieldValue.of(FieldValue.Attribute.PRIMITIVE, "run-1"),
+                FieldValue.of(FieldValue.Attribute.PRIMITIVE, "system-A"),
+                FieldValue.of(FieldValue.Attribute.PRIMITIVE, "customer-ingest"),
+                FieldValue.of(FieldValue.Attribute.PRIMITIVE, "2026-01-15"),
+                FieldValue.of(FieldValue.Attribute.PRIMITIVE, "running"),
+                FieldValue.of(FieldValue.Attribute.PRIMITIVE, "INGESTION"),
+                FieldValue.of(FieldValue.Attribute.PRIMITIVE, "customer"),
+                FieldValue.of(FieldValue.Attribute.PRIMITIVE, "2")), schema.getFields());
+        when(emptyResult.iterateAll()).thenReturn(List.of(row));
+        when(client.query(any(QueryJobConfiguration.class))).thenReturn(emptyResult);
+        BigQueryJobControlRepository repo = newRepo();
+
+        Optional<PipelineJob> result = repo.getJob("run-1");
+
+        assertThat(result).isPresent();
+        PipelineJob job = result.get();
+        assertThat(job.runId()).isEqualTo("run-1");
+        assertThat(job.systemId()).isEqualTo("system-A");
+        assertThat(job.pipelineName()).isEqualTo("customer-ingest");
+        assertThat(job.status()).isEqualTo(JobStatus.RUNNING);
+        assertThat(job.jobType()).isEqualTo(JobType.INGESTION);
+        assertThat(job.entityType()).contains("customer");
+        assertThat(job.retryCount()).isEqualTo(2);
+    }
+
+    // --- updateStatus ------------------------------------------------------
+
+    @Test
+    void updateStatusRunningStampsStartedAt() throws InterruptedException {
+        when(client.query(any(QueryJobConfiguration.class))).thenReturn(emptyResult);
+        BigQueryJobControlRepository repo = newRepo();
+
+        repo.updateStatus("run-1", JobStatus.RUNNING, Optional.empty());
+
+        ArgumentCaptor<QueryJobConfiguration> captor =
+                ArgumentCaptor.forClass(QueryJobConfiguration.class);
+        verify(client).query(captor.capture());
+        String sql = captor.getValue().getQuery();
+        assertThat(sql).contains("UPDATE " + FQTN);
+        assertThat(sql).contains("started_at = CURRENT_TIMESTAMP()");
+    }
+
+    @Test
+    void updateStatusSucceededStampsCompletedAtAndRecordCount() throws InterruptedException {
+        when(client.query(any(QueryJobConfiguration.class))).thenReturn(emptyResult);
+        BigQueryJobControlRepository repo = newRepo();
+
+        repo.updateStatus("run-1", JobStatus.SUCCEEDED, Optional.of(5_000L));
+
+        ArgumentCaptor<QueryJobConfiguration> captor =
+                ArgumentCaptor.forClass(QueryJobConfiguration.class);
+        verify(client).query(captor.capture());
+        String sql = captor.getValue().getQuery();
+        assertThat(sql).contains("completed_at = CURRENT_TIMESTAMP()");
+        assertThat(sql).contains("record_count = @record_count");
+    }
+
+    // --- markFailed --------------------------------------------------------
+
+    @Test
+    void markFailedSetsErrorContextAndFailedStatus() throws InterruptedException {
+        when(client.query(any(QueryJobConfiguration.class))).thenReturn(emptyResult);
+        BigQueryJobControlRepository repo = newRepo();
+
+        repo.markFailed("run-1", "E001", "schema mismatch",
+                FailureStage.VALIDATION, Optional.of("gs://errors/run-1.json"));
+
+        ArgumentCaptor<QueryJobConfiguration> captor =
+                ArgumentCaptor.forClass(QueryJobConfiguration.class);
+        verify(client).query(captor.capture());
+        String sql = captor.getValue().getQuery();
+        assertThat(sql).contains("UPDATE " + FQTN);
+        assertThat(sql).contains("error_code = @error_code", "error_message = @error_message",
+                "failure_stage = @failure_stage", "error_file_path = @error_file_path");
+    }
+
+    // --- markRetrying ------------------------------------------------------
+
+    @Test
+    void markRetryingUpdatesStatusAndCounter() throws InterruptedException {
+        when(client.query(any(QueryJobConfiguration.class))).thenReturn(emptyResult);
+        BigQueryJobControlRepository repo = newRepo();
+
+        repo.markRetrying("run-1", 3);
+
+        ArgumentCaptor<QueryJobConfiguration> captor =
+                ArgumentCaptor.forClass(QueryJobConfiguration.class);
+        verify(client).query(captor.capture());
+        String sql = captor.getValue().getQuery();
+        assertThat(sql).contains("retry_count = @retry_count");
+    }
+
+    @Test
+    void markRetryingRejectsNegativeRetryCount() {
+        BigQueryJobControlRepository repo = newRepo();
+        assertThatThrownBy(() -> repo.markRetrying("run-1", -1))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    // --- getPendingJobs ----------------------------------------------------
+
+    @Test
+    void getPendingJobsAllSystemsSelectsCreatedAndRunning() throws InterruptedException {
+        when(emptyResult.iterateAll()).thenReturn(List.of());
+        when(client.query(any(QueryJobConfiguration.class))).thenReturn(emptyResult);
+        BigQueryJobControlRepository repo = newRepo();
+
+        List<PipelineJob> jobs = repo.getPendingJobs(Optional.empty());
+
+        assertThat(jobs).isEmpty();
+        ArgumentCaptor<QueryJobConfiguration> captor =
+                ArgumentCaptor.forClass(QueryJobConfiguration.class);
+        verify(client).query(captor.capture());
+        String sql = captor.getValue().getQuery();
+        assertThat(sql).contains("status IN (@created, @running)");
+        assertThat(sql).doesNotContain("system_id = @system_id");
+    }
+
+    @Test
+    void getPendingJobsBySystemFiltersOnSystemId() throws InterruptedException {
+        when(emptyResult.iterateAll()).thenReturn(List.of());
+        when(client.query(any(QueryJobConfiguration.class))).thenReturn(emptyResult);
+        BigQueryJobControlRepository repo = newRepo();
+
+        repo.getPendingJobs(Optional.of("system-A"));
+
+        ArgumentCaptor<QueryJobConfiguration> captor =
+                ArgumentCaptor.forClass(QueryJobConfiguration.class);
+        verify(client).query(captor.capture());
+        assertThat(captor.getValue().getQuery()).contains("system_id = @system_id");
+    }
+
+    // --- getEntityStatus ---------------------------------------------------
+
+    @Test
+    void getEntityStatusEmptyReturnsEmptyList() throws InterruptedException {
+        when(emptyResult.iterateAll()).thenReturn(List.of());
+        when(client.query(any(QueryJobConfiguration.class))).thenReturn(emptyResult);
+        BigQueryJobControlRepository repo = newRepo();
+
+        List<EntityStatus> result = repo.getEntityStatus("system-A", LocalDate.of(2026, 1, 15));
+
+        assertThat(result).isEmpty();
+        ArgumentCaptor<QueryJobConfiguration> captor =
+                ArgumentCaptor.forClass(QueryJobConfiguration.class);
+        verify(client).query(captor.capture());
+        String sql = captor.getValue().getQuery();
+        assertThat(sql).contains("entity_type", "status", "run_id");
+        assertThat(sql).contains("system_id = @system_id");
+        assertThat(sql).contains("extract_date = @extract_date");
+    }
+
+    // --- getFailedJobs -----------------------------------------------------
+
+    @Test
+    void getFailedJobsFiltersOnFailedStatus() throws InterruptedException {
+        when(emptyResult.iterateAll()).thenReturn(List.of());
+        when(client.query(any(QueryJobConfiguration.class))).thenReturn(emptyResult);
+        BigQueryJobControlRepository repo = newRepo();
+
+        List<FailedJob> result = repo.getFailedJobs("system-A", LocalDate.of(2026, 1, 15));
+
+        assertThat(result).isEmpty();
+        ArgumentCaptor<QueryJobConfiguration> captor =
+                ArgumentCaptor.forClass(QueryJobConfiguration.class);
+        verify(client).query(captor.capture());
+        String sql = captor.getValue().getQuery();
+        assertThat(sql).contains("status = @status");
+        assertThat(sql).contains("failure_stage", "error_code", "error_message");
+    }
+
+    // --- getFdpJobStatus ---------------------------------------------------
+
+    @Test
+    void getFdpJobStatusEmptyReturnsOptionalEmpty() throws InterruptedException {
+        when(emptyResult.iterateAll()).thenReturn(List.of());
+        when(client.query(any(QueryJobConfiguration.class))).thenReturn(emptyResult);
+        BigQueryJobControlRepository repo = newRepo();
+
+        Optional<FdpJobStatus> result = repo.getFdpJobStatus(
+                "system-A", LocalDate.of(2026, 1, 15), "fdp_customer_v1");
+
+        assertThat(result).isEmpty();
+        ArgumentCaptor<QueryJobConfiguration> captor =
+                ArgumentCaptor.forClass(QueryJobConfiguration.class);
+        verify(client).query(captor.capture());
+        String sql = captor.getValue().getQuery();
+        assertThat(sql).contains("job_type = @job_type");
+        assertThat(sql).contains("pipeline_name = @model_name");
+        assertThat(sql).contains("ORDER BY created_at DESC LIMIT 1");
+    }
+
+    // --- cleanupPartialLoad ------------------------------------------------
+
+    @Test
+    void cleanupPartialLoadDeletesByRunId() throws InterruptedException {
+        when(emptyResult.getTotalRows()).thenReturn(42L);
+        when(client.query(any(QueryJobConfiguration.class))).thenReturn(emptyResult);
+        BigQueryJobControlRepository repo = newRepo();
+
+        int deleted = repo.cleanupPartialLoad("run-1", "my-project.warehouse.customers");
+
+        assertThat(deleted).isEqualTo(42);
+        ArgumentCaptor<QueryJobConfiguration> captor =
+                ArgumentCaptor.forClass(QueryJobConfiguration.class);
+        verify(client).query(captor.capture());
+        String sql = captor.getValue().getQuery();
+        assertThat(sql).contains("DELETE FROM `my-project.warehouse.customers`");
+        assertThat(sql).contains("WHERE _run_id = @run_id");
+    }
+
+    // --- updateCostMetrics -------------------------------------------------
+
+    @Test
+    void updateCostMetricsSetsAllThreeFinOpsFields() throws InterruptedException {
+        when(client.query(any(QueryJobConfiguration.class))).thenReturn(emptyResult);
+        BigQueryJobControlRepository repo = newRepo();
+
+        repo.updateCostMetrics("run-1", 12.34, 1_000_000L, 500_000L);
+
+        ArgumentCaptor<QueryJobConfiguration> captor =
+                ArgumentCaptor.forClass(QueryJobConfiguration.class);
+        verify(client).query(captor.capture());
+        String sql = captor.getValue().getQuery();
+        assertThat(sql).contains("estimated_cost_usd = @cost");
+        assertThat(sql).contains("billed_bytes_scanned = @scanned");
+        assertThat(sql).contains("billed_bytes_written = @written");
+    }
+
+    // --- error path --------------------------------------------------------
+
+    @Test
+    void interruptedExceptionIsRewrappedAndInterruptFlagRestored() throws InterruptedException {
+        when(client.query(any(QueryJobConfiguration.class)))
+                .thenThrow(new InterruptedException("test"));
+        BigQueryJobControlRepository repo = newRepo();
+
+        try {
+            assertThatThrownBy(() -> repo.markRetrying("run-1", 1))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessageContaining("interrupted");
+            assertThat(Thread.currentThread().isInterrupted()).isTrue();
+        } finally {
+            // Clear the interrupted flag so we don't poison other tests.
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    void bigQueryExceptionPropagates() throws InterruptedException {
+        when(client.query(any(QueryJobConfiguration.class)))
+                .thenThrow(new BigQueryException(500, "boom"));
+        BigQueryJobControlRepository repo = newRepo();
+
+        assertThatThrownBy(() -> repo.markRetrying("run-1", 1))
+                .isInstanceOf(BigQueryException.class);
+    }
+}

--- a/docs/framework-evolution/03-dev-process.md
+++ b/docs/framework-evolution/03-dev-process.md
@@ -100,15 +100,19 @@ For sprint-1 GCP modules:
 
 Live-cloud integration tests are sprint-2+ scope.
 
-## Sprint branch workflow (from Sprint 2 onward)
+## Sprint branch workflow
 
-**Sprint 0** lands on `main` directly (process docs + scaffolding only).
+**Sprint 0** is the only sprint that lands on `main` directly — process
+docs + scaffolding only, no production code.
 
-**Sprint 1** also lands on `main` directly — issues #5-#9 were written
-under the direct-to-main model and dispatching is imminent. Don't
-rewrite them.
+**Every other sprint** (Sprint 1 onward) uses a sprint branch. Mid-Sprint-1
+correction: the earlier draft of this doc carved out a "Sprint 1 stays
+direct-to-main" exception. **That exception was removed.** Wave 1 (#5)
+and wave 2 (#6, #7) of Sprint 1 already landed on `main` before the rule
+took full effect; those commits stay on `main` and the violation is
+captured in the Sprint 1 retro. Wave 3 onward goes through `sprint-1`.
 
-**Sprint 2 onward** uses a sprint branch:
+**Sprint 1 onward** uses a sprint branch:
 
 ```
 main

--- a/docs/framework-evolution/04-sprint-plan.md
+++ b/docs/framework-evolution/04-sprint-plan.md
@@ -29,6 +29,12 @@ slack.
 
 ## Sprint 1 — Java GCP adapters (Phase B start)
 
+**Branching:** Wave 1 (#5) and wave 2 (#6, #7) landed on `main` directly
+before the sprint-branch rule was applied retroactively. Wave 3 (#8, #9)
+and the sprint-close UAT run on the `sprint-1` branch; `sprint-1 → main`
+PR at sprint close. The mid-sprint rule change is logged in the Sprint 1
+retro.
+
 **Goal:** First three GCP contracts on the JVM via Mockito-only tests.
 
 **Tickets:**
@@ -51,12 +57,12 @@ slack.
 
 ---
 
-## Sprint 2 — Java GCP adapters (Phase B finish) — **first sprint on a sprint branch**
+## Sprint 2 — Java GCP adapters (Phase B finish)
 
-**Branching:** This is the first sprint that uses the sprint-branch
-workflow (DEV_PROCESS.md). Cut `sprint-2` from `main` after Sprint 1
-merges. Each ticket's feature branch is `feature/issue-N-<slug>` PR'd
-into `sprint-2`. Single `sprint-2 → main` PR at sprint close.
+**Branching:** Standard sprint-branch workflow (DEV_PROCESS.md). Cut
+`sprint-2` from `main` after Sprint 1 merges. Each ticket's feature
+branch is `feature/issue-N-<slug>` PR'd into `sprint-2`. Single
+`sprint-2 → main` PR at sprint close.
 
 **Goal:** Cover the remaining GCP contracts on the JVM so Beam pipelines have a full adapter set.
 


### PR DESCRIPTION
Sprint 1 close PR. Merges `sprint-1` → `main`.

## What's in this PR

Five commits ahead of main:

| | What |
|---|---|
| `d26e005` | docs: apply sprint-branch rule retroactively (drop Sprint 1 direct-to-main exception in DEV_PROCESS.md + SPRINT_PLAN.md) |
| `bff9337` | feat: `BigQueryJobControlRepository` — 11 methods, SQL ported from Python `repository.py`, 17 Mockito tests |
| `a919951` | Merge of PR #19 (the JobControlRepository feature branch) into sprint-1 |
| `85d959e` | feat: `BigQueryFinOpsSink` — `insertAll` to `cost_metrics`, partial-failure → custom exception, 11 Mockito tests |
| `1901309` | Merge of PR #20 (the FinOpsSink feature branch) into sprint-1 |

Issues #5/#6/#7 (waves 1+2) were already on main before the sprint-branch rule was applied — captured in the retro on #1, not duplicated here.

## Sprint-exit gate

```
$ cd data-pipeline-libraries-java && mvn clean test
[INFO] Culvert :: data-pipeline-libraries (parent) ........ SUCCESS
[INFO] Culvert :: data-pipeline-core (Java) ............... SUCCESS  [33 tests]
[INFO] Culvert :: data-pipeline-gcp-secrets (Java) ........ SUCCESS  [4  tests]
[INFO] Culvert :: data-pipeline-gcp-bigquery (Java) ....... SUCCESS  [40 tests: 12 Warehouse + 17 JobControlRepository + 11 FinOpsSink]
[INFO] Culvert :: data-pipeline-gcp-gcs (Java) ............ SUCCESS  [17 tests]
[INFO] BUILD SUCCESS
```

**94 tests green across 4 modules.**

## Sprint 1 retro

Posted on epic #1 (https://github.com/enrichmeai/gcp-pipeline-reference/issues/1#issuecomment-4548892830). Headlines:
- All 5 sprint-1 issues closed (#5, #6, #7, #8, #9). Reactor green.
- Two retro items carry into Sprint 2: (a) sub-agent permission-model triage (#16) — must resolve before sprint-2 wave-1 dispatch, (b) pre-flight permissions check via a throwaway probe-agent.

## Merge guidance

Use a merge commit (not squash, not fast-forward) so the sprint boundary is visible in `git log --first-parent`. That's the convention encoded in DEV_PROCESS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)