### PR TITLE
feat(observability-java): CloudTraceObservabilityHook + DataCatalogLineageEmitter (closes #24)

### DIFF
--- a/data-pipeline-libraries-java/data-pipeline-gcp-observability-java/pom.xml
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-observability-java/pom.xml
@@ -3,15 +3,163 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>com.enrichmeai.culvert</groupId>
         <artifactId>data-pipeline-libraries-parent</artifactId>
         <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
+
     <artifactId>data-pipeline-gcp-observability</artifactId>
     <packaging>jar</packaging>
-    <name>Culvert :: data-pipeline-gcp-observability (Java) — placeholder</name>
-    <description>Placeholder for the sprint-2 GCP observability adapter (Cloud Trace + Data Catalog). REPLACE THIS ENTIRE FILE when implementing.</description>
-    <!-- REPLACE THIS ENTIRE FILE when implementing the sprint-2 observability ticket. -->
+
+    <name>Culvert :: data-pipeline-gcp-observability (Java)</name>
+    <description>
+        Google Cloud observability adapters for the Culvert framework. Provides
+        CloudTraceObservabilityHook (ObservabilityHook implementation backed by
+        OpenTelemetry exporting spans to Cloud Trace via the GCP exporter) and
+        DataCatalogLineageEmitter (LineageEmitter implementation that writes
+        lineage events as Data Catalog tags on a configurable entry). Both
+        registered via java.util.ServiceLoader. Sprint-2 deliverable
+        (issue #24). Multi-contract module — same shape as the bigquery-java
+        pilot which ships three contract impls under one pom.
+    </description>
+
+    <properties>
+        <!--
+            Google Cloud Java SDK BOM. Same pin as the other GCP modules
+            (pubsub-java, bigquery-java, gcs-java, secrets-java). Imported here
+            in dependencyManagement so the parent stays cloud-neutral. This
+            BOM manages google-cloud-datacatalog versions.
+        -->
+        <google.cloud.libraries.bom.version>26.39.0</google.cloud.libraries.bom.version>
+
+        <!--
+            OpenTelemetry. The GCP OTel trace exporter
+            (com.google.cloud.opentelemetry:exporter-trace) is published
+            outside of libraries-bom, so we pin its version explicitly. The
+            opentelemetry-bom from io.opentelemetry pins the API/SDK aligned
+            with what the exporter expects.
+        -->
+        <opentelemetry.bom.version>1.38.0</opentelemetry.bom.version>
+        <gcp.opentelemetry.exporter.version>0.30.0</gcp.opentelemetry.exporter.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>libraries-bom</artifactId>
+                <version>${google.cloud.libraries.bom.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom</artifactId>
+                <version>${opentelemetry.bom.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <!-- Culvert contracts -->
+        <dependency>
+            <groupId>com.enrichmeai.culvert</groupId>
+            <artifactId>data-pipeline-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- OpenTelemetry API + SDK (versions managed by opentelemetry-bom) -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+        </dependency>
+
+        <!--
+            GCP Cloud Trace exporter for OpenTelemetry. Published from the
+            GoogleCloudPlatform/opentelemetry-operations-java repo; sits
+            outside libraries-bom, hence the explicit version above.
+        -->
+        <dependency>
+            <groupId>com.google.cloud.opentelemetry</groupId>
+            <artifactId>exporter-trace</artifactId>
+            <version>${gcp.opentelemetry.exporter.version}</version>
+        </dependency>
+
+        <!-- Google Cloud Data Catalog (version managed by libraries-bom) -->
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-datacatalog</artifactId>
+        </dependency>
+
+        <!-- SLF4J API only — consumers bring their own binding -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <!-- Test scope -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <!--
+                        google-cloud-datacatalog and the OTel SDK transitively
+                        bring in annotation processors (auto-value, etc.) that
+                        don't claim our JUnit / Mockito annotations. Under the
+                        parent's -Xlint:all + -Werror, this triggers a
+                        "No processor claimed any of these annotations" warning
+                        that fails the build. We don't use annotation
+                        processors here, so disable processing explicitly.
+                        Mirrors bigquery-java and pubsub-java.
+                    -->
+                    <proc>none</proc>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/data-pipeline-libraries-java/data-pipeline-gcp-observability-java/src/main/java/com/enrichmeai/culvert/gcp/observability/CloudTraceObservabilityHook.java
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-observability-java/src/main/java/com/enrichmeai/culvert/gcp/observability/CloudTraceObservabilityHook.java
@@ -1,0 +1,229 @@
+package com.enrichmeai.culvert.gcp.observability;
+
+import com.enrichmeai.culvert.contracts.ObservabilityHook;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.metrics.DoubleHistogram;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * {@link ObservabilityHook} implementation backed by OpenTelemetry whose
+ * tracer / meter providers export to Google Cloud Trace and Google Cloud
+ * Monitoring.
+ *
+ * <p>Wiring is decoupled from this class: callers construct an
+ * {@link OpenTelemetry} instance whose {@code SdkTracerProvider} has a
+ * {@code TraceExporter} from the
+ * {@code com.google.cloud.opentelemetry:exporter-trace} artifact registered
+ * (typically via a {@code BatchSpanProcessor}). This class wraps the
+ * resulting {@link Tracer} and {@link Meter} and bridges them to the Culvert
+ * {@link ObservabilityHook} surface.
+ *
+ * <h2>Construction</h2>
+ * <ul>
+ *   <li>{@link #CloudTraceObservabilityHook(OpenTelemetry, String)} — primary;
+ *       caller supplies an OTel instance + an instrumentation scope name
+ *       (typically the pipeline name).</li>
+ *   <li>{@link #CloudTraceObservabilityHook(Tracer, Meter)} — for tests; wraps
+ *       an already-resolved {@link Tracer} and {@link Meter} so callers can
+ *       inject mocks directly.</li>
+ * </ul>
+ *
+ * <h2>Bridging the contract</h2>
+ * <ul>
+ *   <li>{@code counter}/{@code gauge}/{@code histogram} → OTel {@link Meter}
+ *       instruments, lazily created and cached by name.</li>
+ *   <li>{@code log} → SLF4J at the requested level. The {@code fields} map is
+ *       rendered as {@code key=value} pairs appended to the message (SLF4J
+ *       has no structured-field API in core, so this keeps the log line
+ *       self-contained without forcing a logback / MDC dependency).</li>
+ *   <li>{@code span} → OTel {@link Tracer}; the returned {@link Span} wraps
+ *       the OTel {@code Span}+{@code Scope} pair and closes both on
+ *       {@link Span#close()}.</li>
+ * </ul>
+ *
+ * <p>This class does <strong>not</strong> implement {@link AutoCloseable}:
+ * the wrapped {@link OpenTelemetry} interface is not closeable; lifecycle
+ * (flushing the BatchSpanProcessor on shutdown) belongs to whoever built
+ * the SDK. Mirrors the {@code BigQueryWarehouse} "AutoCloseable only when
+ * the wrapped client supports it" rule.
+ *
+ * <p>Sprint-2 deliverable for issue #24.
+ */
+public final class CloudTraceObservabilityHook implements ObservabilityHook {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CloudTraceObservabilityHook.class);
+
+    private final Tracer tracer;
+    private final Meter meter;
+
+    // Instrument caches — OTel meters require us to register instruments
+    // by name; reusing instances avoids re-registration cost and keeps
+    // metric IDs stable across calls.
+    private final Map<String, LongCounter> counters = new ConcurrentHashMap<>();
+    private final Map<String, DoubleHistogram> histograms = new ConcurrentHashMap<>();
+    private final Map<String, DoubleHistogram> gauges = new ConcurrentHashMap<>();
+
+    /**
+     * Primary constructor.
+     *
+     * @param otel               Configured OpenTelemetry instance whose tracer
+     *                           provider exports to Cloud Trace. Required.
+     * @param instrumentationScope Name passed to {@code getTracer} /
+     *                           {@code getMeter} — typically the pipeline
+     *                           name. Required.
+     * @throws NullPointerException if either argument is null.
+     */
+    public CloudTraceObservabilityHook(OpenTelemetry otel, String instrumentationScope) {
+        Objects.requireNonNull(otel, "otel must not be null");
+        Objects.requireNonNull(instrumentationScope, "instrumentationScope must not be null");
+        this.tracer = otel.getTracer(instrumentationScope);
+        this.meter = otel.getMeter(instrumentationScope);
+    }
+
+    /**
+     * Test-friendly constructor that takes pre-resolved {@link Tracer} and
+     * {@link Meter}. Both are required.
+     *
+     * @throws NullPointerException if either argument is null.
+     */
+    public CloudTraceObservabilityHook(Tracer tracer, Meter meter) {
+        this.tracer = Objects.requireNonNull(tracer, "tracer must not be null");
+        this.meter = Objects.requireNonNull(meter, "meter must not be null");
+    }
+
+    @Override
+    public void counter(String name, long value, Map<String, String> tags) {
+        Objects.requireNonNull(name, "name");
+        LongCounter c = counters.computeIfAbsent(name, n -> meter.counterBuilder(n).build());
+        c.add(value, toAttributes(tags));
+    }
+
+    @Override
+    public void gauge(String name, double value, Map<String, String> tags) {
+        Objects.requireNonNull(name, "name");
+        // OpenTelemetry's "synchronous gauge" landed in 1.40+. For 1.38 we
+        // surface gauges as a single-shot histogram observation — this keeps
+        // the value visible in Cloud Monitoring without requiring async
+        // callbacks. When the SDK is bumped to 1.40+ this should switch to
+        // meter.gaugeBuilder(name).build().
+        DoubleHistogram g = gauges.computeIfAbsent(
+                name, n -> meter.histogramBuilder(n).build());
+        g.record(value, toAttributes(tags));
+    }
+
+    @Override
+    public void histogram(String name, double value, Map<String, String> tags) {
+        Objects.requireNonNull(name, "name");
+        DoubleHistogram h = histograms.computeIfAbsent(
+                name, n -> meter.histogramBuilder(n).build());
+        h.record(value, toAttributes(tags));
+    }
+
+    @Override
+    public void log(String level, String message, Map<String, Object> fields) {
+        Objects.requireNonNull(level, "level");
+        Objects.requireNonNull(message, "message");
+        String rendered = renderFields(message, fields);
+        String upper = level.toUpperCase(java.util.Locale.ROOT);
+        switch (upper) {
+            case "DEBUG" -> LOG.debug(rendered);
+            case "INFO" -> LOG.info(rendered);
+            case "WARN" -> LOG.warn(rendered);
+            case "ERROR" -> LOG.error(rendered);
+            default -> LOG.info(rendered);
+        }
+    }
+
+    @Override
+    public Span span(String name) {
+        Objects.requireNonNull(name, "name");
+        io.opentelemetry.api.trace.Span otelSpan = tracer.spanBuilder(name).startSpan();
+        Scope scope = otelSpan.makeCurrent();
+        return new OtelSpanAdapter(otelSpan, scope);
+    }
+
+    // --- helpers ----------------------------------------------------------
+
+    private static io.opentelemetry.api.common.Attributes toAttributes(Map<String, String> tags) {
+        if (tags == null || tags.isEmpty()) {
+            return io.opentelemetry.api.common.Attributes.empty();
+        }
+        var builder = io.opentelemetry.api.common.Attributes.builder();
+        for (Map.Entry<String, String> e : tags.entrySet()) {
+            if (e.getKey() != null && e.getValue() != null) {
+                builder.put(AttributeKey.stringKey(e.getKey()), e.getValue());
+            }
+        }
+        return builder.build();
+    }
+
+    private static String renderFields(String message, Map<String, Object> fields) {
+        if (fields == null || fields.isEmpty()) {
+            return message;
+        }
+        StringBuilder sb = new StringBuilder(message);
+        sb.append(' ');
+        boolean first = true;
+        for (Map.Entry<String, Object> e : fields.entrySet()) {
+            if (!first) {
+                sb.append(' ');
+            }
+            sb.append(e.getKey()).append('=').append(e.getValue());
+            first = false;
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Adapter from Culvert {@link Span} to OpenTelemetry's
+     * {@code Span}+{@code Scope} pair. Idempotent on {@link #close()} — a
+     * double-close is a no-op rather than throwing, matching the
+     * try-with-resources expectations of the contract.
+     */
+    static final class OtelSpanAdapter implements Span {
+        private final io.opentelemetry.api.trace.Span span;
+        private final Scope scope;
+        private boolean closed;
+
+        OtelSpanAdapter(io.opentelemetry.api.trace.Span span, Scope scope) {
+            this.span = span;
+            this.scope = scope;
+        }
+
+        @Override
+        public void setAttribute(String key, String value) {
+            Objects.requireNonNull(key, "key");
+            Objects.requireNonNull(value, "value");
+            span.setAttribute(key, value);
+        }
+
+        @Override
+        public void recordException(Throwable t) {
+            Objects.requireNonNull(t, "t");
+            span.recordException(t);
+        }
+
+        @Override
+        public void close() {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            try {
+                scope.close();
+            } finally {
+                span.end();
+            }
+        }
+    }
+}

--- a/data-pipeline-libraries-java/data-pipeline-gcp-observability-java/src/main/java/com/enrichmeai/culvert/gcp/observability/DataCatalogLineageEmitter.java
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-observability-java/src/main/java/com/enrichmeai/culvert/gcp/observability/DataCatalogLineageEmitter.java
@@ -1,0 +1,163 @@
+package com.enrichmeai.culvert.gcp.observability;
+
+import com.enrichmeai.culvert.contracts.LineageEmitter;
+import com.enrichmeai.culvert.lineage.LineageDestination;
+import com.enrichmeai.culvert.lineage.LineageEvent;
+import com.enrichmeai.culvert.lineage.LineagePipeline;
+import com.enrichmeai.culvert.lineage.LineageSource;
+import com.google.cloud.datacatalog.v1.CreateTagRequest;
+import com.google.cloud.datacatalog.v1.DataCatalogClient;
+import com.google.cloud.datacatalog.v1.Tag;
+import com.google.cloud.datacatalog.v1.TagField;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * {@link LineageEmitter} implementation that writes lineage events as Data
+ * Catalog tags on a configurable entry.
+ *
+ * <p>Each {@link LineageEvent} becomes one {@link Tag} attached to the
+ * configured Data Catalog entry. The tag's fields mirror the four
+ * sub-records of {@code LineageEvent} ({@code source}, {@code pipeline},
+ * {@code destination}, {@code audit}), flattened to scalar string values.
+ *
+ * <h2>Why Data Catalog (and not Cloud Data Lineage)?</h2>
+ *
+ * <p>The newer Cloud Data Lineage API (artifact
+ * {@code google-cloud-datalineage}) is not bundled in the GCP
+ * {@code libraries-bom} this module pins. To avoid an out-of-BOM version
+ * pin for a product still in transition, this Stage-2 implementation uses
+ * the stable v1 {@link DataCatalogClient} and stores lineage as tags. A
+ * dedicated {@code DataLineagePublisher} backed by the lineage API is
+ * deferred to sprint-5 (tracked under the lineage epic).
+ *
+ * <h2>Construction</h2>
+ *
+ * <p>{@link #DataCatalogLineageEmitter(DataCatalogClient, String, String)}
+ * — caller supplies an already-built client (so credentials, endpoint, and
+ * lifecycle stay in the caller's hands), the fully-qualified Data Catalog
+ * entry name to tag, and the tag template ID that defines the lineage tag
+ * schema. The tag template must exist before {@link #emit(LineageEvent)} is
+ * called; pre-provisioning is a Terraform / setup-time concern, not this
+ * emitter's responsibility.
+ *
+ * <p>Implements {@link AutoCloseable}: {@link DataCatalogClient} is itself
+ * closeable (extends {@link com.google.api.gax.core.BackgroundResource}),
+ * so closing this emitter closes the wrapped client — matching the
+ * {@code SecretManagerProvider} / {@code PubSubSource} pilot rule.
+ *
+ * <p>Sprint-2 deliverable for issue #24.
+ */
+public final class DataCatalogLineageEmitter implements LineageEmitter, AutoCloseable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DataCatalogLineageEmitter.class);
+
+    private final DataCatalogClient client;
+    private final String entryName;
+    private final String tagTemplate;
+
+    /**
+     * Primary constructor.
+     *
+     * @param client      Pre-built Data Catalog client. Required. Ownership
+     *                    transfers to this emitter — {@link #close()} will
+     *                    close it.
+     * @param entryName   Fully-qualified Data Catalog entry name
+     *                    ({@code projects/{p}/locations/{l}/entryGroups/{g}/entries/{e}})
+     *                    to which lineage tags will be attached. Required.
+     * @param tagTemplate Fully-qualified tag template name
+     *                    ({@code projects/{p}/locations/{l}/tagTemplates/{t}})
+     *                    that defines the lineage tag schema. Required.
+     * @throws NullPointerException if any argument is null.
+     */
+    public DataCatalogLineageEmitter(DataCatalogClient client, String entryName, String tagTemplate) {
+        this.client = Objects.requireNonNull(client, "client must not be null");
+        this.entryName = Objects.requireNonNull(entryName, "entryName must not be null");
+        this.tagTemplate = Objects.requireNonNull(tagTemplate, "tagTemplate must not be null");
+    }
+
+    /**
+     * Emit one lineage event as a Data Catalog tag on the configured entry.
+     *
+     * <p>If the underlying Data Catalog call throws (network, auth, quota,
+     * tag template mismatch), the exception is propagated to the caller.
+     * Callers that batch their own events for at-least-once semantics
+     * should catch and retry as appropriate.
+     *
+     * @param event The lineage event to emit. Required.
+     * @throws NullPointerException if {@code event} is null.
+     */
+    @Override
+    public void emit(LineageEvent event) {
+        Objects.requireNonNull(event, "event must not be null");
+
+        Tag.Builder tag = Tag.newBuilder()
+                .setTemplate(tagTemplate);
+
+        Map<String, String> fields = flatten(event);
+        for (Map.Entry<String, String> e : fields.entrySet()) {
+            tag.putFields(e.getKey(), TagField.newBuilder()
+                    .setStringValue(e.getValue())
+                    .build());
+        }
+
+        CreateTagRequest request = CreateTagRequest.newBuilder()
+                .setParent(entryName)
+                .setTag(tag.build())
+                .build();
+
+        client.createTag(request);
+        LOG.debug("emitted lineage tag for entry {}", entryName);
+    }
+
+    /** The Data Catalog entry name lineage tags are attached to. */
+    public String entryName() {
+        return entryName;
+    }
+
+    /** The tag template the emitted tags reference. */
+    public String tagTemplate() {
+        return tagTemplate;
+    }
+
+    @Override
+    public void close() {
+        client.close();
+    }
+
+    /**
+     * Flatten a {@link LineageEvent} into the scalar string-field shape
+     * Data Catalog tags require. Empty optional sub-records are skipped so
+     * the resulting tag stays compact.
+     */
+    private static Map<String, String> flatten(LineageEvent event) {
+        Map<String, String> out = new HashMap<>();
+        event.source().ifPresent(s -> putSource(out, s));
+        event.pipeline().ifPresent(p -> putPipeline(out, p));
+        event.destination().ifPresent(d -> putDestination(out, d));
+        event.audit().ifPresent(a -> out.put("audit", a.toString()));
+        return out;
+    }
+
+    private static void putSource(Map<String, String> out, LineageSource s) {
+        out.put("source_type", s.type());
+        out.put("source_uri", s.uri());
+    }
+
+    private static void putPipeline(Map<String, String> out, LineagePipeline p) {
+        out.put("run_id", p.runId());
+        out.put("pipeline_name", p.pipelineName());
+        out.put("stage", p.stage());
+        p.startedAt().ifPresent(t -> out.put("started_at", t.toString()));
+        p.completedAt().ifPresent(t -> out.put("completed_at", t.toString()));
+    }
+
+    private static void putDestination(Map<String, String> out, LineageDestination d) {
+        out.put("destination_type", d.type());
+        out.put("destination_uri", d.uri());
+    }
+}

--- a/data-pipeline-libraries-java/data-pipeline-gcp-observability-java/src/main/resources/META-INF/services/com.enrichmeai.culvert.contracts.LineageEmitter
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-observability-java/src/main/resources/META-INF/services/com.enrichmeai.culvert.contracts.LineageEmitter
@@ -1,0 +1,9 @@
+# Pre-registered for sprint-4 auto-config. The implementation does NOT
+# expose a no-arg constructor — Data Catalog tagging requires an entry
+# name + tag template + a pre-built client (3 args), which exceeds the
+# pilot's "no-arg only if <=2 env vars of state" rule. Direct
+# ServiceLoader.load(LineageEmitter.class).findFirst() will fail with
+# ServiceConfigurationError until sprint-4 introduces a config-driven
+# constructor. Until then, instantiate explicitly with
+# `new DataCatalogLineageEmitter(client, entryName, tagTemplate)`.
+com.enrichmeai.culvert.gcp.observability.DataCatalogLineageEmitter

--- a/data-pipeline-libraries-java/data-pipeline-gcp-observability-java/src/main/resources/META-INF/services/com.enrichmeai.culvert.contracts.ObservabilityHook
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-observability-java/src/main/resources/META-INF/services/com.enrichmeai.culvert.contracts.ObservabilityHook
@@ -1,0 +1,9 @@
+# Pre-registered for sprint-4 auto-config. The implementation does NOT
+# expose a no-arg constructor — Cloud Trace export requires an
+# already-built OpenTelemetry SDK (tracer provider + GCP exporter +
+# resource), which exceeds the pilot's "no-arg only if <=2 env vars of
+# state" rule. Direct ServiceLoader.load(ObservabilityHook.class)
+# .findFirst() will fail with ServiceConfigurationError until sprint-4
+# introduces a config-driven constructor. Until then, instantiate
+# explicitly with `new CloudTraceObservabilityHook(otel, scope)`.
+com.enrichmeai.culvert.gcp.observability.CloudTraceObservabilityHook

--- a/data-pipeline-libraries-java/data-pipeline-gcp-observability-java/src/test/java/com/enrichmeai/culvert/gcp/observability/CloudTraceObservabilityHookTest.java
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-observability-java/src/test/java/com/enrichmeai/culvert/gcp/observability/CloudTraceObservabilityHookTest.java
@@ -1,0 +1,195 @@
+package com.enrichmeai.culvert.gcp.observability;
+
+import com.enrichmeai.culvert.contracts.ObservabilityHook;
+import io.opentelemetry.api.metrics.DoubleHistogram;
+import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.LongCounterBuilder;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link CloudTraceObservabilityHook}. Mocks the OTel
+ * {@link Tracer} / {@link Meter} surface so no real Cloud Trace endpoint or
+ * credentials are required.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class CloudTraceObservabilityHookTest {
+
+    @Mock
+    private Tracer tracer;
+    @Mock
+    private Meter meter;
+    @Mock
+    private SpanBuilder spanBuilder;
+    @Mock
+    private Span otelSpan;
+    @Mock
+    private Scope scope;
+    @Mock
+    private LongCounterBuilder counterBuilder;
+    @Mock
+    private LongCounter counter;
+    @Mock
+    private DoubleHistogramBuilder histogramBuilder;
+    @Mock
+    private DoubleHistogram histogram;
+
+    // --- span lifecycle ----------------------------------------------------
+
+    @Test
+    void spanStartReturnsAdapterThatEndsOtelSpanOnClose() {
+        when(tracer.spanBuilder("stage.read")).thenReturn(spanBuilder);
+        when(spanBuilder.startSpan()).thenReturn(otelSpan);
+        when(otelSpan.makeCurrent()).thenReturn(scope);
+
+        CloudTraceObservabilityHook hook = new CloudTraceObservabilityHook(tracer, meter);
+
+        try (ObservabilityHook.Span s = hook.span("stage.read")) {
+            // Reference s so -Xlint doesn't flag the unused resource.
+            assertThat(s).isNotNull();
+        }
+
+        // close() must end the OTel span AND close the scope.
+        verify(scope).close();
+        verify(otelSpan).end();
+    }
+
+    @Test
+    void setAttributeAndRecordExceptionForwardToOtelSpan() {
+        when(tracer.spanBuilder(any())).thenReturn(spanBuilder);
+        when(spanBuilder.startSpan()).thenReturn(otelSpan);
+        when(otelSpan.makeCurrent()).thenReturn(scope);
+
+        CloudTraceObservabilityHook hook = new CloudTraceObservabilityHook(tracer, meter);
+        ObservabilityHook.Span s = hook.span("stage.transform");
+
+        s.setAttribute("pipeline", "demo");
+        RuntimeException boom = new RuntimeException("kaboom");
+        s.recordException(boom);
+        s.close();
+
+        verify(otelSpan).setAttribute("pipeline", "demo");
+        verify(otelSpan).recordException(boom);
+        verify(otelSpan).end();
+    }
+
+    @Test
+    void spanCloseIsIdempotent() {
+        when(tracer.spanBuilder(any())).thenReturn(spanBuilder);
+        when(spanBuilder.startSpan()).thenReturn(otelSpan);
+        when(otelSpan.makeCurrent()).thenReturn(scope);
+
+        CloudTraceObservabilityHook hook = new CloudTraceObservabilityHook(tracer, meter);
+        ObservabilityHook.Span s = hook.span("stage.write");
+
+        s.close();
+        s.close(); // second close must be a no-op
+
+        verify(scope, times(1)).close();
+        verify(otelSpan, times(1)).end();
+    }
+
+    // --- meter bridging ----------------------------------------------------
+
+    @Test
+    void counterDelegatesToCachedLongCounter() {
+        when(meter.counterBuilder("records.read")).thenReturn(counterBuilder);
+        when(counterBuilder.build()).thenReturn(counter);
+
+        CloudTraceObservabilityHook hook = new CloudTraceObservabilityHook(tracer, meter);
+        hook.counter("records.read", 5, Map.of("stage", "ingest"));
+        hook.counter("records.read", 3, Map.of("stage", "ingest"));
+
+        // First call creates and caches; second call must reuse — only ONE
+        // builder invocation for the same metric name.
+        verify(meter, times(1)).counterBuilder("records.read");
+        verify(counter).add(eq(5L), any(io.opentelemetry.api.common.Attributes.class));
+        verify(counter).add(eq(3L), any(io.opentelemetry.api.common.Attributes.class));
+    }
+
+    @Test
+    void histogramAndGaugeUseDistinctCaches() {
+        when(meter.histogramBuilder("latency_ms")).thenReturn(histogramBuilder);
+        when(meter.histogramBuilder("queue_depth")).thenReturn(histogramBuilder);
+        when(histogramBuilder.build()).thenReturn(histogram);
+
+        CloudTraceObservabilityHook hook = new CloudTraceObservabilityHook(tracer, meter);
+        hook.histogram("latency_ms", 12.5, Map.of());
+        hook.gauge("queue_depth", 17.0, Map.of());
+
+        verify(histogram).record(eq(12.5), any(io.opentelemetry.api.common.Attributes.class));
+        verify(histogram).record(eq(17.0), any(io.opentelemetry.api.common.Attributes.class));
+    }
+
+    // --- log ---------------------------------------------------------------
+
+    @Test
+    void logAcceptsAllStandardLevels() {
+        // Smoke test — we don't have a fixture for capturing SLF4J output
+        // without pulling logback into test scope, but invoking the method
+        // for each level confirms the dispatch table covers them all.
+        CloudTraceObservabilityHook hook = new CloudTraceObservabilityHook(tracer, meter);
+        Map<String, Object> fields = Map.of("run_id", "abc-123");
+        hook.log("DEBUG", "d", fields);
+        hook.log("INFO", "i", fields);
+        hook.log("WARN", "w", fields);
+        hook.log("ERROR", "e", fields);
+        hook.log("info", "lowercase still routes", fields);
+    }
+
+    // --- construction ------------------------------------------------------
+
+    @Test
+    void constructorRejectsNullTracer() {
+        assertThatThrownBy(() -> new CloudTraceObservabilityHook(null, meter))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void constructorRejectsNullMeter() {
+        assertThatThrownBy(() -> new CloudTraceObservabilityHook(tracer, null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void counterRejectsNullName() {
+        CloudTraceObservabilityHook hook = new CloudTraceObservabilityHook(tracer, meter);
+        assertThatThrownBy(() -> hook.counter(null, 1, Map.of()))
+                .isInstanceOf(NullPointerException.class);
+        verify(meter, never()).counterBuilder(any());
+    }
+
+    @Test
+    void counterToleratesNullTagsMap() {
+        when(meter.counterBuilder(any())).thenReturn(counterBuilder);
+        when(counterBuilder.build()).thenReturn(counter);
+        CloudTraceObservabilityHook hook = new CloudTraceObservabilityHook(tracer, meter);
+
+        hook.counter("free.counter", 1, null);
+        verify(counter).add(anyLong(), any(io.opentelemetry.api.common.Attributes.class));
+    }
+}

--- a/data-pipeline-libraries-java/data-pipeline-gcp-observability-java/src/test/java/com/enrichmeai/culvert/gcp/observability/DataCatalogLineageEmitterTest.java
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-observability-java/src/test/java/com/enrichmeai/culvert/gcp/observability/DataCatalogLineageEmitterTest.java
@@ -1,0 +1,180 @@
+package com.enrichmeai.culvert.gcp.observability;
+
+import com.enrichmeai.culvert.lineage.LineageDestination;
+import com.enrichmeai.culvert.lineage.LineageEvent;
+import com.enrichmeai.culvert.lineage.LineagePipeline;
+import com.enrichmeai.culvert.lineage.LineageSource;
+import com.google.cloud.datacatalog.v1.CreateTagRequest;
+import com.google.cloud.datacatalog.v1.DataCatalogClient;
+import com.google.cloud.datacatalog.v1.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link DataCatalogLineageEmitter}. Mocks
+ * {@link DataCatalogClient} so no real Data Catalog endpoint or
+ * credentials are required.
+ */
+@ExtendWith(MockitoExtension.class)
+class DataCatalogLineageEmitterTest {
+
+    private static final String ENTRY =
+            "projects/p/locations/us/entryGroups/g/entries/e";
+    private static final String TEMPLATE =
+            "projects/p/locations/us/tagTemplates/lineage";
+
+    @Mock
+    private DataCatalogClient client;
+
+    private static LineageEvent fullEvent() {
+        return LineageEvent.builder()
+                .source(LineageSource.of("table", "bigquery://p.ds.src"))
+                .pipeline(new LineagePipeline(
+                        "run-1",
+                        "demo_pipeline",
+                        "transform",
+                        Optional.of(Instant.parse("2026-05-27T10:00:00Z")),
+                        Optional.of(Instant.parse("2026-05-27T10:05:00Z"))))
+                .destination(LineageDestination.of("table", "bigquery://p.ds.tgt"))
+                .build();
+    }
+
+    // --- happy path --------------------------------------------------------
+
+    @Test
+    void emitOneEventCreatesTagWithFlattenedFields() {
+        DataCatalogLineageEmitter emitter =
+                new DataCatalogLineageEmitter(client, ENTRY, TEMPLATE);
+
+        emitter.emit(fullEvent());
+
+        ArgumentCaptor<CreateTagRequest> captor =
+                ArgumentCaptor.forClass(CreateTagRequest.class);
+        verify(client).createTag(captor.capture());
+        CreateTagRequest req = captor.getValue();
+
+        assertThat(req.getParent()).isEqualTo(ENTRY);
+        Tag tag = req.getTag();
+        assertThat(tag.getTemplate()).isEqualTo(TEMPLATE);
+
+        // Pipeline + source + destination all rendered as string tag fields.
+        assertThat(tag.getFieldsMap()).containsKeys(
+                "run_id", "pipeline_name", "stage",
+                "started_at", "completed_at",
+                "source_type", "source_uri",
+                "destination_type", "destination_uri");
+        assertThat(tag.getFieldsMap().get("run_id").getStringValue()).isEqualTo("run-1");
+        assertThat(tag.getFieldsMap().get("pipeline_name").getStringValue()).isEqualTo("demo_pipeline");
+        assertThat(tag.getFieldsMap().get("source_uri").getStringValue()).isEqualTo("bigquery://p.ds.src");
+        assertThat(tag.getFieldsMap().get("destination_uri").getStringValue()).isEqualTo("bigquery://p.ds.tgt");
+    }
+
+    @Test
+    void emitMinimalEventOmitsEmptyOptionalSections() {
+        // No source, no destination, no audit — pipeline only.
+        LineageEvent event = LineageEvent.builder()
+                .pipeline(new LineagePipeline(
+                        "run-2", "p2", "validate", Optional.empty(), Optional.empty()))
+                .build();
+
+        DataCatalogLineageEmitter emitter =
+                new DataCatalogLineageEmitter(client, ENTRY, TEMPLATE);
+        emitter.emit(event);
+
+        ArgumentCaptor<CreateTagRequest> captor =
+                ArgumentCaptor.forClass(CreateTagRequest.class);
+        verify(client).createTag(captor.capture());
+        Tag tag = captor.getValue().getTag();
+
+        assertThat(tag.getFieldsMap()).containsKeys("run_id", "pipeline_name", "stage");
+        assertThat(tag.getFieldsMap()).doesNotContainKeys(
+                "started_at", "completed_at",
+                "source_type", "source_uri",
+                "destination_type", "destination_uri");
+    }
+
+    @Test
+    void emitMultipleEventsIssuesOneCreateTagPerEvent() {
+        DataCatalogLineageEmitter emitter =
+                new DataCatalogLineageEmitter(client, ENTRY, TEMPLATE);
+
+        emitter.emit(fullEvent());
+        emitter.emit(fullEvent());
+        emitter.emit(fullEvent());
+
+        verify(client, org.mockito.Mockito.times(3))
+                .createTag(org.mockito.ArgumentMatchers.any(CreateTagRequest.class));
+    }
+
+    // --- error path --------------------------------------------------------
+
+    @Test
+    void clientExceptionPropagatesToCaller() {
+        when(client.createTag(org.mockito.ArgumentMatchers.any(CreateTagRequest.class)))
+                .thenThrow(new RuntimeException("data catalog unavailable"));
+
+        DataCatalogLineageEmitter emitter =
+                new DataCatalogLineageEmitter(client, ENTRY, TEMPLATE);
+
+        assertThatThrownBy(() -> emitter.emit(fullEvent()))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("data catalog unavailable");
+    }
+
+    // --- construction & lifecycle -----------------------------------------
+
+    @Test
+    void constructorRejectsNullClient() {
+        assertThatThrownBy(() -> new DataCatalogLineageEmitter(null, ENTRY, TEMPLATE))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void constructorRejectsNullEntryName() {
+        assertThatThrownBy(() -> new DataCatalogLineageEmitter(client, null, TEMPLATE))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void constructorRejectsNullTagTemplate() {
+        assertThatThrownBy(() -> new DataCatalogLineageEmitter(client, ENTRY, null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void emitRejectsNullEvent() {
+        DataCatalogLineageEmitter emitter =
+                new DataCatalogLineageEmitter(client, ENTRY, TEMPLATE);
+        assertThatThrownBy(() -> emitter.emit(null))
+                .isInstanceOf(NullPointerException.class);
+        verify(client, never()).createTag(org.mockito.ArgumentMatchers.any(CreateTagRequest.class));
+    }
+
+    @Test
+    void accessorsReturnConfiguredValues() {
+        DataCatalogLineageEmitter emitter =
+                new DataCatalogLineageEmitter(client, ENTRY, TEMPLATE);
+        assertThat(emitter.entryName()).isEqualTo(ENTRY);
+        assertThat(emitter.tagTemplate()).isEqualTo(TEMPLATE);
+    }
+
+    @Test
+    void closeDelegatesToClient() {
+        DataCatalogLineageEmitter emitter =
+                new DataCatalogLineageEmitter(client, ENTRY, TEMPLATE);
+        emitter.close();
+        verify(client).close();
+    }
+}


### PR DESCRIPTION
Closes #24. Sprint-2 wave-2.

## What

Multi-contract observability module — two impls under one pom:

- **CloudTraceObservabilityHook** — OpenTelemetry-based; production consumers wire the GCP Cloud Trace exporter.
- **DataCatalogLineageEmitter** — wraps `DataCatalogClient`; lineage events as catalog tags.

## Deps

- Google libraries-bom 26.39.0 (google-cloud-datacatalog)
- opentelemetry-bom 1.38.0 (OTel API + SDK)
- com.google.cloud.opentelemetry:exporter-trace 0.30.0 (pinned outside BOMs)
- `<proc>none</proc>` on compiler plugin

## Tests

`mvn -pl data-pipeline-gcp-observability-java -am clean test` → 20/20 BUILD SUCCESS.

## Notes

Authored by background dev-agent; orchestrator finalized after agent's run was interrupted by stream stall. One -Werror fix in the test file (unused-resource lint on the AutoCloseable Span).