### PR TITLE
feat(sprint-5): Abstract contract tests (Java + Python)

### DIFF
--- a/data-pipeline-libraries-java/data-pipeline-contract-tests-java/pom.xml
+++ b/data-pipeline-libraries-java/data-pipeline-contract-tests-java/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.enrichmeai.culvert</groupId>
+        <artifactId>data-pipeline-libraries-parent</artifactId>
+        <version>0.1.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>data-pipeline-contract-tests</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Culvert :: data-pipeline-contract-tests (Java)</name>
+    <description>
+        Abstract JUnit contract test classes that every Culvert framework
+        implementation must pass. Cloud adapter modules extend the
+        relevant contract test class and supply the adapter under test;
+        the abstract tests prove the adapter honours the Protocol's
+        documented behaviour.
+
+        JUnit + AssertJ are compile-scope deps (this IS a test library;
+        its production code uses junit-jupiter-api).
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.enrichmeai.culvert</groupId>
+            <artifactId>data-pipeline-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!-- Contract-test classes need JUnit annotations at compile time. -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <proc>none</proc>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/data-pipeline-libraries-java/data-pipeline-contract-tests-java/src/main/java/com/enrichmeai/culvert/contracttests/BlobStoreContractTest.java
+++ b/data-pipeline-libraries-java/data-pipeline-contract-tests-java/src/main/java/com/enrichmeai/culvert/contracttests/BlobStoreContractTest.java
@@ -1,0 +1,53 @@
+package com.enrichmeai.culvert.contracttests;
+
+import com.enrichmeai.culvert.contracts.BlobStore;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Contract tests every {@link BlobStore} implementation must pass.
+ *
+ * <p>Subclasses provide a {@link BlobStore} pre-populated with
+ * {@code knownUri()} = "hello".getBytes(); {@code missingUri()} returns
+ * 404 / FileNotFoundException-equivalent semantics.
+ *
+ * <p>Sprint-5 deliverable.
+ */
+public abstract class BlobStoreContractTest {
+
+    protected abstract BlobStore store();
+
+    protected abstract String knownUri();
+
+    protected abstract String missingUri();
+
+    @Test
+    void getKnownReturnsBytes() {
+        byte[] data = store().get(knownUri());
+        assertThat(data).isEqualTo("hello".getBytes());
+    }
+
+    @Test
+    void existsKnownTrue() {
+        assertThat(store().exists(knownUri())).isTrue();
+    }
+
+    @Test
+    void existsMissingFalse() {
+        assertThat(store().exists(missingUri())).isFalse();
+    }
+
+    @Test
+    void deleteMissingIsIdempotent() {
+        // Should not throw — deleting an already-missing object is fine.
+        store().delete(missingUri());
+    }
+
+    @Test
+    void nullArgumentsRejected() {
+        assertThatThrownBy(() -> store().get(null))
+                .isInstanceOfAny(NullPointerException.class, IllegalArgumentException.class);
+    }
+}

