### PR TITLE
feat(pubsub-java): PubSubSource + PubSubSink for sprint-2 (#23)

### DIFF
--- a/data-pipeline-libraries-java/data-pipeline-gcp-pubsub-java/README.md
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-pubsub-java/README.md
@@ -1,0 +1,119 @@
+# data-pipeline-gcp-pubsub (Java)
+
+Google Cloud Pub/Sub adapter for the Culvert data pipeline framework, JVM edition. Provides `PubSubSource` and `PubSubSink`, the GCP implementations of the cloud-neutral [`Source`](../data-pipeline-core-java/src/main/java/com/enrichmeai/culvert/contracts/Source.java) and [`Sink`](../data-pipeline-core-java/src/main/java/com/enrichmeai/culvert/contracts/Sink.java) contracts defined in `data-pipeline-core-java`.
+
+## Status
+
+**Version 0.1.0 — Sprint 2 deliverable** (issue [#23](https://github.com/enrichmeai/gcp-pipeline-reference/issues/23)). Mirrors the sprint-1 BigQuery and Secrets pilots in shape: BOM-in-module, no application framework, ServiceLoader-registered, AutoCloseable only when the wrapped client supports it.
+
+## Install (Maven)
+
+```xml
+<dependency>
+    <groupId>com.enrichmeai.culvert</groupId>
+    <artifactId>data-pipeline-gcp-pubsub</artifactId>
+    <version>0.1.0</version>
+</dependency>
+```
+
+Pulls in `data-pipeline-core` (the contracts) plus `google-cloud-pubsub` (version managed by the Google Cloud `libraries-bom`, pinned to `26.39.0` here).
+
+## Contracts satisfied
+
+```java
+public interface Source<T> {
+    Iterator<T> read(RuntimeContext context);
+}
+
+public interface Sink<U> {
+    void write(Iterator<U> records, RuntimeContext context);
+}
+```
+
+Record type is `com.google.pubsub.v1.PubsubMessage` for both, so a sink can re-emit messages a source produced without translation.
+
+## PubSubSource
+
+Wraps a [`SubscriberStub`](https://cloud.google.com/java/docs/reference/google-cloud-pubsub/latest/com.google.cloud.pubsub.v1.stub.SubscriberStub) and performs a single synchronous `pull` per `read()` call. Returned messages are acknowledged eagerly before `read()` returns, so the delivery model is **at-most-once**. Callers who need at-least-once should wire a Subscriber-based reader instead.
+
+### Constructors
+
+```java
+// Default: max 100 messages per pull
+PubSubSource source = new PubSubSource(subscriberStub, "projects/p/subscriptions/my-sub");
+
+// Explicit per-pull batch size
+PubSubSource source = new PubSubSource(subscriberStub, "projects/p/subscriptions/my-sub", 25);
+```
+
+`subscriptionName` must be the fully-qualified resource name. Use [`ProjectSubscriptionName.of(project, name).toString()`](https://cloud.google.com/java/docs/reference/google-cloud-pubsub/latest/com.google.pubsub.v1.ProjectSubscriptionName) to build it.
+
+### Lifecycle
+
+`PubSubSource` implements `AutoCloseable` because `SubscriberStub` extends `BackgroundResource extends AutoCloseable`. Use try-with-resources:
+
+```java
+try (PubSubSource source = new PubSubSource(stub, subscriptionName)) {
+    source.read(context).forEachRemaining(msg ->
+        System.out.println(msg.getData().toStringUtf8()));
+}
+```
+
+## PubSubSink
+
+Wraps a [`Publisher`](https://cloud.google.com/java/docs/reference/google-cloud-pubsub/latest/com.google.cloud.pubsub.v1.Publisher) and forwards each record via `publisher.publish(message)`. Per-message futures are collected and awaited before `write()` returns, so per-message publish failures surface as `PubSubSink.PubSubPublishException`.
+
+### Constructor
+
+```java
+// Publisher carries the topic name and any batching/retry settings.
+Publisher publisher = Publisher.newBuilder(TopicName.of("p", "t")).build();
+PubSubSink sink = new PubSubSink(publisher);
+```
+
+### Lifecycle
+
+`Publisher` does **not** implement `AutoCloseable` — it exposes `shutdown()` plus `awaitTermination(long, TimeUnit)`. Per the framework's "AutoCloseable only when the wrapped client supports it" rule, `PubSubSink` is not `AutoCloseable` either. Use the passthrough:
+
+```java
+sink.write(records, context);
+sink.shutdown(30, TimeUnit.SECONDS);
+```
+
+## Environment variables
+
+| Variable | Used by | Required? |
+|---|---|---|
+| `GOOGLE_APPLICATION_CREDENTIALS` | The underlying `SubscriberStub` / `Publisher` (standard ADC) | Only when not running on a GCP-managed identity |
+
+No Pub/Sub-specific environment variables are read by this module — the subscription FQN and topic FQN are explicit constructor arguments, so there is no concept of a "default subscription" or "default topic" baked in.
+
+## ServiceLoader registration
+
+`src/main/resources/META-INF/services/` lists both:
+
+- `com.enrichmeai.culvert.contracts.Source` → `com.enrichmeai.culvert.gcp.pubsub.PubSubSource`
+- `com.enrichmeai.culvert.contracts.Sink` → `com.enrichmeai.culvert.gcp.pubsub.PubSubSink`
+
+Like the BigQuery pilot, the implementations do **not** expose a no-arg constructor (they need a `SubscriberStub` / `Publisher` injected). Direct `ServiceLoader.load(Source.class).findFirst()` will therefore fail with `ServiceConfigurationError` until sprint-4 wires a config-driven constructor. Instantiate explicitly until then.
+
+## Errors
+
+| Cause | Thrown |
+|---|---|
+| Pull RPC fails | Underlying `ApiException` propagates unchanged |
+| Acknowledge RPC fails (after pull succeeds) | Underlying `ApiException` propagates unchanged (caller may see ack loss) |
+| Any publish future fails | `PubSubSink.PubSubPublishException` (cause is the underlying SDK exception) |
+| Interrupted during publish await | `PubSubSink.PubSubPublishException` after restoring the interrupt flag |
+| Null constructor arg or `read`/`write` arg | `NullPointerException` |
+| `maxMessages <= 0` | `IllegalArgumentException` |
+
+## Testing
+
+Unit tests mock `SubscriberStub` (plus its `UnaryCallable` chains) and `Publisher` with Mockito. Future-driven behaviour uses `com.google.api.core.ApiFutures.immediateFuture` / `immediateFailedFuture` so no thread juggling is needed. No real Pub/Sub credentials, no network. From the `data-pipeline-libraries-java/` directory:
+
+```bash
+cd data-pipeline-libraries-java && mvn -pl data-pipeline-gcp-pubsub-java -am clean test
+```
+
+Live-cloud integration tests against a real Pub/Sub topic are sprint-3+ scope.

--- a/data-pipeline-libraries-java/data-pipeline-gcp-pubsub-java/pom.xml
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-pubsub-java/pom.xml
@@ -3,15 +3,123 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>com.enrichmeai.culvert</groupId>
         <artifactId>data-pipeline-libraries-parent</artifactId>
         <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
+
     <artifactId>data-pipeline-gcp-pubsub</artifactId>
     <packaging>jar</packaging>
-    <name>Culvert :: data-pipeline-gcp-pubsub (Java) — placeholder</name>
-    <description>Placeholder for the sprint-2 GCP Pub/Sub adapter. REPLACE THIS ENTIRE FILE when implementing.</description>
-    <!-- REPLACE THIS ENTIRE FILE when implementing the sprint-2 pubsub ticket. -->
+
+    <name>Culvert :: data-pipeline-gcp-pubsub (Java)</name>
+    <description>
+        Google Cloud Pub/Sub adapter for the Culvert framework. Provides
+        PubSubSource (Source implementation wrapping a SubscriberStub for
+        synchronous pull) and PubSubSink (Sink implementation wrapping a
+        Publisher). Registered via java.util.ServiceLoader so consumers
+        can wire it without compile-time coupling to the GCP SDK.
+        Sprint-2 deliverable (issue #23).
+    </description>
+
+    <properties>
+        <!--
+            Google Cloud Java SDK BOM. Imported here in dependencyManagement so
+            the GCP modules (this one, bigquery-java, secrets-java, gcs-java)
+            each pin the same SDK family without the parent POM depending on
+            GCP. Keeps the parent cloud-neutral. Mirror of the bigquery-java
+            pilot.
+        -->
+        <google.cloud.libraries.bom.version>26.39.0</google.cloud.libraries.bom.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>libraries-bom</artifactId>
+                <version>${google.cloud.libraries.bom.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <!-- Culvert contracts -->
+        <dependency>
+            <groupId>com.enrichmeai.culvert</groupId>
+            <artifactId>data-pipeline-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Google Cloud Pub/Sub (version managed by libraries-bom) -->
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-pubsub</artifactId>
+        </dependency>
+
+        <!-- SLF4J API only — consumers bring their own binding -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <!-- Test scope -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <!--
+                        google-cloud-pubsub transitively brings in annotation
+                        processors (auto-value, etc.) that don't claim our
+                        JUnit / Mockito annotations. Under the parent's
+                        -Xlint:all + -Werror, this triggers a "No processor
+                        claimed any of these annotations" warning that fails
+                        the build. We don't use annotation processors here, so
+                        disable processing explicitly. Mirrors bigquery-java.
+                    -->
+                    <proc>none</proc>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/data-pipeline-libraries-java/data-pipeline-gcp-pubsub-java/src/main/java/com/enrichmeai/culvert/gcp/pubsub/PubSubSink.java
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-pubsub-java/src/main/java/com/enrichmeai/culvert/gcp/pubsub/PubSubSink.java
@@ -1,0 +1,146 @@
+package com.enrichmeai.culvert.gcp.pubsub;
+
+import com.enrichmeai.culvert.contracts.RuntimeContext;
+import com.enrichmeai.culvert.contracts.Sink;
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.cloud.pubsub.v1.Publisher;
+import com.google.pubsub.v1.PubsubMessage;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * {@link Sink} implementation backed by a Google Cloud Pub/Sub topic.
+ *
+ * <p>Wraps a {@link Publisher} and forwards each record via
+ * {@link Publisher#publish(PubsubMessage)}. {@code publish} is asynchronous
+ * (returns an {@link ApiFuture}); this sink collects all futures emitted by
+ * a single {@link #write(Iterator, RuntimeContext)} call and waits for them
+ * to resolve before returning, so any per-message publish failure surfaces
+ * to the caller as a {@link PubSubPublishException} rather than being
+ * silently dropped.
+ *
+ * <h2>Construction</h2>
+ * <ul>
+ *   <li>{@link #PubSubSink(Publisher)} — primary; the topic name is carried
+ *       on the {@link Publisher} itself
+ *       ({@link Publisher#getTopicNameString()}).</li>
+ * </ul>
+ *
+ * <h2>Lifecycle</h2>
+ *
+ * <p>{@link Publisher} does NOT implement {@link AutoCloseable} — it exposes
+ * {@link Publisher#shutdown()} + {@link Publisher#awaitTermination(long, TimeUnit)}
+ * instead. Per the framework's "AutoCloseable only when the wrapped client
+ * supports it" rule, this sink also does not implement {@code AutoCloseable}.
+ * Callers should invoke {@link #shutdown(long, TimeUnit)} (or manage the
+ * Publisher lifecycle externally) when the pipeline finishes.
+ *
+ * <p>Sprint-2 deliverable for issue #23.
+ */
+public final class PubSubSink implements Sink<PubsubMessage> {
+
+    private final Publisher publisher;
+
+    /**
+     * Primary constructor.
+     *
+     * @param publisher Pre-built Pub/Sub publisher (already wired with a
+     *                  topic and any batching / retry settings the caller
+     *                  wants). Required.
+     * @throws NullPointerException if {@code publisher} is null.
+     */
+    public PubSubSink(Publisher publisher) {
+        this.publisher = Objects.requireNonNull(publisher, "publisher must not be null");
+    }
+
+    /**
+     * Publish every record from {@code records}, blocking until all
+     * resulting futures resolve.
+     *
+     * <p>If any individual publish fails, this method throws a
+     * {@link PubSubPublishException} that wraps the underlying cause. The
+     * iterator is consumed fully before the wait, so partial failures of a
+     * batch still surface — but later records in the same batch may have
+     * already been published.
+     *
+     * @param records Records to publish. Must not be null.
+     * @param context Runtime context. Not used by this implementation but
+     *                accepted to honour the {@link Sink} contract.
+     * @throws NullPointerException   if {@code records} is null.
+     * @throws PubSubPublishException if any publish future fails.
+     */
+    @Override
+    public void write(Iterator<PubsubMessage> records, RuntimeContext context) {
+        Objects.requireNonNull(records, "records must not be null");
+
+        List<ApiFuture<String>> futures = new ArrayList<>();
+        while (records.hasNext()) {
+            PubsubMessage message = records.next();
+            if (message == null) {
+                throw new NullPointerException(
+                        "records iterator yielded a null PubsubMessage");
+            }
+            futures.add(publisher.publish(message));
+        }
+
+        if (futures.isEmpty()) {
+            return;
+        }
+
+        try {
+            // allAsList resolves when every future resolves; if any fails the
+            // composite future fails with the first cause, which surfaces here.
+            ApiFutures.allAsList(futures).get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PubSubPublishException(
+                    "Interrupted while waiting for Pub/Sub publish futures", e);
+        } catch (ExecutionException e) {
+            throw new PubSubPublishException(
+                    "Pub/Sub publish failed: " + e.getCause().getMessage(),
+                    e.getCause());
+        }
+    }
+
+    /**
+     * Trigger an orderly shutdown of the underlying {@link Publisher} and
+     * wait up to {@code timeout} for in-flight publishes to complete.
+     *
+     * <p>This is a passthrough — the framework does not call it
+     * automatically. Wire it into your pipeline teardown hook.
+     *
+     * @param timeout Maximum time to wait.
+     * @param unit    Time unit for {@code timeout}.
+     * @return {@code true} if the publisher terminated within the timeout.
+     * @throws InterruptedException if the calling thread is interrupted
+     *                              while waiting.
+     */
+    public boolean shutdown(long timeout, TimeUnit unit) throws InterruptedException {
+        publisher.shutdown();
+        return publisher.awaitTermination(timeout, unit);
+    }
+
+    /** The topic name the underlying publisher is targeting. */
+    public String topicName() {
+        return publisher.getTopicNameString();
+    }
+
+    /**
+     * Exception thrown when a Pub/Sub publish fails. Wraps the underlying
+     * cause so callers can inspect the GCP-side error without depending on
+     * the SDK's exception hierarchy at the catch site.
+     */
+    public static final class PubSubPublishException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+
+        public PubSubPublishException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/data-pipeline-libraries-java/data-pipeline-gcp-pubsub-java/src/main/java/com/enrichmeai/culvert/gcp/pubsub/PubSubSource.java
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-pubsub-java/src/main/java/com/enrichmeai/culvert/gcp/pubsub/PubSubSource.java
@@ -1,0 +1,156 @@
+package com.enrichmeai.culvert.gcp.pubsub;
+
+import com.enrichmeai.culvert.contracts.RuntimeContext;
+import com.enrichmeai.culvert.contracts.Source;
+import com.google.pubsub.v1.AcknowledgeRequest;
+import com.google.pubsub.v1.PubsubMessage;
+import com.google.pubsub.v1.PullRequest;
+import com.google.pubsub.v1.PullResponse;
+import com.google.pubsub.v1.ReceivedMessage;
+import com.google.cloud.pubsub.v1.stub.SubscriberStub;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * {@link Source} implementation backed by a Google Cloud Pub/Sub subscription.
+ *
+ * <p>Wraps a {@link SubscriberStub} and performs a single synchronous
+ * {@code pull} per {@link #read(RuntimeContext)} call. Returned messages are
+ * acknowledged eagerly before {@code read} returns, so the delivery model is
+ * <em>at-most-once</em>: a consumer that crashes mid-iteration after
+ * {@code read} has returned will lose the pulled batch. Callers needing
+ * at-least-once semantics should wire a separate Subscriber-based reader.
+ *
+ * <h2>Construction</h2>
+ * <ul>
+ *   <li>{@link #PubSubSource(SubscriberStub, String)} — primary; uses the
+ *       default {@code maxMessages} of {@value #DEFAULT_MAX_MESSAGES} per
+ *       pull.</li>
+ *   <li>{@link #PubSubSource(SubscriberStub, String, int)} — explicit
+ *       per-pull batch size.</li>
+ * </ul>
+ *
+ * <p>{@code subscriptionName} must be the fully-qualified resource name
+ * ({@code projects/{project}/subscriptions/{name}}). The
+ * {@link com.google.pubsub.v1.ProjectSubscriptionName#of(String, String)
+ * ProjectSubscriptionName.of} helper produces the canonical form.
+ *
+ * <p>The wrapped {@link SubscriberStub} extends
+ * {@link com.google.api.gax.core.BackgroundResource} which itself extends
+ * {@link AutoCloseable}, so this class also implements {@link AutoCloseable};
+ * closing it closes the stub. Mirrors the {@code SecretManagerProvider}
+ * pilot's "AutoCloseable only when the wrapped client supports it" rule.
+ *
+ * <p>Sprint-2 deliverable for issue #23.
+ */
+public final class PubSubSource implements Source<PubsubMessage>, AutoCloseable {
+
+    /** Default per-pull batch size when not specified. */
+    public static final int DEFAULT_MAX_MESSAGES = 100;
+
+    private final SubscriberStub stub;
+    private final String subscriptionName;
+    private final int maxMessages;
+
+    /**
+     * Primary constructor. Uses {@link #DEFAULT_MAX_MESSAGES} per pull.
+     *
+     * @param stub             Pre-built Pub/Sub subscriber stub. Required.
+     *                         Ownership transfers to this source —
+     *                         {@link #close()} will close it.
+     * @param subscriptionName Fully-qualified subscription resource name
+     *                         ({@code projects/{project}/subscriptions/{name}}).
+     *                         Required.
+     * @throws NullPointerException if either argument is null.
+     */
+    public PubSubSource(SubscriberStub stub, String subscriptionName) {
+        this(stub, subscriptionName, DEFAULT_MAX_MESSAGES);
+    }
+
+    /**
+     * Constructor with explicit per-pull batch size.
+     *
+     * @param stub             Pre-built Pub/Sub subscriber stub. Required.
+     * @param subscriptionName Fully-qualified subscription resource name.
+     *                         Required.
+     * @param maxMessages      Maximum messages per {@code pull} call. Must
+     *                         be positive.
+     * @throws NullPointerException     if {@code stub} or
+     *                                  {@code subscriptionName} is null.
+     * @throws IllegalArgumentException if {@code maxMessages} is not
+     *                                  positive.
+     */
+    public PubSubSource(SubscriberStub stub, String subscriptionName, int maxMessages) {
+        this.stub = Objects.requireNonNull(stub, "stub must not be null");
+        this.subscriptionName = Objects.requireNonNull(
+                subscriptionName, "subscriptionName must not be null");
+        if (maxMessages <= 0) {
+            throw new IllegalArgumentException(
+                    "maxMessages must be positive, got " + maxMessages);
+        }
+        this.maxMessages = maxMessages;
+    }
+
+    /**
+     * Issue one synchronous pull against the wired subscription and
+     * eagerly acknowledge the returned messages.
+     *
+     * <p>Returns an iterator over the message payloads. If the pull returns
+     * no messages the iterator is empty and no acknowledge call is made.
+     *
+     * @param context Runtime context. Not used by this implementation but
+     *                accepted to honour the {@link Source} contract.
+     * @return Iterator over the pulled {@link PubsubMessage}s.
+     */
+    @Override
+    public Iterator<PubsubMessage> read(RuntimeContext context) {
+        PullRequest pullRequest = PullRequest.newBuilder()
+                .setSubscription(subscriptionName)
+                .setMaxMessages(maxMessages)
+                .build();
+
+        PullResponse response = stub.pullCallable().call(pullRequest);
+        List<ReceivedMessage> received = response.getReceivedMessagesList();
+        if (received.isEmpty()) {
+            return Collections.emptyIterator();
+        }
+
+        // Eager ack: collect ackIds and acknowledge before exposing
+        // messages. This gives at-most-once semantics — documented on the
+        // class — and keeps the iterator simple (no per-message ack callback
+        // for the consumer to forget).
+        List<String> ackIds = new ArrayList<>(received.size());
+        List<PubsubMessage> payloads = new ArrayList<>(received.size());
+        for (ReceivedMessage rm : received) {
+            ackIds.add(rm.getAckId());
+            payloads.add(rm.getMessage());
+        }
+
+        AcknowledgeRequest ackRequest = AcknowledgeRequest.newBuilder()
+                .setSubscription(subscriptionName)
+                .addAllAckIds(ackIds)
+                .build();
+        stub.acknowledgeCallable().call(ackRequest);
+
+        return payloads.iterator();
+    }
+
+    /** The fully-qualified subscription name this source pulls from. */
+    public String subscriptionName() {
+        return subscriptionName;
+    }
+
+    /** The configured maximum messages per pull. */
+    public int maxMessages() {
+        return maxMessages;
+    }
+
+    @Override
+    public void close() {
+        stub.close();
+    }
+}

--- a/data-pipeline-libraries-java/data-pipeline-gcp-pubsub-java/src/main/resources/META-INF/services/com.enrichmeai.culvert.contracts.Sink
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-pubsub-java/src/main/resources/META-INF/services/com.enrichmeai.culvert.contracts.Sink
@@ -1,0 +1,8 @@
+# Pre-registered for sprint-4 auto-config. The implementation does NOT
+# expose a no-arg constructor — PubSubSink wraps a pre-built Publisher,
+# which itself requires a topic name and batching/retry config at
+# construction time. Direct ServiceLoader.load(Sink.class).findFirst()
+# will fail with ServiceConfigurationError until sprint-4 introduces a
+# config-driven constructor. Until then, instantiate explicitly with
+# `new PubSubSink(publisher)`.
+com.enrichmeai.culvert.gcp.pubsub.PubSubSink

--- a/data-pipeline-libraries-java/data-pipeline-gcp-pubsub-java/src/main/resources/META-INF/services/com.enrichmeai.culvert.contracts.Source
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-pubsub-java/src/main/resources/META-INF/services/com.enrichmeai.culvert.contracts.Source
@@ -1,0 +1,9 @@
+# Pre-registered for sprint-4 auto-config. The implementation does NOT
+# expose a no-arg constructor — PubSubSource needs a SubscriberStub and a
+# fully-qualified subscription name at construction time, which exceeds
+# the pilot's "no-arg only if <=2 env vars of state" rule. Direct
+# ServiceLoader.load(Source.class).findFirst() will fail with
+# ServiceConfigurationError until sprint-4 introduces a config-driven
+# constructor. Until then, instantiate explicitly with
+# `new PubSubSource(stub, subscriptionName)`.
+com.enrichmeai.culvert.gcp.pubsub.PubSubSource

--- a/data-pipeline-libraries-java/data-pipeline-gcp-pubsub-java/src/test/java/com/enrichmeai/culvert/gcp/pubsub/PubSubSinkTest.java
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-pubsub-java/src/test/java/com/enrichmeai/culvert/gcp/pubsub/PubSubSinkTest.java
@@ -1,0 +1,148 @@
+package com.enrichmeai.culvert.gcp.pubsub;
+
+import com.enrichmeai.culvert.contracts.RuntimeContext;
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.cloud.pubsub.v1.Publisher;
+import com.google.protobuf.ByteString;
+import com.google.pubsub.v1.PubsubMessage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link PubSubSink}. Mocks {@link Publisher} so no real
+ * Pub/Sub credentials or network are required. Uses
+ * {@link ApiFutures#immediateFuture(Object)} / {@code immediateFailedFuture}
+ * to drive the future-resolution code path deterministically.
+ */
+@ExtendWith(MockitoExtension.class)
+class PubSubSinkTest {
+
+    @Mock
+    private Publisher publisher;
+
+    @Mock
+    private RuntimeContext context;
+
+    private static PubsubMessage msg(String body) {
+        return PubsubMessage.newBuilder()
+                .setData(ByteString.copyFromUtf8(body))
+                .build();
+    }
+
+    private static ApiFuture<String> ok(String messageId) {
+        return ApiFutures.immediateFuture(messageId);
+    }
+
+    private static ApiFuture<String> fail(Throwable cause) {
+        return ApiFutures.immediateFailedFuture(cause);
+    }
+
+    // --- happy paths -------------------------------------------------------
+
+    @Test
+    void publishSingleMessageResolvesAndReturns() {
+        when(publisher.publish(any(PubsubMessage.class))).thenReturn(ok("server-id-1"));
+
+        PubSubSink sink = new PubSubSink(publisher);
+        sink.write(List.of(msg("hello")).iterator(), context);
+
+        ArgumentCaptor<PubsubMessage> captor = ArgumentCaptor.forClass(PubsubMessage.class);
+        verify(publisher).publish(captor.capture());
+        assertThat(captor.getValue().getData().toStringUtf8()).isEqualTo("hello");
+    }
+
+    @Test
+    void publishMultipleMessagesIssuesOnePublishCallPerRecord() {
+        // Chain individual thenReturn calls instead of varargs to avoid the
+        // "unchecked generic array creation for varargs parameter" warning
+        // that -Werror promotes to an error in this codebase.
+        when(publisher.publish(any(PubsubMessage.class)))
+                .thenReturn(ok("id-1"))
+                .thenReturn(ok("id-2"))
+                .thenReturn(ok("id-3"));
+
+        PubSubSink sink = new PubSubSink(publisher);
+        Iterator<PubsubMessage> records = List.of(
+                msg("a"), msg("b"), msg("c")).iterator();
+        sink.write(records, context);
+
+        verify(publisher, times(3)).publish(any(PubsubMessage.class));
+    }
+
+    @Test
+    void emptyIteratorDoesNotInvokePublisher() {
+        PubSubSink sink = new PubSubSink(publisher);
+        sink.write(Collections.emptyIterator(), context);
+
+        verify(publisher, never()).publish(any(PubsubMessage.class));
+    }
+
+    @Test
+    void topicNameDelegatesToPublisher() {
+        when(publisher.getTopicNameString()).thenReturn("projects/p/topics/t");
+        PubSubSink sink = new PubSubSink(publisher);
+        assertThat(sink.topicName()).isEqualTo("projects/p/topics/t");
+    }
+
+    // --- error paths -------------------------------------------------------
+
+    @Test
+    void publishFailureSurfacesAsPubSubPublishException() {
+        when(publisher.publish(any(PubsubMessage.class))).thenReturn(
+                fail(new IOException("topic not found")));
+
+        PubSubSink sink = new PubSubSink(publisher);
+        Iterator<PubsubMessage> records = List.of(msg("doomed")).iterator();
+
+        assertThatThrownBy(() -> sink.write(records, context))
+                .isInstanceOf(PubSubSink.PubSubPublishException.class)
+                .hasMessageContaining("topic not found")
+                .hasCauseInstanceOf(IOException.class);
+    }
+
+    @Test
+    void nullRecordsRejected() {
+        PubSubSink sink = new PubSubSink(publisher);
+        assertThatThrownBy(() -> sink.write(null, context))
+                .isInstanceOf(NullPointerException.class);
+        verify(publisher, never()).publish(any(PubsubMessage.class));
+    }
+
+    @Test
+    void constructorRejectsNullPublisher() {
+        assertThatThrownBy(() -> new PubSubSink(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    // --- lifecycle ---------------------------------------------------------
+
+    @Test
+    void shutdownDelegatesToPublisher() throws InterruptedException {
+        when(publisher.awaitTermination(5L, TimeUnit.SECONDS)).thenReturn(true);
+
+        PubSubSink sink = new PubSubSink(publisher);
+        boolean terminated = sink.shutdown(5L, TimeUnit.SECONDS);
+
+        assertThat(terminated).isTrue();
+        verify(publisher).shutdown();
+        verify(publisher).awaitTermination(5L, TimeUnit.SECONDS);
+    }
+}

--- a/data-pipeline-libraries-java/data-pipeline-gcp-pubsub-java/src/test/java/com/enrichmeai/culvert/gcp/pubsub/PubSubSourceTest.java
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-pubsub-java/src/test/java/com/enrichmeai/culvert/gcp/pubsub/PubSubSourceTest.java
@@ -1,0 +1,181 @@
+package com.enrichmeai.culvert.gcp.pubsub;
+
+import com.enrichmeai.culvert.contracts.RuntimeContext;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.cloud.pubsub.v1.stub.SubscriberStub;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Empty;
+import com.google.pubsub.v1.AcknowledgeRequest;
+import com.google.pubsub.v1.PubsubMessage;
+import com.google.pubsub.v1.PullRequest;
+import com.google.pubsub.v1.PullResponse;
+import com.google.pubsub.v1.ReceivedMessage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link PubSubSource}. Mocks {@link SubscriberStub} so no
+ * real Pub/Sub credentials or network are required.
+ */
+@ExtendWith(MockitoExtension.class)
+class PubSubSourceTest {
+
+    private static final String SUBSCRIPTION =
+            "projects/my-project/subscriptions/my-sub";
+
+    @Mock
+    private SubscriberStub stub;
+
+    @Mock
+    private UnaryCallable<PullRequest, PullResponse> pullCallable;
+
+    @Mock
+    private UnaryCallable<AcknowledgeRequest, Empty> ackCallable;
+
+    @Mock
+    private RuntimeContext context;
+
+    private static PubsubMessage msg(String body) {
+        return PubsubMessage.newBuilder()
+                .setData(ByteString.copyFromUtf8(body))
+                .build();
+    }
+
+    private static ReceivedMessage received(String ackId, String body) {
+        return ReceivedMessage.newBuilder()
+                .setAckId(ackId)
+                .setMessage(msg(body))
+                .build();
+    }
+
+    private static PullResponse pullResponseWith(ReceivedMessage... msgs) {
+        return PullResponse.newBuilder()
+                .addAllReceivedMessages(List.of(msgs))
+                .build();
+    }
+
+    // --- happy paths -------------------------------------------------------
+
+    @Test
+    void readReturnsPulledMessagesAndAcksThem() {
+        when(stub.pullCallable()).thenReturn(pullCallable);
+        when(stub.acknowledgeCallable()).thenReturn(ackCallable);
+        when(pullCallable.call(any(PullRequest.class))).thenReturn(
+                pullResponseWith(received("ack-1", "hello"), received("ack-2", "world")));
+
+        PubSubSource source = new PubSubSource(stub, SUBSCRIPTION);
+        Iterator<PubsubMessage> it = source.read(context);
+
+        List<PubsubMessage> drained = new ArrayList<>();
+        it.forEachRemaining(drained::add);
+
+        assertThat(drained).hasSize(2);
+        assertThat(drained.get(0).getData().toStringUtf8()).isEqualTo("hello");
+        assertThat(drained.get(1).getData().toStringUtf8()).isEqualTo("world");
+
+        // Both ackIds carried on a single acknowledge call.
+        ArgumentCaptor<AcknowledgeRequest> ackCaptor =
+                ArgumentCaptor.forClass(AcknowledgeRequest.class);
+        verify(ackCallable).call(ackCaptor.capture());
+        assertThat(ackCaptor.getValue().getAckIdsList())
+                .containsExactly("ack-1", "ack-2");
+        assertThat(ackCaptor.getValue().getSubscription()).isEqualTo(SUBSCRIPTION);
+    }
+
+    @Test
+    void emptyPullYieldsEmptyIteratorAndNoAck() {
+        when(stub.pullCallable()).thenReturn(pullCallable);
+        when(pullCallable.call(any(PullRequest.class))).thenReturn(
+                PullResponse.getDefaultInstance());
+
+        PubSubSource source = new PubSubSource(stub, SUBSCRIPTION);
+        Iterator<PubsubMessage> it = source.read(context);
+
+        assertThat(it.hasNext()).isFalse();
+        // Empty pull must NOT issue an acknowledge call (no ackIds to send).
+        verify(stub, never()).acknowledgeCallable();
+    }
+
+    @Test
+    void pullRequestCarriesSubscriptionAndMaxMessages() {
+        when(stub.pullCallable()).thenReturn(pullCallable);
+        when(stub.acknowledgeCallable()).thenReturn(ackCallable);
+        when(pullCallable.call(any(PullRequest.class))).thenReturn(
+                pullResponseWith(received("a", "x")));
+
+        PubSubSource source = new PubSubSource(stub, SUBSCRIPTION, 25);
+        source.read(context);
+
+        ArgumentCaptor<PullRequest> pullCaptor =
+                ArgumentCaptor.forClass(PullRequest.class);
+        verify(pullCallable).call(pullCaptor.capture());
+        assertThat(pullCaptor.getValue().getSubscription()).isEqualTo(SUBSCRIPTION);
+        assertThat(pullCaptor.getValue().getMaxMessages()).isEqualTo(25);
+    }
+
+    @Test
+    void defaultMaxMessagesIsUsedWhenNotSpecified() {
+        PubSubSource source = new PubSubSource(stub, SUBSCRIPTION);
+        assertThat(source.maxMessages()).isEqualTo(PubSubSource.DEFAULT_MAX_MESSAGES);
+        assertThat(source.subscriptionName()).isEqualTo(SUBSCRIPTION);
+    }
+
+    // --- error paths -------------------------------------------------------
+
+    @Test
+    void pullExceptionPropagatesToCaller() {
+        when(stub.pullCallable()).thenReturn(pullCallable);
+        when(pullCallable.call(any(PullRequest.class)))
+                .thenThrow(new RuntimeException("pubsub unavailable"));
+
+        PubSubSource source = new PubSubSource(stub, SUBSCRIPTION);
+
+        assertThatThrownBy(() -> source.read(context))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("pubsub unavailable");
+
+        // No acknowledge attempted when the pull itself failed.
+        verify(stub, never()).acknowledgeCallable();
+    }
+
+    @Test
+    void constructorRejectsNullStub() {
+        assertThatThrownBy(() -> new PubSubSource(null, SUBSCRIPTION))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void constructorRejectsNullSubscription() {
+        assertThatThrownBy(() -> new PubSubSource(stub, null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void constructorRejectsNonPositiveMaxMessages() {
+        assertThatThrownBy(() -> new PubSubSource(stub, SUBSCRIPTION, 0))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new PubSubSource(stub, SUBSCRIPTION, -1))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void closeDelegatesToStub() {
+        PubSubSource source = new PubSubSource(stub, SUBSCRIPTION);
+        source.close();
+        verify(stub).close();
+    }
+}


### PR DESCRIPTION
Closes #23.

## Summary
- New `data-pipeline-gcp-pubsub-java` module: `PubSubSource` (Source<PubsubMessage>, AutoCloseable, wraps SubscriberStub with synchronous pull + eager ack) and `PubSubSink` (Sink<PubsubMessage>, wraps Publisher with ApiFuture collection + await).
- pom.xml now matches the bigquery-java pilot (BOM 26.39.0 in-module, `<proc>none</proc>`, full test-scope deps).
- META-INF/services files for both contracts; README documenting contracts, constructors, env vars, errors, and lifecycle.
- AutoCloseable applied only where the wrapped client supports it: SubscriberStub via BackgroundResource → yes on Source; Publisher has shutdown()/awaitTermination() only → no on Sink (passthrough `shutdown(timeout, unit)` instead).

## Test plan
- [x] `mvn -pl data-pipeline-gcp-pubsub-java -am clean test` → BUILD SUCCESS, 17/17 tests (9 source + 8 sink)
- [x] PubSubSourceTest: happy-path pull+ack, empty pull (no ack issued), pull-exception propagation, default and explicit maxMessages, null/non-positive constructor validation, close delegates to stub
- [x] PubSubSinkTest: publish single/multi/empty iterator, ApiFuture failure → PubSubPublishException with cause, null constructor + null records rejected, shutdown delegates to publisher
- [ ] Live-cloud integration deferred to sprint-3+

🤖 Generated with [Claude Code](https://claude.com/claude-code)