### PR TITLE
feat(tester-java): Mockito fixture builders for 5 protocols (closes #26)

### DIFF
--- a/data-pipeline-libraries-java/data-pipeline-tester-java/README.md
+++ b/data-pipeline-libraries-java/data-pipeline-tester-java/README.md
@@ -1,0 +1,140 @@
+# data-pipeline-tester (Java)
+
+Mockito-helper fixture builders for the Culvert framework's contract
+Protocols. Consumers of `data-pipeline-core` use these helpers to mock
+`SecretProvider`, `Warehouse`, `BlobStore`, `JobControlRepository`, and
+`FinOpsSink` in their own unit tests without repeating the
+`Mockito.mock(...)` + `when(...).thenReturn(...)` boilerplate.
+
+Sprint-2 deliverable (issue #26). Sprint-5 will add a full contract test
+harness on top of these fixtures.
+
+## Add to your tests
+
+```xml
+<dependency>
+    <groupId>com.enrichmeai.culvert</groupId>
+    <artifactId>data-pipeline-tester</artifactId>
+    <version>0.1.0</version>
+    <scope>test</scope>
+</dependency>
+```
+
+Mockito and AssertJ come transitively (the tester library uses them at
+compile scope, so consumers don't need to add them separately).
+
+## SecretProviderFixtures
+
+Build a `SecretProvider` mock backed by a static map, or one that fails
+on every call. Use this when your unit under test reads secrets via a
+`SecretProvider` and you don't want to touch real Secret Manager.
+
+```java
+import static com.enrichmeai.culvert.tester.SecretProviderFixtures.*;
+
+SecretProvider sp = staticSecretProvider(Map.of(
+    "db.password", "hunter2",
+    "api.key", "abc"));
+String pwd = sp.get("db.password");           // "hunter2"
+sp.get("missing");                             // throws NoSuchElementException
+
+SecretProvider broken = failingSecretProvider(
+    new RuntimeException("IAM denied"));
+broken.get("anything");                        // throws
+
+SecretProvider partial = notFoundFor("missing.one");
+partial.get("present");                        // "fixture-value-for-present"
+partial.get("missing.one");                    // throws NoSuchElementException
+```
+
+## WarehouseFixtures
+
+Build a `Warehouse` mock with empty defaults (queries empty, tableExists
+false) and add specific stubbing on top. The `rows(...)` helper builds a
+lazy iterator over row maps for stubbing `query` results.
+
+```java
+import static com.enrichmeai.culvert.tester.WarehouseFixtures.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+Warehouse w = warehouseWithTables("proj.ds.users", "proj.ds.orders");
+w.tableExists("proj.ds.users");                // true
+w.tableExists("proj.ds.missing");              // false
+
+when(w.query(anyString(), anyMap()))
+    .thenReturn(rows(Map.of("id", 1), Map.of("id", 2)));
+
+Warehouse broken = failingWarehouse(new RuntimeException("outage"));
+broken.query("SELECT 1", Map.of());            // throws
+```
+
+## BlobStoreFixtures
+
+Build a `BlobStore` mock backed by an in-memory URI -> bytes map.
+`get`, `openInput`, and `exists` reflect the map; missing URIs raise
+`UncheckedIOException(FileNotFoundException)` matching the contract.
+`put`/`openOutput`/`delete`/`copy` default to Mockito no-ops; stub on
+top with `doAnswer`/`verify` when you need to assert against writes.
+
+```java
+import static com.enrichmeai.culvert.tester.BlobStoreFixtures.*;
+
+BlobStore bs = blobStoreWith(Map.of(
+    "gs://b/users.csv",  "id,name\n1,Alice\n".getBytes(),
+    "gs://b/orders.csv", "id,total\n1,100\n".getBytes()));
+
+bs.exists("gs://b/users.csv");                 // true
+byte[] bytes = bs.get("gs://b/users.csv");
+bs.list("gs://b/");                            // iterates both URIs (sorted)
+bs.get("gs://b/missing");                      // throws UncheckedIOException
+```
+
+## JobControlRepositoryFixtures
+
+Build a `JobControlRepository` mock pre-populated with `PipelineJob`
+records. `getJob(runId)` resolves the matching job; `getPendingJobs`
+returns the seed list. Mutating methods (`createJob`, `updateStatus`,
+`markFailed`, etc.) are Mockito no-ops — use `verify(repo).createJob(...)`
+to assert your unit under test wrote what it should.
+
+```java
+import static com.enrichmeai.culvert.tester.JobControlRepositoryFixtures.*;
+
+PipelineJob job = PipelineJob.builder(
+        "run-1", "retail", "ingest", LocalDate.of(2026, 1, 1),
+        JobStatus.RUNNING)
+    .build();
+
+JobControlRepository repo = repoWith(job);
+repo.getJob("run-1");                          // Optional.of(job)
+repo.getJob("missing");                        // Optional.empty()
+
+// Mockito verify-style assertions still work:
+// verify(repo).updateStatus("run-1", JobStatus.SUCCEEDED, Optional.of(100L));
+```
+
+## FinOpsSinkFixtures
+
+Build a `CaptureSink` — a real `FinOpsSink` (not a mock) that records
+every `record(...)` invocation to a thread-safe list for later
+assertion. Simpler than wrestling Mockito `ArgumentCaptor` for a record
+of two non-null arguments.
+
+```java
+import static com.enrichmeai.culvert.tester.FinOpsSinkFixtures.*;
+
+CaptureSink sink = captureSink();
+pipeline.run(sink);
+
+assertThat(sink.records()).hasSize(3);
+assertThat(sink.records().get(0).metrics().runId()).isEqualTo("run-1");
+assertThat(sink.records().get(0).tags().environment()).isEqualTo("dev");
+```
+
+## Build and test
+
+```sh
+cd data-pipeline-libraries-java
+mvn -pl data-pipeline-tester-java -am clean test
+```

--- a/data-pipeline-libraries-java/data-pipeline-tester-java/pom.xml
+++ b/data-pipeline-libraries-java/data-pipeline-tester-java/pom.xml
@@ -3,15 +3,108 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>com.enrichmeai.culvert</groupId>
         <artifactId>data-pipeline-libraries-parent</artifactId>
         <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
+
     <artifactId>data-pipeline-tester</artifactId>
     <packaging>jar</packaging>
-    <name>Culvert :: data-pipeline-tester (Java) — placeholder</name>
-    <description>Placeholder for the sprint-2 Mockito-helper test fixtures library for the 11 protocols. REPLACE THIS ENTIRE FILE when implementing.</description>
-    <!-- REPLACE THIS ENTIRE FILE when implementing the sprint-2 tester ticket. -->
+
+    <name>Culvert :: data-pipeline-tester (Java)</name>
+    <description>
+        Mockito-helper fixture builders for the Culvert framework contracts.
+        Consumers use these helpers to mock SecretProvider, Warehouse,
+        BlobStore, JobControlRepository, and FinOpsSink in their own unit
+        tests without repeating the Mockito + when(...).thenReturn(...)
+        boilerplate. Sprint-2 deliverable (issue #26).
+
+        Note: Mockito and AssertJ are COMPILE-scope deps here (overriding the
+        parent's test scope). This module IS a test-helper library — its
+        production code uses Mockito. NOT a libraries-bom user (no GCP deps).
+    </description>
+
+    <dependencies>
+        <!-- Culvert contracts -->
+        <dependency>
+            <groupId>com.enrichmeai.culvert</groupId>
+            <artifactId>data-pipeline-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!--
+            Mockito at compile scope — this module's production code uses
+            Mockito.mock(...) inside fixture builders. The parent
+            dependencyManagement declares Mockito as test scope; we override
+            explicitly here.
+        -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <!--
+            AssertJ at compile scope — fixture builders expose typed assertion
+            handles (e.g. capture-sink lookups) that callers can chain with
+            AssertJ. Same scope override as Mockito.
+        -->
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <!-- SLF4J API only — consumers bring their own binding -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <!-- Test scope: JUnit for self-testing the helpers. -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <!--
+                        Mockito's byte-buddy / inline-mock-maker pulls in
+                        annotation processors that don't claim our JUnit /
+                        Mockito annotations. Under the parent's -Xlint:all +
+                        -Werror this triggers a "No processor claimed any of
+                        these annotations" warning that fails the build. We
+                        don't use annotation processors here, so disable
+                        processing explicitly. Same pattern as the GCP
+                        adapter modules.
+                    -->
+                    <proc>none</proc>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/data-pipeline-libraries-java/data-pipeline-tester-java/src/main/java/com/enrichmeai/culvert/tester/BlobStoreFixtures.java
+++ b/data-pipeline-libraries-java/data-pipeline-tester-java/src/main/java/com/enrichmeai/culvert/tester/BlobStoreFixtures.java
@@ -1,0 +1,109 @@
+package com.enrichmeai.culvert.tester;
+
+import com.enrichmeai.culvert.contracts.BlobStore;
+import org.mockito.Mockito;
+
+import java.io.ByteArrayInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+
+/**
+ * Mockito-mock fixture builders for {@link BlobStore}.
+ *
+ * <p>Returned mocks expose a read-only in-memory blob store backed by the
+ * supplied map. {@link BlobStore#get(String)} and
+ * {@link BlobStore#openInput(String)} surface bytes for known URIs and
+ * raise an {@link UncheckedIOException} wrapping {@link FileNotFoundException}
+ * for unknown URIs (matching the documented contract). Write operations
+ * ({@code put}, {@code openOutput}, {@code delete}, {@code copy}) are
+ * no-ops on the returned mock — consumers add further stubbing when they
+ * need to assert against writes.
+ *
+ * <p>This class is non-instantiable.
+ */
+public final class BlobStoreFixtures {
+
+    private BlobStoreFixtures() {
+        throw new AssertionError("no instances");
+    }
+
+    /**
+     * Mock {@link BlobStore} where no objects exist.
+     * {@code exists} returns false; {@code get} / {@code openInput} raise
+     * the wrapped {@link FileNotFoundException}; {@code list} returns an
+     * empty iterator.
+     */
+    public static BlobStore emptyBlobStore() {
+        return blobStoreWith(Collections.emptyMap());
+    }
+
+    /**
+     * Mock {@link BlobStore} backed by an in-memory URI -> bytes map.
+     *
+     * <p>For each URI in {@code contents}:
+     * <ul>
+     *     <li>{@code get(uri)} returns the matching byte array.</li>
+     *     <li>{@code openInput(uri)} returns a {@link ByteArrayInputStream}
+     *         over those bytes.</li>
+     *     <li>{@code exists(uri)} returns true.</li>
+     * </ul>
+     * For any URI not in {@code contents}:
+     * <ul>
+     *     <li>{@code get / openInput} raise
+     *         {@code UncheckedIOException(FileNotFoundException)}.</li>
+     *     <li>{@code exists} returns false.</li>
+     * </ul>
+     * {@code list(prefix)} returns the URIs in {@code contents} that start
+     * with {@code prefix}, in lexicographic order.
+     *
+     * @param contents URI -> bytes map. Must not be null.
+     */
+    public static BlobStore blobStoreWith(Map<String, byte[]> contents) {
+        Objects.requireNonNull(contents, "contents must not be null");
+        // Sort by URI for the lexicographic-order list() guarantee.
+        TreeMap<String, byte[]> sorted = new TreeMap<>(contents);
+
+        BlobStore mock = Mockito.mock(BlobStore.class);
+
+        Mockito.when(mock.get(Mockito.anyString())).thenAnswer(invocation -> {
+            String uri = invocation.getArgument(0);
+            byte[] bytes = sorted.get(uri);
+            if (bytes == null) {
+                throw new UncheckedIOException(
+                        new FileNotFoundException("No object at " + uri));
+            }
+            return bytes.clone();
+        });
+
+        Mockito.when(mock.openInput(Mockito.anyString())).thenAnswer(invocation -> {
+            String uri = invocation.getArgument(0);
+            byte[] bytes = sorted.get(uri);
+            if (bytes == null) {
+                throw new UncheckedIOException(
+                        new FileNotFoundException("No object at " + uri));
+            }
+            return (InputStream) new ByteArrayInputStream(bytes);
+        });
+
+        Mockito.when(mock.exists(Mockito.anyString())).thenAnswer(invocation -> {
+            String uri = invocation.getArgument(0);
+            return sorted.containsKey(uri);
+        });
+
+        Mockito.when(mock.list(Mockito.anyString())).thenAnswer(invocation -> {
+            String prefix = invocation.getArgument(0);
+            return sorted.keySet().stream()
+                    .filter(uri -> uri.startsWith(prefix))
+                    .iterator();
+        });
+
+        // put / openOutput / delete / copy default to Mockito no-op /
+        // null returns. Consumers stub these on top when needed.
+        return mock;
+    }
+}

--- a/data-pipeline-libraries-java/data-pipeline-tester-java/src/main/java/com/enrichmeai/culvert/tester/FinOpsSinkFixtures.java
+++ b/data-pipeline-libraries-java/data-pipeline-tester-java/src/main/java/com/enrichmeai/culvert/tester/FinOpsSinkFixtures.java
@@ -1,0 +1,97 @@
+package com.enrichmeai.culvert.tester;
+
+import com.enrichmeai.culvert.contracts.FinOpsSink;
+import com.enrichmeai.culvert.finops.CostMetrics;
+import com.enrichmeai.culvert.finops.FinOpsTag;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Fixture builders for {@link FinOpsSink}.
+ *
+ * <p>Unlike the other fixture builders in this module, the capture-sink
+ * here is implemented as a real {@link FinOpsSink} (not a Mockito mock) —
+ * a tiny direct implementation that appends every {@code record} call to
+ * a thread-safe list is simpler and clearer than the Mockito
+ * {@code ArgumentCaptor} equivalent.
+ *
+ * <p>This class is non-instantiable.
+ */
+public final class FinOpsSinkFixtures {
+
+    private FinOpsSinkFixtures() {
+        throw new AssertionError("no instances");
+    }
+
+    /**
+     * A {@link FinOpsSink} that captures every {@link FinOpsSink#record}
+     * call to an in-memory list. Use {@link #records()} to retrieve the
+     * captured invocations for assertion.
+     *
+     * <p>Thread-safe — backed by a {@link CopyOnWriteArrayList} so tests
+     * that exercise concurrent record paths don't trip on
+     * {@code ConcurrentModificationException}.
+     */
+    public static final class CaptureSink implements FinOpsSink {
+
+        private final List<Recorded> records = new CopyOnWriteArrayList<>();
+
+        @Override
+        public void record(CostMetrics metrics, FinOpsTag tags) {
+            Objects.requireNonNull(metrics, "metrics");
+            Objects.requireNonNull(tags, "tags");
+            records.add(new Recorded(metrics, tags));
+        }
+
+        /** Unmodifiable snapshot of every {@code record} call so far. */
+        public List<Recorded> records() {
+            return Collections.unmodifiableList(records);
+        }
+
+        /** Number of {@code record} calls so far. */
+        public int recordCount() {
+            return records.size();
+        }
+
+        /** Clear all captured records. Useful between phases of a long test. */
+        public void clear() {
+            records.clear();
+        }
+    }
+
+    /** A single captured {@link FinOpsSink#record} invocation. */
+    public record Recorded(CostMetrics metrics, FinOpsTag tags) {
+        public Recorded {
+            Objects.requireNonNull(metrics, "metrics");
+            Objects.requireNonNull(tags, "tags");
+        }
+    }
+
+    /**
+     * Build a {@link CaptureSink} — a real {@link FinOpsSink} that captures
+     * each {@code record} call to an in-memory list for later assertion.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * CaptureSink sink = FinOpsSinkFixtures.captureSink();
+     * pipeline.run(sink);
+     * assertThat(sink.records()).hasSize(3);
+     * assertThat(sink.records().get(0).metrics().runId()).isEqualTo("run-1");
+     * }</pre>
+     */
+    public static CaptureSink captureSink() {
+        return new CaptureSink();
+    }
+
+    /**
+     * Alias for {@link #captureSink()} — matches the wording in the
+     * issue's DoD checklist ("inMemorySink returning a sink that captures
+     * records to a List for assertions").
+     */
+    public static CaptureSink inMemorySink() {
+        return captureSink();
+    }
+}

--- a/data-pipeline-libraries-java/data-pipeline-tester-java/src/main/java/com/enrichmeai/culvert/tester/JobControlRepositoryFixtures.java
+++ b/data-pipeline-libraries-java/data-pipeline-tester-java/src/main/java/com/enrichmeai/culvert/tester/JobControlRepositoryFixtures.java
@@ -1,0 +1,80 @@
+package com.enrichmeai.culvert.tester;
+
+import com.enrichmeai.culvert.contracts.JobControlRepository;
+import com.enrichmeai.culvert.jobcontrol.PipelineJob;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Mockito-mock fixture builders for {@link JobControlRepository}.
+ *
+ * <p>Returned mocks expose a read-mostly view of the supplied jobs:
+ * {@link JobControlRepository#getJob(String)} returns the matching
+ * {@link PipelineJob}; list-style methods return empty lists; write-style
+ * methods ({@code createJob}, {@code updateStatus}, {@code markFailed},
+ * etc.) are no-ops. Consumers add further stubbing on top when they need
+ * to assert against writes or surface specific failed-job lists.
+ *
+ * <p>This class is non-instantiable.
+ */
+public final class JobControlRepositoryFixtures {
+
+    private JobControlRepositoryFixtures() {
+        throw new AssertionError("no instances");
+    }
+
+    /**
+     * Mock {@link JobControlRepository} with no jobs. Every lookup returns
+     * empty / empty list. Mutating methods are no-ops.
+     */
+    public static JobControlRepository emptyRepo() {
+        return repoWith();
+    }
+
+    /**
+     * Mock {@link JobControlRepository} pre-populated with {@code jobs}.
+     *
+     * <p>{@code getJob(runId)} returns the matching {@link PipelineJob} (or
+     * empty if no match). {@code getPendingJobs} returns the input list as
+     * a snapshot, regardless of the system filter — consumers stub
+     * specifically when they care about filter semantics. Other list-style
+     * methods return empty lists.
+     *
+     * @param jobs Jobs to seed. Must not be null.
+     */
+    public static JobControlRepository repoWith(PipelineJob... jobs) {
+        Objects.requireNonNull(jobs, "jobs must not be null");
+        Map<String, PipelineJob> byRunId = new HashMap<>();
+        for (PipelineJob job : jobs) {
+            byRunId.put(job.runId(), job);
+        }
+        List<PipelineJob> snapshot = List.of(jobs);
+
+        JobControlRepository mock = Mockito.mock(JobControlRepository.class);
+
+        Mockito.when(mock.getJob(Mockito.anyString())).thenAnswer(invocation -> {
+            String runId = invocation.getArgument(0);
+            return Optional.ofNullable(byRunId.get(runId));
+        });
+
+        Mockito.when(mock.getPendingJobs(Mockito.any())).thenReturn(snapshot);
+        Mockito.when(mock.getEntityStatus(Mockito.anyString(), Mockito.any()))
+                .thenReturn(Collections.emptyList());
+        Mockito.when(mock.getFailedJobs(Mockito.anyString(), Mockito.any()))
+                .thenReturn(Collections.emptyList());
+        Mockito.when(mock.getFdpJobStatus(Mockito.anyString(), Mockito.any(), Mockito.anyString()))
+                .thenReturn(Optional.empty());
+        Mockito.when(mock.cleanupPartialLoad(Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(0);
+
+        // createJob / updateStatus / markFailed / markRetrying /
+        // updateCostMetrics default to Mockito no-ops.
+        return mock;
+    }
+}

--- a/data-pipeline-libraries-java/data-pipeline-tester-java/src/main/java/com/enrichmeai/culvert/tester/SecretProviderFixtures.java
+++ b/data-pipeline-libraries-java/data-pipeline-tester-java/src/main/java/com/enrichmeai/culvert/tester/SecretProviderFixtures.java
@@ -1,0 +1,103 @@
+package com.enrichmeai.culvert.tester;
+
+import com.enrichmeai.culvert.contracts.SecretProvider;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Mockito-mock fixture builders for {@link SecretProvider}.
+ *
+ * <p>Each method returns a Mockito mock pre-wired with {@code when(...)}
+ * stubs that match the documented {@link SecretProvider} contract. Consumers
+ * use these to skip the {@code Mockito.mock(SecretProvider.class)} +
+ * {@code when(...).thenReturn(...)} boilerplate in their own tests.
+ *
+ * <p>This class is non-instantiable.
+ */
+public final class SecretProviderFixtures {
+
+    private SecretProviderFixtures() {
+        throw new AssertionError("no instances");
+    }
+
+    /**
+     * Mock {@link SecretProvider} backed by a static map.
+     *
+     * <p>{@code get(name, version)} and {@code get(name)} both look up
+     * {@code name} in {@code secrets} (version is ignored — fixtures don't
+     * model version history). Missing names raise
+     * {@link NoSuchElementException}, matching the contract.
+     *
+     * @param secrets Secret name -> value map. Must not be null.
+     * @return a Mockito mock of {@link SecretProvider}.
+     */
+    public static SecretProvider staticSecretProvider(Map<String, String> secrets) {
+        Objects.requireNonNull(secrets, "secrets must not be null");
+        SecretProvider mock = Mockito.mock(SecretProvider.class);
+        // Two-arg get(name, version): look up name, ignore version.
+        Mockito.when(mock.get(Mockito.anyString(), Mockito.anyString()))
+                .thenAnswer(invocation -> {
+                    String name = invocation.getArgument(0);
+                    String value = secrets.get(name);
+                    if (value == null) {
+                        throw new NoSuchElementException("Secret not found: " + name);
+                    }
+                    return value;
+                });
+        // Single-arg get(name): delegate to the two-arg form via the real
+        // default method. Mockito mocks default methods to return null
+        // unless we tell it to call the real method.
+        Mockito.when(mock.get(Mockito.anyString())).thenCallRealMethod();
+        return mock;
+    }
+
+    /**
+     * Mock {@link SecretProvider} that throws {@code error} on every
+     * {@code get} call. Use to simulate a misconfigured Secret Manager or
+     * an IAM-denied lookup.
+     *
+     * @param error The exception to throw. Must not be null.
+     * @return a Mockito mock of {@link SecretProvider}.
+     */
+    public static SecretProvider failingSecretProvider(RuntimeException error) {
+        Objects.requireNonNull(error, "error must not be null");
+        SecretProvider mock = Mockito.mock(SecretProvider.class);
+        Mockito.when(mock.get(Mockito.anyString(), Mockito.anyString())).thenThrow(error);
+        Mockito.when(mock.get(Mockito.anyString())).thenThrow(error);
+        return mock;
+    }
+
+    /**
+     * Mock {@link SecretProvider} that returns successfully for every secret
+     * EXCEPT the names in {@code notFound} — those raise
+     * {@link NoSuchElementException}, matching the contract for missing
+     * secrets.
+     *
+     * <p>Use to test "what happens if exactly secret X is missing" without
+     * having to populate a full secret map.
+     *
+     * @param names Secret names that should raise {@link NoSuchElementException}.
+     * @return a Mockito mock of {@link SecretProvider}.
+     */
+    public static SecretProvider notFoundFor(String... names) {
+        Objects.requireNonNull(names, "names must not be null");
+        Set<String> missing = new HashSet<>(Arrays.asList(names));
+        SecretProvider mock = Mockito.mock(SecretProvider.class);
+        Mockito.when(mock.get(Mockito.anyString(), Mockito.anyString()))
+                .thenAnswer(invocation -> {
+                    String name = invocation.getArgument(0);
+                    if (missing.contains(name)) {
+                        throw new NoSuchElementException("Secret not found: " + name);
+                    }
+                    return "fixture-value-for-" + name;
+                });
+        Mockito.when(mock.get(Mockito.anyString())).thenCallRealMethod();
+        return mock;
+    }
+}

--- a/data-pipeline-libraries-java/data-pipeline-tester-java/src/main/java/com/enrichmeai/culvert/tester/WarehouseFixtures.java
+++ b/data-pipeline-libraries-java/data-pipeline-tester-java/src/main/java/com/enrichmeai/culvert/tester/WarehouseFixtures.java
@@ -1,0 +1,112 @@
+package com.enrichmeai.culvert.tester;
+
+import com.enrichmeai.culvert.contracts.Warehouse;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Mockito-mock fixture builders for {@link Warehouse}.
+ *
+ * <p>Returned mocks satisfy the documented {@link Warehouse} contract for
+ * the configured state — empty result sets for queries, false for
+ * {@code tableExists} on unlisted tables, etc. {@code execute},
+ * {@code loadFromUri}, {@code merge}, {@code copy} default to no-op
+ * returns (zero rows) unless the consumer adds further stubbing on top.
+ *
+ * <p>This class is non-instantiable.
+ */
+public final class WarehouseFixtures {
+
+    private WarehouseFixtures() {
+        throw new AssertionError("no instances");
+    }
+
+    /**
+     * Mock {@link Warehouse} where everything is empty:
+     * <ul>
+     *     <li>{@code query(...)} returns an empty iterator.</li>
+     *     <li>{@code tableExists(...)} returns false for every FQTN.</li>
+     *     <li>{@code execute(...)} is a no-op.</li>
+     *     <li>{@code loadFromUri / merge / copy} all return 0.</li>
+     * </ul>
+     */
+    @SuppressWarnings("unchecked")
+    public static Warehouse emptyWarehouse() {
+        Warehouse mock = Mockito.mock(Warehouse.class);
+        Mockito.when(mock.query(Mockito.anyString(), Mockito.anyMap()))
+                .thenAnswer(invocation -> Collections.emptyIterator());
+        Mockito.when(mock.tableExists(Mockito.anyString())).thenReturn(false);
+        Mockito.when(mock.loadFromUri(Mockito.anyString(), Mockito.anyString(), Mockito.any()))
+                .thenReturn(0L);
+        Mockito.when(mock.merge(Mockito.anyString(), Mockito.anyString(), Mockito.anyList()))
+                .thenReturn(0L);
+        Mockito.when(mock.copy(Mockito.anyString(), Mockito.anyString())).thenReturn(0L);
+        return mock;
+    }
+
+    /**
+     * Mock {@link Warehouse} where the named fully-qualified tables exist
+     * ({@code tableExists} returns true) and every other table is missing.
+     * Queries still return empty iterators — for stubbing query results,
+     * the consumer adds {@code when(mock.query(...)).thenReturn(...)} on
+     * top of the returned mock.
+     *
+     * @param fqtns Fully-qualified table names that {@code tableExists}
+     *              should return true for.
+     */
+    public static Warehouse warehouseWithTables(String... fqtns) {
+        Objects.requireNonNull(fqtns, "fqtns must not be null");
+        Set<String> known = new HashSet<>(Arrays.asList(fqtns));
+        Warehouse mock = emptyWarehouse();
+        // Re-stub tableExists with a name-aware answer.
+        Mockito.when(mock.tableExists(Mockito.anyString())).thenAnswer(invocation -> {
+            String fqtn = invocation.getArgument(0);
+            return known.contains(fqtn);
+        });
+        return mock;
+    }
+
+    /**
+     * Mock {@link Warehouse} whose every method throws {@code error}.
+     * Use to simulate a warehouse outage or auth failure.
+     *
+     * @param error The exception to throw. Must not be null.
+     */
+    @SuppressWarnings("unchecked")
+    public static Warehouse failingWarehouse(RuntimeException error) {
+        Objects.requireNonNull(error, "error must not be null");
+        Warehouse mock = Mockito.mock(Warehouse.class);
+        Mockito.when(mock.query(Mockito.anyString(), Mockito.anyMap())).thenThrow(error);
+        Mockito.doThrow(error).when(mock).execute(Mockito.anyString(), Mockito.anyMap());
+        Mockito.when(mock.loadFromUri(Mockito.anyString(), Mockito.anyString(), Mockito.any()))
+                .thenThrow(error);
+        Mockito.when(mock.merge(Mockito.anyString(), Mockito.anyString(), Mockito.anyList()))
+                .thenThrow(error);
+        Mockito.when(mock.copy(Mockito.anyString(), Mockito.anyString())).thenThrow(error);
+        Mockito.when(mock.tableExists(Mockito.anyString())).thenThrow(error);
+        return mock;
+    }
+
+    /**
+     * Helper: build an iterator over a list of row maps. Convenience for
+     * consumers who want to stub {@code query} with concrete results:
+     *
+     * <pre>{@code
+     * Warehouse w = WarehouseFixtures.emptyWarehouse();
+     * when(w.query(anyString(), anyMap()))
+     *     .thenReturn(WarehouseFixtures.rows(Map.of("id", 1), Map.of("id", 2)));
+     * }</pre>
+     */
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    public static Iterator<Map<String, Object>> rows(Map<String, Object>... rows) {
+        return Arrays.asList(rows).iterator();
+    }
+}

--- a/data-pipeline-libraries-java/data-pipeline-tester-java/src/main/java/com/enrichmeai/culvert/tester/package-info.java
+++ b/data-pipeline-libraries-java/data-pipeline-tester-java/src/main/java/com/enrichmeai/culvert/tester/package-info.java
@@ -1,0 +1,16 @@
+/**
+ * Mockito-helper fixture builders for the Culvert framework's contract
+ * Protocols.
+ *
+ * <p>Each public class in this package targets one contract from
+ * {@code com.enrichmeai.culvert.contracts} and exposes static factory
+ * methods that return a pre-configured Mockito mock (or, in the case of
+ * {@link com.enrichmeai.culvert.tester.FinOpsSinkFixtures}, a tiny
+ * real implementation). Consumers add further stubbing on top with
+ * standard Mockito calls when their tests need behaviour beyond the
+ * fixture defaults.
+ *
+ * <p>Sprint-2 deliverable (issue #26). Sprint-5 will add a full contract
+ * test harness on top of these fixtures.
+ */
+package com.enrichmeai.culvert.tester;

--- a/data-pipeline-libraries-java/data-pipeline-tester-java/src/test/java/com/enrichmeai/culvert/tester/BlobStoreFixturesTest.java
+++ b/data-pipeline-libraries-java/data-pipeline-tester-java/src/test/java/com/enrichmeai/culvert/tester/BlobStoreFixturesTest.java
@@ -1,0 +1,60 @@
+package com.enrichmeai.culvert.tester;
+
+import com.enrichmeai.culvert.contracts.BlobStore;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class BlobStoreFixturesTest {
+
+    @Test
+    void emptyBlobStoreHasNoObjects() {
+        BlobStore bs = BlobStoreFixtures.emptyBlobStore();
+
+        assertThat(bs.exists("gs://b/o")).isFalse();
+        assertThat(bs.list("gs://b/")).isExhausted();
+        assertThatThrownBy(() -> bs.get("gs://b/o"))
+                .isInstanceOf(UncheckedIOException.class);
+    }
+
+    @Test
+    void blobStoreWithReturnsBytesAndStreamsForKnownUris() throws IOException {
+        byte[] hello = "hello".getBytes();
+        byte[] world = "world".getBytes();
+        BlobStore bs = BlobStoreFixtures.blobStoreWith(Map.of(
+                "gs://b/a.txt", hello,
+                "gs://b/b.txt", world));
+
+        assertThat(bs.exists("gs://b/a.txt")).isTrue();
+        assertThat(bs.get("gs://b/a.txt")).isEqualTo(hello);
+
+        try (InputStream in = bs.openInput("gs://b/b.txt")) {
+            assertThat(in.readAllBytes()).isEqualTo(world);
+        }
+
+        assertThat(bs.exists("gs://b/missing")).isFalse();
+        assertThatThrownBy(() -> bs.openInput("gs://b/missing"))
+                .isInstanceOf(UncheckedIOException.class);
+    }
+
+    @Test
+    void listReturnsMatchingUrisInLexicographicOrder() {
+        BlobStore bs = BlobStoreFixtures.blobStoreWith(Map.of(
+                "gs://b/data/2.txt", new byte[0],
+                "gs://b/data/1.txt", new byte[0],
+                "gs://b/other/x.txt", new byte[0]));
+
+        Iterator<String> listed = bs.list("gs://b/data/");
+        List<String> all = new java.util.ArrayList<>();
+        listed.forEachRemaining(all::add);
+        assertThat(all).containsExactly("gs://b/data/1.txt", "gs://b/data/2.txt");
+    }
+}

--- a/data-pipeline-libraries-java/data-pipeline-tester-java/src/test/java/com/enrichmeai/culvert/tester/FinOpsSinkFixturesTest.java
+++ b/data-pipeline-libraries-java/data-pipeline-tester-java/src/test/java/com/enrichmeai/culvert/tester/FinOpsSinkFixturesTest.java
@@ -1,0 +1,53 @@
+package com.enrichmeai.culvert.tester;
+
+import com.enrichmeai.culvert.finops.CostMetrics;
+import com.enrichmeai.culvert.finops.FinOpsTag;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class FinOpsSinkFixturesTest {
+
+    @Test
+    void captureSinkRecordsEveryInvocation() {
+        FinOpsSinkFixtures.CaptureSink sink = FinOpsSinkFixtures.captureSink();
+        FinOpsTag tag = FinOpsTag.of("retail", "dev", "cc-100", "data-eng", "run-1");
+        CostMetrics m1 = new CostMetrics("run-1", 1.5, 10L, 20L, 0L, 0L, 0L, 0.0,
+                Map.of(), Instant.parse("2026-01-01T00:00:00Z"));
+        CostMetrics m2 = new CostMetrics("run-1", 0.5, 5L, 0L, 0L, 0L, 0L, 0.0,
+                Map.of(), Instant.parse("2026-01-01T00:01:00Z"));
+
+        sink.record(m1, tag);
+        sink.record(m2, tag);
+
+        assertThat(sink.recordCount()).isEqualTo(2);
+        assertThat(sink.records()).hasSize(2);
+        assertThat(sink.records().get(0).metrics()).isEqualTo(m1);
+        assertThat(sink.records().get(0).tags()).isEqualTo(tag);
+        assertThat(sink.records().get(1).metrics()).isEqualTo(m2);
+    }
+
+    @Test
+    void captureSinkClearResetsState() {
+        FinOpsSinkFixtures.CaptureSink sink = FinOpsSinkFixtures.captureSink();
+        sink.record(CostMetrics.zero("run-1"),
+                FinOpsTag.of("retail", "dev", "cc", "owner", "run-1"));
+        assertThat(sink.recordCount()).isEqualTo(1);
+        sink.clear();
+        assertThat(sink.recordCount()).isZero();
+    }
+
+    @Test
+    void captureSinkRejectsNullArgs() {
+        FinOpsSinkFixtures.CaptureSink sink = FinOpsSinkFixtures.captureSink();
+        assertThatThrownBy(() -> sink.record(null,
+                FinOpsTag.of("retail", "dev", "cc", "owner", "run-1")))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> sink.record(CostMetrics.zero("run-1"), null))
+                .isInstanceOf(NullPointerException.class);
+    }
+}

--- a/data-pipeline-libraries-java/data-pipeline-tester-java/src/test/java/com/enrichmeai/culvert/tester/JobControlRepositoryFixturesTest.java
+++ b/data-pipeline-libraries-java/data-pipeline-tester-java/src/test/java/com/enrichmeai/culvert/tester/JobControlRepositoryFixturesTest.java
@@ -1,0 +1,40 @@
+package com.enrichmeai.culvert.tester;
+
+import com.enrichmeai.culvert.contracts.JobControlRepository;
+import com.enrichmeai.culvert.jobcontrol.JobStatus;
+import com.enrichmeai.culvert.jobcontrol.PipelineJob;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JobControlRepositoryFixturesTest {
+
+    @Test
+    void emptyRepoReturnsEmptyForEveryLookup() {
+        JobControlRepository repo = JobControlRepositoryFixtures.emptyRepo();
+
+        assertThat(repo.getJob("any")).isEmpty();
+        assertThat(repo.getPendingJobs(Optional.empty())).isEmpty();
+        assertThat(repo.getEntityStatus("sys", LocalDate.of(2026, 1, 1))).isEmpty();
+        assertThat(repo.getFailedJobs("sys", LocalDate.of(2026, 1, 1))).isEmpty();
+        assertThat(repo.getFdpJobStatus("sys", LocalDate.of(2026, 1, 1), "model")).isEmpty();
+        assertThat(repo.cleanupPartialLoad("run-1", "tbl")).isZero();
+    }
+
+    @Test
+    void repoWithReturnsSeededJobByRunId() {
+        PipelineJob j1 = PipelineJob.builder("run-1", "sys", "pipe", LocalDate.of(2026, 1, 1),
+                JobStatus.CREATED).build();
+        PipelineJob j2 = PipelineJob.builder("run-2", "sys", "pipe", LocalDate.of(2026, 1, 1),
+                JobStatus.RUNNING).build();
+        JobControlRepository repo = JobControlRepositoryFixtures.repoWith(j1, j2);
+
+        assertThat(repo.getJob("run-1")).contains(j1);
+        assertThat(repo.getJob("run-2")).contains(j2);
+        assertThat(repo.getJob("missing")).isEmpty();
+        assertThat(repo.getPendingJobs(Optional.empty())).containsExactly(j1, j2);
+    }
+}

--- a/data-pipeline-libraries-java/data-pipeline-tester-java/src/test/java/com/enrichmeai/culvert/tester/SecretProviderFixturesTest.java
+++ b/data-pipeline-libraries-java/data-pipeline-tester-java/src/test/java/com/enrichmeai/culvert/tester/SecretProviderFixturesTest.java
@@ -1,0 +1,45 @@
+package com.enrichmeai.culvert.tester;
+
+import com.enrichmeai.culvert.contracts.SecretProvider;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SecretProviderFixturesTest {
+
+    @Test
+    void staticSecretProviderReturnsValuesAndThrowsForMissingNames() {
+        SecretProvider sp = SecretProviderFixtures.staticSecretProvider(
+                Map.of("db.password", "hunter2", "api.key", "abc"));
+
+        assertThat(sp.get("db.password")).isEqualTo("hunter2");
+        assertThat(sp.get("api.key", "latest")).isEqualTo("abc");
+        assertThat(sp.get("api.key", "5")).isEqualTo("abc"); // version ignored
+
+        assertThatThrownBy(() -> sp.get("missing"))
+                .isInstanceOf(NoSuchElementException.class)
+                .hasMessageContaining("missing");
+    }
+
+    @Test
+    void failingSecretProviderThrowsForEveryLookup() {
+        RuntimeException boom = new RuntimeException("IAM denied");
+        SecretProvider sp = SecretProviderFixtures.failingSecretProvider(boom);
+
+        assertThatThrownBy(() -> sp.get("any.name")).isSameAs(boom);
+        assertThatThrownBy(() -> sp.get("any.name", "5")).isSameAs(boom);
+    }
+
+    @Test
+    void notFoundForRaisesOnlyForListedNames() {
+        SecretProvider sp = SecretProviderFixtures.notFoundFor("missing.one", "missing.two");
+
+        assertThat(sp.get("present")).isEqualTo("fixture-value-for-present");
+        assertThatThrownBy(() -> sp.get("missing.one")).isInstanceOf(NoSuchElementException.class);
+        assertThatThrownBy(() -> sp.get("missing.two")).isInstanceOf(NoSuchElementException.class);
+    }
+}

--- a/data-pipeline-libraries-java/data-pipeline-tester-java/src/test/java/com/enrichmeai/culvert/tester/WarehouseFixturesTest.java
+++ b/data-pipeline-libraries-java/data-pipeline-tester-java/src/test/java/com/enrichmeai/culvert/tester/WarehouseFixturesTest.java
@@ -1,0 +1,59 @@
+package com.enrichmeai.culvert.tester;
+
+import com.enrichmeai.culvert.contracts.Warehouse;
+import org.junit.jupiter.api.Test;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+class WarehouseFixturesTest {
+
+    @Test
+    void emptyWarehouseReturnsEmptyResultsAndFalseTableExists() {
+        Warehouse w = WarehouseFixtures.emptyWarehouse();
+
+        assertThat(w.query("SELECT 1", Map.of()).hasNext()).isFalse();
+        assertThat(w.tableExists("p.d.t")).isFalse();
+        assertThat(w.loadFromUri("gs://b/o", "p.d.t", null)).isZero();
+        assertThat(w.merge("src", "dst", List.of("id"))).isZero();
+        assertThat(w.copy("src", "dst")).isZero();
+    }
+
+    @Test
+    void warehouseWithTablesReturnsTrueOnlyForListedFqtns() {
+        Warehouse w = WarehouseFixtures.warehouseWithTables("proj.ds.users", "proj.ds.orders");
+
+        assertThat(w.tableExists("proj.ds.users")).isTrue();
+        assertThat(w.tableExists("proj.ds.orders")).isTrue();
+        assertThat(w.tableExists("proj.ds.missing")).isFalse();
+    }
+
+    @Test
+    void failingWarehouseThrowsFromEveryMethod() {
+        RuntimeException boom = new RuntimeException("outage");
+        Warehouse w = WarehouseFixtures.failingWarehouse(boom);
+
+        assertThatThrownBy(() -> w.query("SELECT 1", Map.of())).isSameAs(boom);
+        assertThatThrownBy(() -> w.execute("DROP TABLE t", Map.of())).isSameAs(boom);
+        assertThatThrownBy(() -> w.tableExists("p.d.t")).isSameAs(boom);
+    }
+
+    @Test
+    void rowsHelperWiresQueryResultsForConsumers() {
+        Warehouse w = WarehouseFixtures.emptyWarehouse();
+        when(w.query(anyString(), anyMap()))
+                .thenReturn(WarehouseFixtures.rows(Map.of("id", 1), Map.of("id", 2)));
+
+        Iterator<Map<String, Object>> it = w.query("SELECT id FROM t", Map.of());
+        assertThat(it.next()).containsEntry("id", 1);
+        assertThat(it.next()).containsEntry("id", 2);
+        assertThat(it.hasNext()).isFalse();
+    }
+}


### PR DESCRIPTION
Closes #26. Sprint-2 wave-2.

## What

- 5 fixture-builder classes in `com.enrichmeai.culvert.tester`:
  - `SecretProviderFixtures` — staticSecretProvider/failingSecretProvider/notFoundFor
  - `WarehouseFixtures` — emptyWarehouse/warehouseWithTables + `rows(...)` helper
  - `BlobStoreFixtures` — emptyBlobStore/blobStoreWith
  - `JobControlRepositoryFixtures` — emptyRepo/repoWith
  - `FinOpsSinkFixtures` — captureSink with assertion helpers
- 15 self-tests verify each fixture produces correctly configured mocks.

## Notes

- Mockito + AssertJ are **compile-scope** in this module (test-helper library convention).
- Authored by background dev-agent; orchestrator finalized after agent's run was interrupted by stream stall. Work was complete on disk.

## Tests

`mvn -pl data-pipeline-tester-java -am clean test` → 15/15 BUILD SUCCESS.