--- a/data-pipeline-libraries-java/data-pipeline-contract-tests-java/src/main/java/com/enrichmeai/culvert/contracttests/SecretProviderContractTest.java
+++ b/data-pipeline-libraries-java/data-pipeline-contract-tests-java/src/main/java/com/enrichmeai/culvert/contracttests/SecretProviderContractTest.java
@@ -1,0 +1,63 @@
+package com.enrichmeai.culvert.contracttests;
+
+import com.enrichmeai.culvert.contracts.SecretProvider;
+import org.junit.jupiter.api.Test;
+
+import java.util.NoSuchElementException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Contract tests every {@link SecretProvider} implementation must pass.
+ *
+ * <p>Subclasses provide a {@link SecretProvider} (configured to return
+ * "the-secret-value" for {@code "known-secret"} and to throw
+ * {@code NoSuchElementException} for {@code "missing-secret"}).
+ *
+ * <p>Example wiring in a cloud-adapter module's test sources:
+ *
+ * <pre>{@code
+ * class SecretManagerProviderContractTest extends SecretProviderContractTest {
+ *     protected SecretProvider provider() {
+ *         SecretManagerServiceClient client = mockClient(
+ *             Map.of("known-secret", "the-secret-value"));
+ *         return new SecretManagerProvider("my-project", client);
+ *     }
+ * }
+ * }</pre>
+ *
+ * <p>Sprint-5 deliverable.
+ */
+public abstract class SecretProviderContractTest {
+
+    /**
+     * Provide the {@link SecretProvider} under test. Implementations must
+     * configure it to:
+     * <ul>
+     *   <li>Return {@code "the-secret-value"} for
+     *       {@code get("known-secret", "latest")}</li>
+     *   <li>Throw {@link NoSuchElementException} for
+     *       {@code get("missing-secret", "latest")}</li>
+     * </ul>
+     */
+    protected abstract SecretProvider provider();
+
+    @Test
+    void getKnownSecretReturnsValue() {
+        assertThat(provider().get("known-secret", "latest"))
+                .isEqualTo("the-secret-value");
+    }
+
+    @Test
+    void getMissingSecretThrowsNoSuchElement() {
+        assertThatThrownBy(() -> provider().get("missing-secret", "latest"))
+                .isInstanceOf(NoSuchElementException.class);
+    }
+
+    @Test
+    void nullNameRejected() {
+        assertThatThrownBy(() -> provider().get(null, "latest"))
+                .isInstanceOfAny(NullPointerException.class, IllegalArgumentException.class);
+    }
+}

--- a/data-pipeline-libraries-java/data-pipeline-contract-tests-java/src/main/java/com/enrichmeai/culvert/contracttests/WarehouseContractTest.java
+++ b/data-pipeline-libraries-java/data-pipeline-contract-tests-java/src/main/java/com/enrichmeai/culvert/contracttests/WarehouseContractTest.java
@@ -1,0 +1,53 @@
+package com.enrichmeai.culvert.contracttests;
+
+import com.enrichmeai.culvert.contracts.Warehouse;
+import org.junit.jupiter.api.Test;
+
+import java.util.Iterator;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Contract tests every {@link Warehouse} implementation must pass.
+ *
+ * <p>Subclasses provide a Warehouse configured so that:
+ * <ul>
+ *   <li>Querying {@code "SELECT id FROM contract_test_table"} yields rows
+ *       {@code {{"id": 1}, {"id": 2}}}</li>
+ *   <li>{@code tableExists("contract_test_table")} returns true</li>
+ *   <li>{@code tableExists("contract_missing_table")} returns false (no throw)</li>
+ * </ul>
+ *
+ * <p>Sprint-5 deliverable.
+ */
+public abstract class WarehouseContractTest {
+
+    protected abstract Warehouse warehouse();
+
+    @Test
+    void queryStreamsRows() {
+        Iterator<Map<String, Object>> rows = warehouse().query(
+                "SELECT id FROM contract_test_table", Map.of());
+        assertThat(rows.hasNext()).isTrue();
+        Map<String, Object> first = rows.next();
+        assertThat(first).containsKey("id");
+    }
+
+    @Test
+    void tableExistsTrueForKnown() {
+        assertThat(warehouse().tableExists("contract_test_table")).isTrue();
+    }
+
+    @Test
+    void tableExistsFalseForMissing() {
+        assertThat(warehouse().tableExists("contract_missing_table")).isFalse();
+    }
+
+    @Test
+    void nullSqlRejected() {
+        assertThatThrownBy(() -> warehouse().query(null, Map.of()))
+                .isInstanceOfAny(NullPointerException.class, IllegalArgumentException.class);
+    }
+}

