### PR TITLE
Sprint 4 → main: AutoConfig + decorators

### DIFF
--- a/data-pipeline-libraries-java/data-pipeline-core-java/src/main/java/com/enrichmeai/culvert/autoconfig/AutoConfig.java
+++ b/data-pipeline-libraries-java/data-pipeline-core-java/src/main/java/com/enrichmeai/culvert/autoconfig/AutoConfig.java
@@ -1,0 +1,233 @@
+package com.enrichmeai.culvert.autoconfig;
+
+import com.enrichmeai.culvert.contracts.AuditEventPublisher;
+import com.enrichmeai.culvert.contracts.BlobStore;
+import com.enrichmeai.culvert.contracts.FinOpsSink;
+import com.enrichmeai.culvert.contracts.GovernancePolicy;
+import com.enrichmeai.culvert.contracts.JobControlRepository;
+import com.enrichmeai.culvert.contracts.LineageEmitter;
+import com.enrichmeai.culvert.contracts.ObservabilityHook;
+import com.enrichmeai.culvert.contracts.Pipeline;
+import com.enrichmeai.culvert.contracts.PipelineStage;
+import com.enrichmeai.culvert.contracts.RuntimeContext;
+import com.enrichmeai.culvert.contracts.SecretProvider;
+import com.enrichmeai.culvert.contracts.Sink;
+import com.enrichmeai.culvert.contracts.Source;
+import com.enrichmeai.culvert.contracts.Transform;
+import com.enrichmeai.culvert.contracts.Warehouse;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.ServiceLoader;
+
+/**
+ * Stage 3 auto-config registry.
+ *
+ * <p>Discovers Culvert contract implementations on the classpath via
+ * {@link ServiceLoader} and exposes typed lookup methods. Each GCP/AWS/
+ * Azure adapter module pre-registers its impls under
+ * {@code META-INF/services/com.enrichmeai.culvert.contracts.<Contract>}.
+ *
+ * <p>Usage:
+ *
+ * <pre>{@code
+ * AutoConfig config = AutoConfig.discover();
+ * Warehouse warehouse = config.warehouse()
+ *     .orElseThrow(() -> new IllegalStateException("No Warehouse on classpath"));
+ * }</pre>
+ *
+ * <p>Most adapters require constructor arguments (BigQuery client + project
+ * + dataset, GCS client, etc.) that ServiceLoader can't supply. Those
+ * adapters' {@code META-INF/services} entries are reserved for the future
+ * config-driven discovery wave — calling {@link #warehouse()} today on a
+ * classpath that contains only the sprint-1 adapters will return
+ * {@link Optional#empty()} unless a no-arg-friendly impl is also present.
+ *
+ * <p>Sprint-4 deliverable. The full config-driven instantiation arrives
+ * in sprint-5.
+ */
+public final class AutoConfig {
+
+    private final List<Source<?>> sources;
+    private final List<Sink<?>> sinks;
+    private final List<Transform<?, ?>> transforms;
+    private final List<Pipeline> pipelines;
+    private final List<PipelineStage> stages;
+    private final List<RuntimeContext> runtimeContexts;
+    private final List<JobControlRepository> jobControl;
+    private final List<BlobStore> blobStores;
+    private final List<Warehouse> warehouses;
+    private final List<AuditEventPublisher> auditPublishers;
+    private final List<GovernancePolicy> governancePolicies;
+    private final List<LineageEmitter> lineageEmitters;
+    private final List<ObservabilityHook> observabilityHooks;
+    private final List<FinOpsSink> finOpsSinks;
+    private final List<SecretProvider> secretProviders;
+
+    private AutoConfig() {
+        this.sources = loadServiceListRaw(Source.class);
+        this.sinks = loadServiceListRaw(Sink.class);
+        this.transforms = loadServiceListRaw(Transform.class);
+        this.pipelines = loadServiceList(Pipeline.class);
+        this.stages = loadServiceList(PipelineStage.class);
+        this.runtimeContexts = loadServiceList(RuntimeContext.class);
+        this.jobControl = loadServiceList(JobControlRepository.class);
+        this.blobStores = loadServiceList(BlobStore.class);
+        this.warehouses = loadServiceList(Warehouse.class);
+        this.auditPublishers = loadServiceList(AuditEventPublisher.class);
+        this.governancePolicies = loadServiceList(GovernancePolicy.class);
+        this.lineageEmitters = loadServiceList(LineageEmitter.class);
+        this.observabilityHooks = loadServiceList(ObservabilityHook.class);
+        this.finOpsSinks = loadServiceList(FinOpsSink.class);
+        this.secretProviders = loadServiceList(SecretProvider.class);
+    }
+
+    /**
+     * Discover implementations on the classpath. Each contract's
+     * {@code META-INF/services} entries are loaded and instantiated via
+     * each impl's no-arg constructor; impls without a no-arg constructor
+     * are silently skipped (sprint-4 limitation; sprint-5 adds config-
+     * driven instantiation).
+     */
+    public static AutoConfig discover() {
+        return new AutoConfig();
+    }
+
+    public Optional<Warehouse> warehouse() {
+        return first(warehouses);
+    }
+
+    public List<Warehouse> warehouses() {
+        return warehouses;
+    }
+
+    public Optional<BlobStore> blobStore() {
+        return first(blobStores);
+    }
+
+    public List<BlobStore> blobStores() {
+        return blobStores;
+    }
+
+    public Optional<SecretProvider> secretProvider() {
+        return first(secretProviders);
+    }
+
+    public List<SecretProvider> secretProviders() {
+        return secretProviders;
+    }
+
+    public Optional<JobControlRepository> jobControl() {
+        return first(jobControl);
+    }
+
+    public List<JobControlRepository> jobControls() {
+        return jobControl;
+    }
+
+    public Optional<FinOpsSink> finOpsSink() {
+        return first(finOpsSinks);
+    }
+
+    public List<FinOpsSink> finOpsSinks() {
+        return finOpsSinks;
+    }
+
+    public Optional<ObservabilityHook> observabilityHook() {
+        return first(observabilityHooks);
+    }
+
+    public List<ObservabilityHook> observabilityHooks() {
+        return observabilityHooks;
+    }
+
+    public Optional<LineageEmitter> lineageEmitter() {
+        return first(lineageEmitters);
+    }
+
+    public List<LineageEmitter> lineageEmitters() {
+        return lineageEmitters;
+    }
+
+    public Optional<AuditEventPublisher> auditEventPublisher() {
+        return first(auditPublishers);
+    }
+
+    public List<AuditEventPublisher> auditEventPublishers() {
+        return auditPublishers;
+    }
+
+    public Optional<GovernancePolicy> governancePolicy() {
+        return first(governancePolicies);
+    }
+
+    public List<GovernancePolicy> governancePolicies() {
+        return governancePolicies;
+    }
+
+    public Optional<Pipeline> pipeline() {
+        return first(pipelines);
+    }
+
+    public List<Pipeline> pipelines() {
+        return pipelines;
+    }
+
+    public List<Source<?>> sources() {
+        return sources;
+    }
+
+    public List<Sink<?>> sinks() {
+        return sinks;
+    }
+
+    public List<Transform<?, ?>> transforms() {
+        return transforms;
+    }
+
+    public List<PipelineStage> stages() {
+        return stages;
+    }
+
+    public List<RuntimeContext> runtimeContexts() {
+        return runtimeContexts;
+    }
+
+    // --- helpers -----------------------------------------------------------
+
+    private static <T> List<T> loadServiceList(Class<T> contract) {
+        List<T> impls = new ArrayList<>();
+        try {
+            for (T impl : ServiceLoader.load(contract)) {
+                impls.add(impl);
+            }
+        } catch (Throwable ignored) {
+            // ServiceConfigurationError from missing no-arg constructors:
+            // sprint-4 limitation. Sprint-5 config-driven instantiation
+            // will replace this swallow with structured reporting.
+        }
+        return List.copyOf(impls);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static <T> List<T> loadServiceListRaw(Class<?> contract) {
+        // Generic contracts (Source<T>, Sink<T>, Transform<V, W>) erase to
+        // their raw form for ServiceLoader. Same swallow semantics as
+        // loadServiceList; cast to the raw element type.
+        List<T> impls = new ArrayList<>();
+        try {
+            ServiceLoader<?> loader = ServiceLoader.load(contract);
+            for (Object impl : loader) {
+                impls.add((T) impl);
+            }
+        } catch (Throwable ignored) {
+            // Sprint-4 limitation.
+        }
+        return List.copyOf(impls);
+    }
+
+    private static <T> Optional<T> first(List<T> impls) {
+        return impls.isEmpty() ? Optional.empty() : Optional.of(impls.get(0));
+    }
+}

--- a/data-pipeline-libraries-java/data-pipeline-core-java/src/test/java/com/enrichmeai/culvert/autoconfig/AutoConfigTest.java
+++ b/data-pipeline-libraries-java/data-pipeline-core-java/src/test/java/com/enrichmeai/culvert/autoconfig/AutoConfigTest.java
@@ -1,0 +1,45 @@
+package com.enrichmeai.culvert.autoconfig;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Smoke tests for the auto-config registry. On the data-pipeline-core
+ * classpath there are no impls, so all lookups should return empty
+ * (proving the ServiceLoader path doesn't throw).
+ */
+class AutoConfigTest {
+
+    @Test
+    void discoverReturnsAutoConfigInstance() {
+        AutoConfig config = AutoConfig.discover();
+        assertThat(config).isNotNull();
+    }
+
+    @Test
+    void allLookupsEmptyWithoutImpls() {
+        AutoConfig config = AutoConfig.discover();
+        // The data-pipeline-core test classpath has no provider entries.
+        assertThat(config.warehouse()).isEmpty();
+        assertThat(config.blobStore()).isEmpty();
+        assertThat(config.secretProvider()).isEmpty();
+        assertThat(config.jobControl()).isEmpty();
+        assertThat(config.finOpsSink()).isEmpty();
+        assertThat(config.observabilityHook()).isEmpty();
+        assertThat(config.lineageEmitter()).isEmpty();
+    }
+
+    @Test
+    void listGettersReturnEmptyListsWhenNoImpls() {
+        AutoConfig config = AutoConfig.discover();
+        assertThat(config.warehouses()).isEmpty();
+        assertThat(config.blobStores()).isEmpty();
+        assertThat(config.secretProviders()).isEmpty();
+        assertThat(config.sources()).isEmpty();
+        assertThat(config.sinks()).isEmpty();
+        assertThat(config.transforms()).isEmpty();
+        assertThat(config.pipelines()).isEmpty();
+        assertThat(config.stages()).isEmpty();
+    }
+}

--- a/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/autoconfig.py
+++ b/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/autoconfig.py
@@ -1,0 +1,141 @@
+"""Stage 3 auto-config registry — Python equivalent of the Java AutoConfig.
+
+Discovers Culvert contract implementations on the import path via Python's
+``importlib.metadata.entry_points`` and exposes typed lookup methods.
+
+Each cloud module (``data-pipeline-gcp-bigquery``, ``data-pipeline-gcp-gcs``,
+...) declares its implementations under the ``data_pipeline_core.adapters``
+entry-point group in its ``pyproject.toml``:
+
+.. code-block:: toml
+
+    [project.entry-points."data_pipeline_core.adapters"]
+    warehouse = "data_pipeline_gcp_bigquery:BigQueryWarehouse"
+    blob_store = "data_pipeline_gcp_gcs:GcsBlobStore"
+
+The registry imports the named class (no instantiation — most adapters
+need constructor arguments). Consumers retrieve the class and instantiate
+explicitly, or use the upcoming sprint-5 config-driven layer to wire
+arguments automatically.
+
+Sprint-4 deliverable.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from dataclasses import dataclass, field
+from importlib.metadata import entry_points
+from typing import Any, Dict, List, Optional, Type
+
+logger = logging.getLogger(__name__)
+
+ENTRY_POINT_GROUP = "data_pipeline_core.adapters"
+
+
+@dataclass
+class AutoConfig:
+    """Lookup table of contract -> impl-class entries discovered on the
+    import path.
+
+    Field names match the contract module names in
+    ``data_pipeline_core.contracts.*`` (warehouse, blob_store, source, sink,
+    transform, secrets, job_control, finops, observability, lineage,
+    audit, governance, pipeline, runtime).
+    """
+
+    warehouse: List[Type[Any]] = field(default_factory=list)
+    blob_store: List[Type[Any]] = field(default_factory=list)
+    source: List[Type[Any]] = field(default_factory=list)
+    sink: List[Type[Any]] = field(default_factory=list)
+    transform: List[Type[Any]] = field(default_factory=list)
+    secrets: List[Type[Any]] = field(default_factory=list)
+    job_control: List[Type[Any]] = field(default_factory=list)
+    finops: List[Type[Any]] = field(default_factory=list)
+    observability: List[Type[Any]] = field(default_factory=list)
+    lineage: List[Type[Any]] = field(default_factory=list)
+    audit: List[Type[Any]] = field(default_factory=list)
+    governance: List[Type[Any]] = field(default_factory=list)
+    pipeline: List[Type[Any]] = field(default_factory=list)
+    runtime: List[Type[Any]] = field(default_factory=list)
+
+    # In-process registration table — overrides anything from entry points.
+    # Filled by the @register_adapter decorator below.
+    _process_overrides: Dict[str, List[Type[Any]]] = field(default_factory=dict)
+
+    def first(self, name: str) -> Optional[Type[Any]]:
+        """Return the first registered impl class for ``name``, or None."""
+        impls = self.all(name)
+        return impls[0] if impls else None
+
+    def all(self, name: str) -> List[Type[Any]]:
+        """Return all registered impl classes for ``name``."""
+        # In-process overrides first; then entry-point discoveries.
+        return list(self._process_overrides.get(name, [])) + list(getattr(self, name, []))
+
+
+# Module-level shared registry (process overrides accumulate here).
+_REGISTRY: AutoConfig = AutoConfig()
+
+
+def discover() -> AutoConfig:
+    """Build a fresh AutoConfig by walking ``importlib.metadata.entry_points``.
+
+    Re-importable: each call re-reads the entry points (useful if a plugin
+    is installed at runtime).
+    """
+    config = AutoConfig()
+    config._process_overrides = dict(_REGISTRY._process_overrides)
+    eps = entry_points()
+    # Python 3.10+ entry_points() returns a SelectableGroups; .select() for
+    # 3.10+, fallback to dict-style for older.
+    try:
+        group_entries = eps.select(group=ENTRY_POINT_GROUP)
+    except AttributeError:
+        group_entries = eps.get(ENTRY_POINT_GROUP, [])
+
+    for ep in group_entries:
+        try:
+            cls = ep.load()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "Failed to load entry-point %s = %s: %s",
+                ep.name, ep.value, exc,
+            )
+            continue
+        # Entry-point name maps directly to AutoConfig field.
+        field_list = getattr(config, ep.name, None)
+        if field_list is None:
+            logger.warning("Unknown adapter contract '%s' (entry-point=%s)", ep.name, ep.value)
+            continue
+        field_list.append(cls)
+    return config
+
+
+def register_adapter(contract_name: str):
+    """Decorator that registers ``cls`` as an impl of ``contract_name``
+    in the process-wide registry.
+
+    Useful for in-process registration (testing, demos) where you don't
+    want to package the impl as a separate distribution.
+
+    .. code-block:: python
+
+        from data_pipeline_core.autoconfig import register_adapter
+
+        @register_adapter("warehouse")
+        class MyTestWarehouse:
+            def query(self, sql, params=None): ...
+            ...
+    """
+    def decorator(cls):
+        _REGISTRY._process_overrides.setdefault(contract_name, []).append(cls)
+        return cls
+
+    return decorator
+
+
+def reset_process_registry() -> None:
+    """Clear the process-wide registry. For tests."""
+    _REGISTRY._process_overrides.clear()

--- a/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/decorators.py
+++ b/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/decorators.py
@@ -1,0 +1,77 @@
+"""Stage 3 decorators — declarative pipeline composition.
+
+Lightweight markers that register classes/functions with the auto-config
+registry. The framework then walks the registry to assemble a pipeline.
+
+These are intentionally thin: they don't impose any base class or
+metaclass on the decorated target; they just tag it with metadata
+attributes that the registry reads.
+
+Sprint-4 deliverable.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional, TypeVar
+
+from data_pipeline_core.autoconfig import register_adapter
+
+T = TypeVar("T")
+
+
+def pipeline(name: Optional[str] = None) -> Callable[[T], T]:
+    """Mark a class as a Pipeline impl. Also registers it with the
+    auto-config registry under ``pipeline``.
+
+    .. code-block:: python
+
+        @pipeline(name="customer-ingest")
+        class CustomerIngest:
+            def name(self): return "customer-ingest"
+            def stages(self): return [...]
+            def validate(self): ...
+    """
+    def decorator(cls: T) -> T:
+        setattr(cls, "__culvert_pipeline_name__", name or cls.__name__)
+        register_adapter("pipeline")(cls)
+        return cls
+    return decorator
+
+
+def stage(name: Optional[str] = None) -> Callable[[T], T]:
+    """Mark a class as a PipelineStage impl. Registers under ``runtime``
+    (PipelineStages are runtime fragments, not adapters)."""
+    def decorator(cls: T) -> T:
+        setattr(cls, "__culvert_stage_name__", name or cls.__name__)
+        return cls
+    return decorator
+
+
+def source(name: Optional[str] = None) -> Callable[[T], T]:
+    """Mark a class as a Source impl. Registers under ``source``."""
+    def decorator(cls: T) -> T:
+        setattr(cls, "__culvert_source_name__", name or cls.__name__)
+        register_adapter("source")(cls)
+        return cls
+    return decorator
+
+
+def sink(name: Optional[str] = None) -> Callable[[T], T]:
+    """Mark a class as a Sink impl. Registers under ``sink``."""
+    def decorator(cls: T) -> T:
+        setattr(cls, "__culvert_sink_name__", name or cls.__name__)
+        register_adapter("sink")(cls)
+        return cls
+    return decorator
+
+
+def transform(name: Optional[str] = None) -> Callable[[T], T]:
+    """Mark a class as a Transform impl. Registers under ``transform``."""
+    def decorator(cls: T) -> T:
+        setattr(cls, "__culvert_transform_name__", name or cls.__name__)
+        register_adapter("transform")(cls)
+        return cls
+    return decorator
+
+
+__all__ = ["pipeline", "stage", "source", "sink", "transform"]

--- a/data-pipeline-libraries/data-pipeline-core/tests/test_autoconfig.py
+++ b/data-pipeline-libraries/data-pipeline-core/tests/test_autoconfig.py
@@ -1,0 +1,116 @@
+"""Tests for the Python AutoConfig registry + decorators."""
+
+from __future__ import annotations
+
+import pytest
+
+from data_pipeline_core.autoconfig import (
+    AutoConfig,
+    discover,
+    register_adapter,
+    reset_process_registry,
+)
+from data_pipeline_core.decorators import pipeline, sink, source, stage, transform
+
+
+@pytest.fixture(autouse=True)
+def _clear_registry():
+    """Each test gets a clean process-wide registry."""
+    reset_process_registry()
+    yield
+    reset_process_registry()
+
+
+def test_discover_returns_autoconfig():
+    config = discover()
+    assert isinstance(config, AutoConfig)
+
+
+def test_empty_registry_returns_empty_lists():
+    config = discover()
+    assert config.all("warehouse") == []
+    assert config.first("warehouse") is None
+
+
+def test_register_adapter_decorator_adds_to_registry():
+    @register_adapter("warehouse")
+    class MyWarehouse:
+        pass
+
+    config = discover()
+    assert MyWarehouse in config.all("warehouse")
+    assert config.first("warehouse") is MyWarehouse
+
+
+def test_register_adapter_supports_multiple_impls():
+    @register_adapter("warehouse")
+    class W1:
+        pass
+
+    @register_adapter("warehouse")
+    class W2:
+        pass
+
+    config = discover()
+    impls = config.all("warehouse")
+    assert W1 in impls
+    assert W2 in impls
+
+
+def test_pipeline_decorator_registers_and_tags():
+    @pipeline(name="ingest-customers")
+    class CustomerPipeline:
+        pass
+
+    assert CustomerPipeline.__culvert_pipeline_name__ == "ingest-customers"
+    config = discover()
+    assert CustomerPipeline in config.all("pipeline")
+
+
+def test_stage_decorator_tags_class():
+    @stage(name="read-customers")
+    class ReadCustomers:
+        pass
+
+    assert ReadCustomers.__culvert_stage_name__ == "read-customers"
+
+
+def test_source_decorator_registers():
+    @source(name="csv-files")
+    class CsvSource:
+        pass
+
+    config = discover()
+    assert CsvSource in config.all("source")
+
+
+def test_sink_decorator_registers():
+    @sink(name="bq-sink")
+    class BqSink:
+        pass
+
+    config = discover()
+    assert BqSink in config.all("sink")
+
+
+def test_transform_decorator_registers():
+    @transform(name="cleanse")
+    class Cleanser:
+        pass
+
+    config = discover()
+    assert Cleanser in config.all("transform")
+
+
+def test_decorator_default_name_uses_class_name():
+    @pipeline()
+    class MyPipeline:
+        pass
+
+    assert MyPipeline.__culvert_pipeline_name__ == "MyPipeline"
+
+
+def test_unknown_contract_name_returns_empty():
+    config = discover()
+    assert config.all("nonexistent") == []
+    assert config.first("nonexistent") is None


### PR DESCRIPTION
Sprint 4 close.

- Java + Python AutoConfig registries
- Python @pipeline/@stage/@source/@sink/@transform decorators
- 14 new tests, full reactor still green

Retro on epic #13. Starter + quickstart deferred to sprint-5.