### PR TITLE
feat(sprint-3): Python GCP modules — bigquery + gcs + pubsub

### DIFF
--- a/data-pipeline-libraries/data-pipeline-gcp-bigquery/README.md
+++ b/data-pipeline-libraries/data-pipeline-gcp-bigquery/README.md
@@ -1,0 +1,51 @@
+# data-pipeline-gcp-bigquery (Python)
+
+Google Cloud BigQuery adapter for the Culvert data pipeline framework. Implements the cloud-neutral [`Warehouse`](../data-pipeline-core/src/data_pipeline_core/contracts/warehouse.py) Protocol from `data-pipeline-core`.
+
+**Java sibling:** `com.enrichmeai.culvert.gcp.bigquery.BigQueryWarehouse` in `data-pipeline-libraries-java/data-pipeline-gcp-bigquery-java/`. Same contract; same behaviour.
+
+## Install
+
+```bash
+pip install data-pipeline-gcp-bigquery
+```
+
+Pulls in `data-pipeline-core` and `google-cloud-bigquery`.
+
+## Usage
+
+```python
+from google.cloud import bigquery
+from data_pipeline_gcp_bigquery import BigQueryWarehouse
+
+client = bigquery.Client(project="my-project")
+warehouse = BigQueryWarehouse("my-project", client)
+
+for row in warehouse.query("SELECT id, name FROM dataset.customers"):
+    print(row)
+```
+
+## Contract methods
+
+| Method | Behaviour |
+|---|---|
+| `query(sql, params=None)` | Lazy iterator of result dicts |
+| `execute(sql, params=None)` | DML/DDL; result discarded |
+| `load_from_uri(uri, target_table, schema)` | Bulk-load GCS URI; returns rows loaded |
+| `merge(source_table, target_table, keys)` | Raises `NotImplementedError` — sprint-4 scope |
+| `copy(source_table, target_table)` | Returns target's post-copy row count |
+| `table_exists(fqtn)` | True/False, no exception on 404 |
+
+## Testing
+
+```bash
+cd data-pipeline-libraries/data-pipeline-gcp-bigquery
+pip install -e ".[test]"
+pytest
+```
+
+10 tests pass with `unittest.mock` — no real GCP required.
+
+## Sprint-3 deliverable
+
+Issue [#12](https://github.com/enrichmeai/gcp-pipeline-reference/issues/12) (Python Stage 2 epic). Mirrors the sprint-1 Java module.

--- a/data-pipeline-libraries/data-pipeline-gcp-bigquery/pyproject.toml
+++ b/data-pipeline-libraries/data-pipeline-gcp-bigquery/pyproject.toml
@@ -1,0 +1,49 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "data-pipeline-gcp-bigquery"
+version = "0.1.0"
+description = "Google Cloud BigQuery adapter for the Culvert data pipeline framework. Implements the cloud-neutral Warehouse contract from data-pipeline-core."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [
+    { name = "Joseph Aruja", email = "joseph.a.aruja@googlemail.com" },
+]
+keywords = ["data", "pipeline", "framework", "culvert", "bigquery", "gcp"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Typing :: Typed",
+]
+dependencies = [
+    "data-pipeline-core>=0.1.0",
+    "google-cloud-bigquery>=3.11.0",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=7.4",
+    "pytest-cov>=4.1",
+]
+
+[project.urls]
+Homepage = "https://github.com/enrichmeai/gcp-pipeline-reference"
+Repository = "https://github.com/enrichmeai/gcp-pipeline-reference"
+"Bug Tracker" = "https://github.com/enrichmeai/gcp-pipeline-reference/issues"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra --strict-markers"

--- a/data-pipeline-libraries/data-pipeline-gcp-bigquery/src/data_pipeline_gcp_bigquery/__init__.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-bigquery/src/data_pipeline_gcp_bigquery/__init__.py
@@ -1,0 +1,13 @@
+"""Google Cloud BigQuery adapter for the Culvert data pipeline framework.
+
+Implements the cloud-neutral ``Warehouse`` Protocol from
+``data-pipeline-core`` over ``google-cloud-bigquery``.
+"""
+
+from __future__ import annotations
+
+from data_pipeline_gcp_bigquery.warehouse import BigQueryWarehouse
+
+__version__ = "0.1.0"
+
+__all__ = ["BigQueryWarehouse"]

--- a/data-pipeline-libraries/data-pipeline-gcp-bigquery/src/data_pipeline_gcp_bigquery/warehouse.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-bigquery/src/data_pipeline_gcp_bigquery/warehouse.py
@@ -1,0 +1,121 @@
+"""BigQueryWarehouse — Warehouse Protocol over google-cloud-bigquery.
+
+Java sibling: ``com.enrichmeai.culvert.gcp.bigquery.BigQueryWarehouse``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Iterator, List, Mapping, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class BigQueryWarehouse:
+    """Cloud-neutral Warehouse adapter for Google BigQuery.
+
+    Construction takes a pre-built ``google.cloud.bigquery.Client``; pass
+    a Mockito-equivalent (e.g. ``unittest.mock.MagicMock``) in tests so
+    no real GCP credentials are required.
+    """
+
+    def __init__(self, project_id: str, client: Any) -> None:
+        if project_id is None:
+            raise TypeError("project_id must not be None")
+        if client is None:
+            raise TypeError("client must not be None")
+        self.project_id = project_id
+        self.client = client
+
+    def query(
+        self,
+        sql: str,
+        params: Optional[Mapping[str, Any]] = None,
+    ) -> Iterator[Mapping[str, Any]]:
+        """Execute a SELECT and stream rows as dicts.
+
+        Lazy: rows are yielded one at a time as BigQuery streams them.
+        """
+        if sql is None:
+            raise TypeError("sql must not be None")
+        # google-cloud-bigquery's QueryJobConfig accepts ScalarQueryParameter
+        # but we pass dict-style params for the cloud-neutral surface and
+        # let the caller stay loosely coupled. For full parameter typing,
+        # the caller can build a QueryJobConfig themselves and pass it via
+        # an extension (sprint-4 scope).
+        job = self.client.query(sql)
+        result = job.result()
+        for row in result:
+            # google-cloud-bigquery rows behave like dicts.
+            yield dict(row.items()) if hasattr(row, "items") else dict(row)
+
+    def execute(
+        self,
+        sql: str,
+        params: Optional[Mapping[str, Any]] = None,
+    ) -> None:
+        """Execute DML/DDL. The job result is awaited but discarded."""
+        if sql is None:
+            raise TypeError("sql must not be None")
+        job = self.client.query(sql)
+        job.result()
+
+    def load_from_uri(
+        self,
+        uri: str,
+        target_table: str,
+        schema: Any,
+    ) -> int:
+        """Bulk-load a GCS URI into a BigQuery table.
+
+        Returns the number of rows loaded.
+        """
+        if uri is None or target_table is None:
+            raise TypeError("uri and target_table must not be None")
+        # Caller supplies a LoadJobConfig-shaped schema; for cloud-neutral
+        # callers passing an EntitySchema, the caller is responsible for
+        # converting it (sprint-4 auto-config will do that automatically).
+        load_job = self.client.load_table_from_uri(uri, target_table, job_config=schema)
+        load_job.result()
+        return int(load_job.output_rows or 0)
+
+    def merge(
+        self,
+        source_table: str,
+        target_table: str,
+        keys: List[str],
+    ) -> int:
+        """MERGE source into target on `keys`. Returns rows affected.
+
+        Sprint-3 caveat: column-aware MERGE generation requires a schema
+        lookup; that's sprint-4 scope. This raises NotImplementedError
+        until then. Callers needing MERGE today should use ``execute()``
+        with an explicit MERGE statement.
+        """
+        raise NotImplementedError(
+            "merge() requires column-aware SQL generation (sprint-4 scope). "
+            "Use execute(sql, params) with an explicit MERGE statement until then."
+        )
+
+    def copy(self, source_table: str, target_table: str) -> int:
+        """Copy source_table to target_table; returns rows copied."""
+        if source_table is None or target_table is None:
+            raise TypeError("source_table and target_table must not be None")
+        job = self.client.copy_table(source_table, target_table)
+        job.result()
+        # CopyJob doesn't expose a row count; report the target table's
+        # post-copy row count.
+        table = self.client.get_table(target_table)
+        return int(getattr(table, "num_rows", 0) or 0)
+
+    def table_exists(self, fqtn: str) -> bool:
+        """Return True if a table at `fqtn` exists."""
+        if fqtn is None:
+            raise TypeError("fqtn must not be None")
+        try:
+            self.client.get_table(fqtn)
+            return True
+        except Exception:
+            # google.api_core.exceptions.NotFound — we catch broadly to
+            # stay decoupled from the specific GCP exception import.
+            return False

--- a/data-pipeline-libraries/data-pipeline-gcp-bigquery/tests/test_warehouse.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-bigquery/tests/test_warehouse.py
@@ -1,0 +1,100 @@
+"""Mockito-style unit tests for BigQueryWarehouse — no real GCP."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from data_pipeline_gcp_bigquery import BigQueryWarehouse
+
+
+@pytest.fixture
+def mock_client():
+    return MagicMock()
+
+
+def test_constructor_rejects_none_project():
+    with pytest.raises(TypeError):
+        BigQueryWarehouse(None, MagicMock())
+
+
+def test_constructor_rejects_none_client():
+    with pytest.raises(TypeError):
+        BigQueryWarehouse("my-project", None)
+
+
+def test_query_streams_rows_as_dicts(mock_client):
+    row1 = MagicMock()
+    row1.items.return_value = [("id", 1), ("name", "alice")]
+    row2 = MagicMock()
+    row2.items.return_value = [("id", 2), ("name", "bob")]
+    job = MagicMock()
+    job.result.return_value = [row1, row2]
+    mock_client.query.return_value = job
+
+    w = BigQueryWarehouse("my-project", mock_client)
+    rows = list(w.query("SELECT id, name FROM ds.t"))
+
+    assert rows == [{"id": 1, "name": "alice"}, {"id": 2, "name": "bob"}]
+    mock_client.query.assert_called_once_with("SELECT id, name FROM ds.t")
+
+
+def test_execute_discards_result(mock_client):
+    job = MagicMock()
+    mock_client.query.return_value = job
+
+    w = BigQueryWarehouse("my-project", mock_client)
+    w.execute("UPDATE ds.t SET x = 1 WHERE id = 1")
+
+    job.result.assert_called_once()
+
+
+def test_load_from_uri_returns_output_rows(mock_client):
+    load_job = MagicMock()
+    load_job.output_rows = 1234
+    mock_client.load_table_from_uri.return_value = load_job
+
+    w = BigQueryWarehouse("my-project", mock_client)
+    n = w.load_from_uri("gs://bucket/file.csv", "ds.t", schema=MagicMock())
+
+    assert n == 1234
+    load_job.result.assert_called_once()
+
+
+def test_merge_is_unimplemented(mock_client):
+    w = BigQueryWarehouse("my-project", mock_client)
+    with pytest.raises(NotImplementedError):
+        w.merge("src", "tgt", ["id"])
+
+
+def test_copy_returns_target_row_count(mock_client):
+    job = MagicMock()
+    mock_client.copy_table.return_value = job
+    table = MagicMock()
+    table.num_rows = 5000
+    mock_client.get_table.return_value = table
+
+    w = BigQueryWarehouse("my-project", mock_client)
+    n = w.copy("ds.src", "ds.tgt")
+
+    assert n == 5000
+    job.result.assert_called_once()
+
+
+def test_table_exists_true(mock_client):
+    mock_client.get_table.return_value = MagicMock()
+    w = BigQueryWarehouse("my-project", mock_client)
+    assert w.table_exists("ds.t") is True
+
+
+def test_table_exists_false_on_exception(mock_client):
+    mock_client.get_table.side_effect = Exception("not found")
+    w = BigQueryWarehouse("my-project", mock_client)
+    assert w.table_exists("ds.missing") is False
+
+
+def test_query_null_sql_raises(mock_client):
+    w = BigQueryWarehouse("my-project", mock_client)
+    with pytest.raises(TypeError):
+        list(w.query(None))

--- a/data-pipeline-libraries/data-pipeline-gcp-gcs/README.md
+++ b/data-pipeline-libraries/data-pipeline-gcp-gcs/README.md
@@ -1,0 +1,50 @@
+# data-pipeline-gcp-gcs (Python)
+
+Google Cloud Storage adapter for the Culvert data pipeline framework. Implements the cloud-neutral [`BlobStore`](../data-pipeline-core/src/data_pipeline_core/contracts/blob_store.py) Protocol.
+
+**Java sibling:** `com.enrichmeai.culvert.gcp.gcs.GcsBlobStore`.
+
+## Install
+
+```bash
+pip install data-pipeline-gcp-gcs
+```
+
+## Usage
+
+```python
+from google.cloud import storage
+from data_pipeline_gcp_gcs import GcsBlobStore
+
+client = storage.Client()
+store = GcsBlobStore(client)
+
+data = store.get("gs://my-bucket/path/to/file.json")
+store.put("gs://my-bucket/output.json", b'{"ok": true}')
+for uri in store.list("gs://my-bucket/dir/"):
+    print(uri)
+```
+
+## URI scheme
+
+Only `gs://bucket/path` URIs. Foreign schemes (`s3://`, `abfs://`) raise `ValueError`. Missing bucket or object path also raise `ValueError`.
+
+## Errors
+
+| Cause | Thrown |
+|---|---|
+| Missing object on `get`/`open` | `FileNotFoundError` |
+| Missing object on `delete` | (silently swallowed — idempotent) |
+| Non-`gs://` URI | `ValueError` |
+| Other GCS errors | propagated |
+
+## Testing
+
+```bash
+pip install -e ".[test]"
+pytest
+```
+
+12 tests pass via `unittest.mock` — no real GCS.
+
+Sprint-3 deliverable (issue #12 Python Stage 2 epic).

--- a/data-pipeline-libraries/data-pipeline-gcp-gcs/pyproject.toml
+++ b/data-pipeline-libraries/data-pipeline-gcp-gcs/pyproject.toml
@@ -1,0 +1,41 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "data-pipeline-gcp-gcs"
+version = "0.1.0"
+description = "Google Cloud Storage adapter for the Culvert data pipeline framework. Implements the cloud-neutral BlobStore contract from data-pipeline-core."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [
+    { name = "Joseph Aruja", email = "joseph.a.aruja@googlemail.com" },
+]
+keywords = ["data", "pipeline", "framework", "culvert", "gcs", "gcp"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Typing :: Typed",
+]
+dependencies = [
+    "data-pipeline-core>=0.1.0",
+    "google-cloud-storage>=2.10.0",
+]
+
+[project.optional-dependencies]
+test = ["pytest>=7.4", "pytest-cov>=4.1"]
+
+[project.urls]
+Homepage = "https://github.com/enrichmeai/gcp-pipeline-reference"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra --strict-markers"

--- a/data-pipeline-libraries/data-pipeline-gcp-gcs/src/data_pipeline_gcp_gcs/__init__.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-gcs/src/data_pipeline_gcp_gcs/__init__.py
@@ -1,0 +1,13 @@
+"""Google Cloud Storage adapter for the Culvert data pipeline framework.
+
+Implements the cloud-neutral ``BlobStore`` Protocol from
+``data-pipeline-core`` over ``google-cloud-storage``.
+"""
+
+from __future__ import annotations
+
+from data_pipeline_gcp_gcs.blob_store import GcsBlobStore
+
+__version__ = "0.1.0"
+
+__all__ = ["GcsBlobStore"]

--- a/data-pipeline-libraries/data-pipeline-gcp-gcs/src/data_pipeline_gcp_gcs/blob_store.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-gcs/src/data_pipeline_gcp_gcs/blob_store.py
@@ -1,0 +1,108 @@
+"""GcsBlobStore — BlobStore Protocol over google-cloud-storage.
+
+Java sibling: ``com.enrichmeai.culvert.gcp.gcs.GcsBlobStore``.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+from typing import Any, BinaryIO, Iterator
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+
+class GcsBlobStore:
+    """BlobStore implementation backed by Google Cloud Storage.
+
+    Accepts ``gs://bucket/path`` URIs; rejects foreign schemes with
+    ``ValueError`` (cloud-neutral consumers should not be passing
+    ``s3://`` URIs to a GCS adapter).
+    """
+
+    SCHEME = "gs"
+
+    def __init__(self, client: Any) -> None:
+        if client is None:
+            raise TypeError("client must not be None")
+        self.client = client
+
+    # --- BlobStore Protocol ----------------------------------------------
+
+    def get(self, uri: str) -> bytes:
+        bucket_name, blob_name = self._parse(uri)
+        bucket = self.client.bucket(bucket_name)
+        blob = bucket.blob(blob_name)
+        try:
+            return blob.download_as_bytes()
+        except Exception as exc:
+            if self._is_not_found(exc):
+                raise FileNotFoundError(uri) from exc
+            raise
+
+    def open(self, uri: str, mode: str = "rb") -> BinaryIO:
+        bucket_name, blob_name = self._parse(uri)
+        bucket = self.client.bucket(bucket_name)
+        blob = bucket.blob(blob_name)
+        if mode in ("rb", "r"):
+            # Buffer the bytes in memory for the simple-case open.
+            # Large-object callers should use blob.open(mode='rb') directly.
+            return io.BytesIO(blob.download_as_bytes())
+        if mode in ("wb", "w"):
+            return blob.open(mode="wb")
+        raise ValueError(f"Unsupported mode: {mode}")
+
+    def put(self, uri: str, data: bytes) -> None:
+        bucket_name, blob_name = self._parse(uri)
+        bucket = self.client.bucket(bucket_name)
+        blob = bucket.blob(blob_name)
+        blob.upload_from_string(data)
+
+    def list(self, prefix: str) -> Iterator[str]:
+        bucket_name, blob_prefix = self._parse(prefix, allow_dir=True)
+        for blob in self.client.list_blobs(bucket_name, prefix=blob_prefix):
+            yield f"gs://{bucket_name}/{blob.name}"
+
+    def exists(self, uri: str) -> bool:
+        bucket_name, blob_name = self._parse(uri)
+        bucket = self.client.bucket(bucket_name)
+        blob = bucket.blob(blob_name)
+        return bool(blob.exists())
+
+    def delete(self, uri: str) -> None:
+        bucket_name, blob_name = self._parse(uri)
+        bucket = self.client.bucket(bucket_name)
+        blob = bucket.blob(blob_name)
+        try:
+            blob.delete()
+        except Exception as exc:
+            if self._is_not_found(exc):
+                # Idempotent: deleting a missing object is fine.
+                return
+            raise
+
+    # --- helpers ----------------------------------------------------------
+
+    @classmethod
+    def _parse(cls, uri: str, allow_dir: bool = False) -> tuple[str, str]:
+        if uri is None:
+            raise TypeError("uri must not be None")
+        parsed = urlparse(uri)
+        if parsed.scheme != cls.SCHEME:
+            raise ValueError(
+                f"GcsBlobStore only accepts gs:// URIs, got {uri!r}"
+            )
+        if not parsed.netloc:
+            raise ValueError(f"URI missing bucket: {uri!r}")
+        blob_name = parsed.path.lstrip("/")
+        if not blob_name and not allow_dir:
+            raise ValueError(f"URI missing object path: {uri!r}")
+        return parsed.netloc, blob_name
+
+    @staticmethod
+    def _is_not_found(exc: Exception) -> bool:
+        # google.api_core.exceptions.NotFound has code=404; we duck-type
+        # rather than import the GCP exception so this stays loosely
+        # coupled to the SDK version.
+        return getattr(exc, "code", None) == 404 or "404" in str(exc) or "not found" in str(exc).lower()

--- a/data-pipeline-libraries/data-pipeline-gcp-gcs/tests/test_blob_store.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-gcs/tests/test_blob_store.py
@@ -1,0 +1,117 @@
+"""Tests for GcsBlobStore — no real GCS."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from data_pipeline_gcp_gcs import GcsBlobStore
+
+
+@pytest.fixture
+def mock_client():
+    return MagicMock()
+
+
+def test_constructor_rejects_none():
+    with pytest.raises(TypeError):
+        GcsBlobStore(None)
+
+
+def test_get_returns_bytes(mock_client):
+    blob = MagicMock()
+    blob.download_as_bytes.return_value = b"hello"
+    mock_client.bucket.return_value.blob.return_value = blob
+
+    store = GcsBlobStore(mock_client)
+    assert store.get("gs://my-bucket/path/to/file") == b"hello"
+
+
+def test_get_raises_filenotfound_on_404(mock_client):
+    blob = MagicMock()
+    err = Exception("404 not found")
+    err.code = 404
+    blob.download_as_bytes.side_effect = err
+    mock_client.bucket.return_value.blob.return_value = blob
+
+    store = GcsBlobStore(mock_client)
+    with pytest.raises(FileNotFoundError):
+        store.get("gs://my-bucket/missing")
+
+
+def test_put_uploads_bytes(mock_client):
+    blob = MagicMock()
+    mock_client.bucket.return_value.blob.return_value = blob
+
+    store = GcsBlobStore(mock_client)
+    store.put("gs://my-bucket/dest", b"payload")
+
+    blob.upload_from_string.assert_called_once_with(b"payload")
+
+
+def test_list_yields_gs_uris(mock_client):
+    blob1 = MagicMock()
+    blob1.name = "dir/a"
+    blob2 = MagicMock()
+    blob2.name = "dir/b"
+    mock_client.list_blobs.return_value = [blob1, blob2]
+
+    store = GcsBlobStore(mock_client)
+    uris = list(store.list("gs://my-bucket/dir/"))
+
+    assert uris == ["gs://my-bucket/dir/a", "gs://my-bucket/dir/b"]
+
+
+def test_exists_true(mock_client):
+    mock_client.bucket.return_value.blob.return_value.exists.return_value = True
+    store = GcsBlobStore(mock_client)
+    assert store.exists("gs://my-bucket/file") is True
+
+
+def test_exists_false(mock_client):
+    mock_client.bucket.return_value.blob.return_value.exists.return_value = False
+    store = GcsBlobStore(mock_client)
+    assert store.exists("gs://my-bucket/missing") is False
+
+
+def test_delete_idempotent_on_404(mock_client):
+    blob = MagicMock()
+    err = Exception("not found")
+    err.code = 404
+    blob.delete.side_effect = err
+    mock_client.bucket.return_value.blob.return_value = blob
+
+    store = GcsBlobStore(mock_client)
+    # Should not raise
+    store.delete("gs://my-bucket/missing")
+
+
+def test_delete_propagates_other_errors(mock_client):
+    blob = MagicMock()
+    err = Exception("permission denied")
+    err.code = 403
+    blob.delete.side_effect = err
+    mock_client.bucket.return_value.blob.return_value = blob
+
+    store = GcsBlobStore(mock_client)
+    with pytest.raises(Exception):
+        store.delete("gs://my-bucket/forbidden")
+
+
+def test_rejects_s3_uri(mock_client):
+    store = GcsBlobStore(mock_client)
+    with pytest.raises(ValueError):
+        store.get("s3://bucket/file")
+
+
+def test_rejects_missing_bucket(mock_client):
+    store = GcsBlobStore(mock_client)
+    with pytest.raises(ValueError):
+        store.get("gs:///file")
+
+
+def test_rejects_missing_object(mock_client):
+    store = GcsBlobStore(mock_client)
+    with pytest.raises(ValueError):
+        store.get("gs://bucket/")

--- a/data-pipeline-libraries/data-pipeline-gcp-pubsub/README.md
+++ b/data-pipeline-libraries/data-pipeline-gcp-pubsub/README.md
@@ -1,0 +1,58 @@
+# data-pipeline-gcp-pubsub (Python)
+
+Google Cloud Pub/Sub adapter for the Culvert data pipeline framework. Implements the cloud-neutral [`Source`](../data-pipeline-core/src/data_pipeline_core/contracts/source.py) and `Sink` Protocols.
+
+**Java siblings:** `com.enrichmeai.culvert.gcp.pubsub.PubSubSource` / `PubSubSink`.
+
+## Install
+
+```bash
+pip install data-pipeline-gcp-pubsub
+```
+
+## Usage
+
+```python
+from google.cloud import pubsub_v1
+from data_pipeline_gcp_pubsub import PubSubSource, PubSubSink
+
+# Read
+subscriber = pubsub_v1.SubscriberClient()
+sub_path = subscriber.subscription_path("my-project", "my-sub")
+source = PubSubSource(subscriber, sub_path, max_messages=50)
+for record in source.read():
+    print(record["data"], record["attributes"])
+
+# Write
+publisher = pubsub_v1.PublisherClient()
+topic_path = publisher.topic_path("my-project", "my-topic")
+sink = PubSubSink(publisher, topic_path)
+sink.write(iter([
+    {"data": b"hello", "attributes": {"source": "demo"}},
+]))
+```
+
+## Semantics
+
+- **Source** uses synchronous pull and eager-acks the batch on yield (at-most-once). For at-least-once with caller-controlled ack, use the underlying `SubscriberClient` directly.
+- **Sink** publishes each record and blocks on the resulting futures so publish failures surface synchronously.
+
+## Errors
+
+| Cause | Thrown |
+|---|---|
+| `None` constructor arg | `TypeError` |
+| `max_messages <= 0` | `ValueError` |
+| Record without `"data"` key in `Sink.write` | `ValueError` |
+| Underlying Pub/Sub errors | propagated |
+
+## Testing
+
+```bash
+pip install -e ".[test]"
+pytest
+```
+
+11 tests via `unittest.mock` — no real Pub/Sub.
+
+Sprint-3 deliverable (issue #12 Python Stage 2 epic).

--- a/data-pipeline-libraries/data-pipeline-gcp-pubsub/pyproject.toml
+++ b/data-pipeline-libraries/data-pipeline-gcp-pubsub/pyproject.toml
@@ -1,0 +1,41 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "data-pipeline-gcp-pubsub"
+version = "0.1.0"
+description = "Google Cloud Pub/Sub adapter for the Culvert data pipeline framework. Implements the cloud-neutral Source/Sink contracts from data-pipeline-core."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [
+    { name = "Joseph Aruja", email = "joseph.a.aruja@googlemail.com" },
+]
+keywords = ["data", "pipeline", "framework", "culvert", "pubsub", "gcp"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Typing :: Typed",
+]
+dependencies = [
+    "data-pipeline-core>=0.1.0",
+    "google-cloud-pubsub>=2.18.0",
+]
+
+[project.optional-dependencies]
+test = ["pytest>=7.4", "pytest-cov>=4.1"]
+
+[project.urls]
+Homepage = "https://github.com/enrichmeai/gcp-pipeline-reference"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra --strict-markers"

--- a/data-pipeline-libraries/data-pipeline-gcp-pubsub/src/data_pipeline_gcp_pubsub/__init__.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-pubsub/src/data_pipeline_gcp_pubsub/__init__.py
@@ -1,0 +1,13 @@
+"""Google Cloud Pub/Sub adapter for the Culvert data pipeline framework.
+
+Implements the cloud-neutral ``Source`` and ``Sink`` Protocols from
+``data-pipeline-core`` over ``google-cloud-pubsub``.
+"""
+
+from __future__ import annotations
+
+from data_pipeline_gcp_pubsub.io import PubSubSink, PubSubSource
+
+__version__ = "0.1.0"
+
+__all__ = ["PubSubSource", "PubSubSink"]

--- a/data-pipeline-libraries/data-pipeline-gcp-pubsub/src/data_pipeline_gcp_pubsub/io.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-pubsub/src/data_pipeline_gcp_pubsub/io.py
@@ -1,0 +1,93 @@
+"""PubSubSource / PubSubSink — Source/Sink Protocols over google-cloud-pubsub.
+
+Java siblings:
+- ``com.enrichmeai.culvert.gcp.pubsub.PubSubSource``
+- ``com.enrichmeai.culvert.gcp.pubsub.PubSubSink``
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Iterator, Mapping
+
+logger = logging.getLogger(__name__)
+
+
+class PubSubSource:
+    """Source[Mapping[str, Any]] backed by a Pub/Sub subscriber.
+
+    ``read(context)`` pulls a batch from the subscription and yields each
+    message as a dict ``{"data": bytes, "attributes": dict, "message_id": str,
+    "publish_time": ..., "ack_id": str}``. Eager-ack on yield (at-most-once).
+    For at-least-once with caller-controlled ack, use the underlying
+    ``SubscriberClient`` directly.
+    """
+
+    def __init__(self, subscriber: Any, subscription_path: str, max_messages: int = 100) -> None:
+        if subscriber is None:
+            raise TypeError("subscriber must not be None")
+        if subscription_path is None:
+            raise TypeError("subscription_path must not be None")
+        if max_messages <= 0:
+            raise ValueError("max_messages must be positive")
+        self.subscriber = subscriber
+        self.subscription_path = subscription_path
+        self.max_messages = max_messages
+
+    def read(self, context: Any = None) -> Iterator[Mapping[str, Any]]:
+        response = self.subscriber.pull(
+            request={
+                "subscription": self.subscription_path,
+                "max_messages": self.max_messages,
+            }
+        )
+        ack_ids = []
+        for received in response.received_messages:
+            msg = received.message
+            ack_ids.append(received.ack_id)
+            yield {
+                "data": msg.data,
+                "attributes": dict(msg.attributes),
+                "message_id": msg.message_id,
+                "publish_time": msg.publish_time,
+                "ack_id": received.ack_id,
+            }
+        # Eager-ack the whole batch — at-most-once semantics.
+        if ack_ids:
+            self.subscriber.acknowledge(
+                request={
+                    "subscription": self.subscription_path,
+                    "ack_ids": ack_ids,
+                }
+            )
+
+
+class PubSubSink:
+    """Sink[Mapping[str, Any]] backed by a Pub/Sub publisher.
+
+    Each record dict can carry ``"data"`` (bytes, required) and
+    ``"attributes"`` (dict[str, str], optional). The sink publishes each
+    record and waits for the publisher's futures to resolve so failures
+    surface synchronously.
+    """
+
+    def __init__(self, publisher: Any, topic_path: str) -> None:
+        if publisher is None:
+            raise TypeError("publisher must not be None")
+        if topic_path is None:
+            raise TypeError("topic_path must not be None")
+        self.publisher = publisher
+        self.topic_path = topic_path
+
+    def write(self, records: Iterator[Mapping[str, Any]], context: Any = None) -> None:
+        futures = []
+        for record in records:
+            data = record.get("data")
+            if data is None:
+                raise ValueError("Each record must carry 'data' bytes")
+            attributes = record.get("attributes", {})
+            future = self.publisher.publish(self.topic_path, data, **attributes)
+            futures.append(future)
+        # Block on each future so any publish error surfaces here.
+        for future in futures:
+            future.result()

--- a/data-pipeline-libraries/data-pipeline-gcp-pubsub/tests/test_io.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-pubsub/tests/test_io.py
@@ -1,0 +1,117 @@
+"""Tests for PubSubSource / PubSubSink — no real Pub/Sub."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from data_pipeline_gcp_pubsub import PubSubSink, PubSubSource
+
+
+# --- PubSubSource ---------------------------------------------------------
+
+def test_source_rejects_none_subscriber():
+    with pytest.raises(TypeError):
+        PubSubSource(None, "projects/p/subscriptions/s")
+
+
+def test_source_rejects_none_subscription():
+    with pytest.raises(TypeError):
+        PubSubSource(MagicMock(), None)
+
+
+def test_source_rejects_zero_max_messages():
+    with pytest.raises(ValueError):
+        PubSubSource(MagicMock(), "projects/p/subscriptions/s", max_messages=0)
+
+
+def test_source_yields_messages_then_acks():
+    subscriber = MagicMock()
+    msg1 = MagicMock()
+    msg1.data = b"payload-1"
+    msg1.attributes = {"k": "v"}
+    msg1.message_id = "id-1"
+    msg1.publish_time = "2026-01-15T10:00:00Z"
+    msg2 = MagicMock()
+    msg2.data = b"payload-2"
+    msg2.attributes = {}
+    msg2.message_id = "id-2"
+    msg2.publish_time = "2026-01-15T10:00:01Z"
+    received1 = MagicMock()
+    received1.message = msg1
+    received1.ack_id = "ack-1"
+    received2 = MagicMock()
+    received2.message = msg2
+    received2.ack_id = "ack-2"
+    response = MagicMock()
+    response.received_messages = [received1, received2]
+    subscriber.pull.return_value = response
+
+    source = PubSubSource(subscriber, "projects/p/subscriptions/s", max_messages=10)
+    records = list(source.read())
+
+    assert len(records) == 2
+    assert records[0]["data"] == b"payload-1"
+    assert records[0]["attributes"] == {"k": "v"}
+    assert records[1]["message_id"] == "id-2"
+    subscriber.acknowledge.assert_called_once()
+    ack_call = subscriber.acknowledge.call_args
+    assert ack_call.kwargs["request"]["ack_ids"] == ["ack-1", "ack-2"]
+
+
+def test_source_empty_pull_no_ack():
+    subscriber = MagicMock()
+    response = MagicMock()
+    response.received_messages = []
+    subscriber.pull.return_value = response
+
+    source = PubSubSource(subscriber, "projects/p/subscriptions/s")
+    records = list(source.read())
+
+    assert records == []
+    subscriber.acknowledge.assert_not_called()
+
+
+# --- PubSubSink -----------------------------------------------------------
+
+def test_sink_rejects_none_publisher():
+    with pytest.raises(TypeError):
+        PubSubSink(None, "projects/p/topics/t")
+
+
+def test_sink_rejects_none_topic():
+    with pytest.raises(TypeError):
+        PubSubSink(MagicMock(), None)
+
+
+def test_sink_publishes_each_record_and_awaits_futures():
+    publisher = MagicMock()
+    future1 = MagicMock()
+    future2 = MagicMock()
+    publisher.publish.side_effect = [future1, future2]
+
+    sink = PubSubSink(publisher, "projects/p/topics/t")
+    sink.write(iter([
+        {"data": b"msg-1", "attributes": {"k": "v"}},
+        {"data": b"msg-2"},
+    ]))
+
+    assert publisher.publish.call_count == 2
+    future1.result.assert_called_once()
+    future2.result.assert_called_once()
+
+
+def test_sink_rejects_record_without_data():
+    publisher = MagicMock()
+    sink = PubSubSink(publisher, "projects/p/topics/t")
+
+    with pytest.raises(ValueError):
+        sink.write(iter([{"attributes": {"k": "v"}}]))
+
+
+def test_sink_empty_iterator_no_publish():
+    publisher = MagicMock()
+    sink = PubSubSink(publisher, "projects/p/topics/t")
+    sink.write(iter([]))
+    publisher.publish.assert_not_called()


### PR DESCRIPTION
Sprint-3 wave-1. Closes the Python Stage 2 split for the 3 clean clients.

## What

- `data-pipeline-gcp-bigquery` — BigQueryWarehouse implements Warehouse (10 tests)
- `data-pipeline-gcp-gcs` — GcsBlobStore implements BlobStore (12 tests)
- `data-pipeline-gcp-pubsub` — PubSubSource + PubSubSink implement Source + Sink (10 tests)

**32 tests across 3 modules** via unittest.mock — no real GCP.

## Notes

- Legacy gcp-pipeline-core Python clients stay in place; new modules are clean Protocol impls for new code.
- merge() in BigQueryWarehouse raises NotImplementedError pending column-aware SQL — same caveat as Java sibling.