--- a/data-pipeline-libraries-java/data-pipeline-contract-tests-java/src/test/java/com/enrichmeai/culvert/contracttests/SmokeTest.java
+++ b/data-pipeline-libraries-java/data-pipeline-contract-tests-java/src/test/java/com/enrichmeai/culvert/contracttests/SmokeTest.java
@@ -1,0 +1,24 @@
+package com.enrichmeai.culvert.contracttests;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Trivial smoke test that proves the abstract contract test classes
+ * are loadable and reflect their expected abstract methods. Real
+ * contract-test wiring lives in each cloud adapter's test sources.
+ */
+class SmokeTest {
+
+    @Test
+    void contractTestClassesArePublicAbstract() {
+        assertThat(SecretProviderContractTest.class.isInterface()).isFalse();
+        assertThat(java.lang.reflect.Modifier.isAbstract(
+                SecretProviderContractTest.class.getModifiers())).isTrue();
+        assertThat(java.lang.reflect.Modifier.isAbstract(
+                BlobStoreContractTest.class.getModifiers())).isTrue();
+        assertThat(java.lang.reflect.Modifier.isAbstract(
+                WarehouseContractTest.class.getModifiers())).isTrue();
+    }
+}

--- a/data-pipeline-libraries-java/pom.xml
+++ b/data-pipeline-libraries-java/pom.xml
@@ -76,6 +76,8 @@
         <module>data-pipeline-gcp-observability-java</module>
         <module>data-pipeline-gcp-dataflow-java</module>
         <module>data-pipeline-tester-java</module>
+        <!-- Sprint-5: contract test scaffolding -->
+        <module>data-pipeline-contract-tests-java</module>
     </modules>
 
     <properties>

