### PR TITLE
feat(sprint-6): WireMock UAT harness

### DIFF
--- a/uat/README.md
+++ b/uat/README.md
@@ -1,0 +1,55 @@
+# Culvert UAT harness — internal-demo only
+
+Sprint-6 deliverable. Provides a WireMock-based mock-service harness for running end-to-end demos of the framework without live cloud accounts or credentials.
+
+**Internal-demo only.** Not a customer-facing UAT environment.
+
+## What this provides
+
+- A single `docker-compose.uat.yml` standing up [WireMock 3.5.4](https://wiremock.org/) on `localhost:8080`.
+- Three pre-built mock endpoints (`uat/wiremock/mappings/`):
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `POST /oauth2/token` | mock OAuth2 token endpoint | Demo of authenticated downstream calls |
+| `POST /webhooks/pipeline-event` | mock webhook receiver | Demo of audit / lineage emission via HTTP |
+| `GET /api/v1/health` | mock health check | Demo of orchestration polling |
+
+## What this does NOT provide
+
+- **Mocks for GCP Pub/Sub, BigQuery, Cloud Storage.** Those clients use gRPC; Mockito at the SDK level is the right tool, and unit tests in each `data-pipeline-gcp-*-java` module already do that.
+- A wired sample pipeline that demonstrates a full flow against these mocks (deferred to sprint-7+).
+
+## Running
+
+```bash
+cd uat
+docker-compose -f docker-compose.uat.yml up -d
+
+# Sanity check
+curl -s http://localhost:8080/api/v1/health | jq
+
+# Mock an OAuth2 token
+curl -s -X POST http://localhost:8080/oauth2/token | jq
+
+# Mock a webhook submission
+curl -s -X POST http://localhost:8080/webhooks/pipeline-event \
+  -H "Authorization: Bearer uat-mock-access-token-1234" \
+  -d '{"event": "stage.completed", "run_id": "demo-1"}' | jq
+
+# WireMock admin
+curl -s http://localhost:8080/__admin/mappings | jq
+
+# Tear down
+docker-compose -f docker-compose.uat.yml down
+```
+
+## Adding more mocks
+
+Drop a JSON file into `uat/wiremock/mappings/`. WireMock auto-loads on container start. See the [WireMock JSON spec](https://wiremock.org/docs/stubbing/) for the shape.
+
+For dynamic templated responses, mappings can reference `{{request.body}}`, `{{randomValue}}`, and other helpers — see `webhook-event.json` for an example using a templated UUID.
+
+## CI considerations
+
+This harness is local-developer-only at sprint-6 close. CI integration (a make target that spins WireMock up, runs the framework's integration tests against it, tears down) is sprint-7+ scope. CI workflows themselves are currently disabled (#14) to save Actions minutes during the sprint phase.

--- a/uat/docker-compose.uat.yml
+++ b/uat/docker-compose.uat.yml
@@ -1,0 +1,40 @@
+# Culvert UAT harness — internal-demo only.
+#
+# Stands up the mock HTTP services that the framework needs for a
+# realistic end-to-end demo without live GCP/AWS/Azure credentials.
+#
+# The GCP Pub/Sub, BigQuery, and Cloud Storage clients are gRPC and are
+# mocked at the SDK level via Mockito in unit/integration tests. WireMock
+# here is for HTTP-style services that surface around the framework
+# (auth gateways, external REST APIs, webhooks). Sprint-6 ships the
+# scaffolding; sample-pipeline demos and the make uat-demo target are
+# follow-up scope.
+#
+# Usage:
+#   cd uat && docker-compose -f docker-compose.uat.yml up -d
+#   curl http://localhost:8080/oauth2/token  # see wiremock/mappings/
+#   docker-compose -f docker-compose.uat.yml down
+#
+# Sprint-6 deliverable. Issue #16.
+
+version: "3.8"
+
+services:
+  wiremock:
+    image: wiremock/wiremock:3.5.4
+    container_name: culvert-uat-wiremock
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./wiremock/mappings:/home/wiremock/mappings:ro
+      - ./wiremock/__files:/home/wiremock/__files:ro
+    command:
+      - --port=8080
+      - --verbose
+      - --global-response-templating
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/__admin/health || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 5s

--- a/uat/wiremock/mappings/auth-token.json
+++ b/uat/wiremock/mappings/auth-token.json
@@ -1,0 +1,18 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "/oauth2/token"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "access_token": "uat-mock-access-token-1234",
+      "token_type": "Bearer",
+      "expires_in": 3600,
+      "scope": "openid profile email"
+    }
+  }
+}

--- a/uat/wiremock/mappings/health.json
+++ b/uat/wiremock/mappings/health.json
@@ -1,0 +1,17 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "/api/v1/health"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "status": "ok",
+      "uptime_seconds": 1234,
+      "version": "0.1.0"
+    }
+  }
+}

--- a/uat/wiremock/mappings/webhook-event.json
+++ b/uat/wiremock/mappings/webhook-event.json
@@ -1,0 +1,21 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "/webhooks/pipeline-event",
+    "headers": {
+      "Authorization": {
+        "matches": "Bearer .+"
+      }
+    }
+  },
+  "response": {
+    "status": 202,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "received": true,
+      "event_id": "{{randomValue type='UUID'}}"
+    }
+  }
+}


### PR DESCRIPTION
Sprint-6 wave-1. WireMock 3.5.4 + 3 mock endpoints + docker-compose + README. Internal-demo only. Sample pipeline wiring deferred.