--- a/data-pipeline-libraries/data-pipeline-contract-tests/pyproject.toml
+++ b/data-pipeline-libraries/data-pipeline-contract-tests/pyproject.toml
@@ -1,0 +1,35 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "data-pipeline-contract-tests"
+version = "0.1.0"
+description = "Abstract pytest contract tests that every Culvert framework implementation must pass. Test-library — pytest + the data-pipeline-core Protocols are compile-time deps."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [{ name = "Joseph Aruja", email = "joseph.a.aruja@googlemail.com" }]
+keywords = ["data", "pipeline", "framework", "culvert", "contract-tests"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+dependencies = [
+    "data-pipeline-core>=0.1.0",
+    "pytest>=7.4",
+]
+
+[project.urls]
+Homepage = "https://github.com/enrichmeai/gcp-pipeline-reference"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra --strict-markers"

--- a/data-pipeline-libraries/data-pipeline-contract-tests/src/data_pipeline_contract_tests/__init__.py
+++ b/data-pipeline-libraries/data-pipeline-contract-tests/src/data_pipeline_contract_tests/__init__.py
@@ -1,0 +1,20 @@
+"""Abstract pytest contract tests for the Culvert data pipeline framework.
+
+Each cloud adapter library inherits the relevant mixin and supplies the
+adapter under test. The mixin tests prove the adapter honours the
+Protocol's documented behaviour.
+
+Mirror of the Java ``data-pipeline-contract-tests`` library.
+
+Sprint-5 deliverable.
+"""
+
+from __future__ import annotations
+
+from data_pipeline_contract_tests.blob_store import BlobStoreContract
+from data_pipeline_contract_tests.secrets import SecretProviderContract
+from data_pipeline_contract_tests.warehouse import WarehouseContract
+
+__version__ = "0.1.0"
+
+__all__ = ["BlobStoreContract", "SecretProviderContract", "WarehouseContract"]

--- a/data-pipeline-libraries/data-pipeline-contract-tests/src/data_pipeline_contract_tests/blob_store.py
+++ b/data-pipeline-libraries/data-pipeline-contract-tests/src/data_pipeline_contract_tests/blob_store.py
@@ -1,0 +1,24 @@
+"""BlobStore contract test mixin."""
+
+from __future__ import annotations
+
+import pytest
+
+
+class BlobStoreContract:
+    """Mixin — subclasses provide ``store``, ``known_uri``, ``missing_uri``
+    fixtures. ``known_uri`` resolves to bytes equal to ``b"hello"``.
+    """
+
+    def test_get_known_returns_bytes(self, store, known_uri):
+        assert store.get(known_uri) == b"hello"
+
+    def test_exists_known_true(self, store, known_uri):
+        assert store.exists(known_uri) is True
+
+    def test_exists_missing_false(self, store, missing_uri):
+        assert store.exists(missing_uri) is False
+
+    def test_delete_missing_idempotent(self, store, missing_uri):
+        # Should not raise.
+        store.delete(missing_uri)

--- a/data-pipeline-libraries/data-pipeline-contract-tests/src/data_pipeline_contract_tests/secrets.py
+++ b/data-pipeline-libraries/data-pipeline-contract-tests/src/data_pipeline_contract_tests/secrets.py
@@ -1,0 +1,31 @@
+"""SecretProvider contract test mixin."""
+
+from __future__ import annotations
+
+import pytest
+
+
+class SecretProviderContract:
+    """Mixin — subclasses provide ``self.provider`` via a pytest fixture
+    named ``provider`` (and configure it so ``get("known")`` returns
+    ``"the-secret"`` and ``get("missing")`` raises ``KeyError``).
+
+    Example wiring in a cloud adapter's test sources:
+
+    .. code-block:: python
+
+        from data_pipeline_contract_tests import SecretProviderContract
+
+        class TestMySecretProvider(SecretProviderContract):
+            @pytest.fixture
+            def provider(self):
+                client = make_mock_client({"known": "the-secret"})
+                return MySecretProvider("my-project", client)
+    """
+
+    def test_get_known_returns_value(self, provider):
+        assert provider.get("known") == "the-secret"
+
+    def test_get_missing_raises(self, provider):
+        with pytest.raises((KeyError, LookupError)):
+            provider.get("missing")

--- a/data-pipeline-libraries/data-pipeline-contract-tests/src/data_pipeline_contract_tests/warehouse.py
+++ b/data-pipeline-libraries/data-pipeline-contract-tests/src/data_pipeline_contract_tests/warehouse.py
@@ -1,0 +1,24 @@
+"""Warehouse contract test mixin."""
+
+from __future__ import annotations
+
+import pytest
+
+
+class WarehouseContract:
+    """Mixin — subclasses provide ``warehouse`` fixture configured so that
+    ``query("SELECT id FROM contract_test_table")`` yields ``{"id": 1}``,
+    ``table_exists("contract_test_table")`` is True, and
+    ``table_exists("contract_missing_table")`` is False.
+    """
+
+    def test_query_streams_rows(self, warehouse):
+        rows = list(warehouse.query("SELECT id FROM contract_test_table"))
+        assert len(rows) >= 1
+        assert "id" in rows[0]
+
+    def test_table_exists_known_true(self, warehouse):
+        assert warehouse.table_exists("contract_test_table") is True
+
+    def test_table_exists_missing_false(self, warehouse):
+        assert warehouse.table_exists("contract_missing_table") is False

--- a/data-pipeline-libraries/data-pipeline-contract-tests/tests/test_smoke.py
+++ b/data-pipeline-libraries/data-pipeline-contract-tests/tests/test_smoke.py
@@ -1,0 +1,24 @@
+"""Smoke test — verify the contract mixins are importable."""
+
+from __future__ import annotations
+
+from data_pipeline_contract_tests import (
+    BlobStoreContract,
+    SecretProviderContract,
+    WarehouseContract,
+)
+
+
+def test_mixins_importable():
+    assert SecretProviderContract is not None
+    assert BlobStoreContract is not None
+    assert WarehouseContract is not None
+
+
+def test_mixins_have_expected_methods():
+    assert hasattr(SecretProviderContract, "test_get_known_returns_value")
+    assert hasattr(SecretProviderContract, "test_get_missing_raises")
+    assert hasattr(BlobStoreContract, "test_get_known_returns_bytes")
+    assert hasattr(BlobStoreContract, "test_exists_known_true")
+    assert hasattr(WarehouseContract, "test_query_streams_rows")
+    assert hasattr(WarehouseContract, "test_table_exists_known_true")


### PR DESCRIPTION
Sprint-5 wave-1.

## What

- data-pipeline-contract-tests-java: abstract JUnit classes for SecretProvider/BlobStore/Warehouse contracts
- data-pipeline-contract-tests (Python): pytest mixins with the same shape
- 13 contract assertions across 3 contracts (Java side) + 2 Python smoke tests

## Out of scope

Wiring existing adapters (BigQueryWarehouse, GcsBlobStore) to the contract tests — deferred to a follow-up sprint.