### PR TITLE
docs(sprint-7): release-prep CHANGELOG + RELEASE + REPO_RENAME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog
+
+All notable changes to the Culvert data pipeline framework. See [DEV_PROCESS.md](docs/framework-evolution/03-dev-process.md) for the sprint workflow.
+
+## [0.1.0] — unreleased
+
+The framework's first feature-complete dev-cycle. **Not yet published to PyPI / Maven Central** — that step waits for explicit go.
+
+### Java libraries (`com.enrichmeai.culvert:*`)
+
+- `data-pipeline-core` — cloud-neutral kernel: 15 contract interfaces (Source, Sink, Transform, Pipeline, PipelineStage, RuntimeContext, JobControlRepository, BlobStore, Warehouse, AuditEventPublisher, GovernancePolicy, LineageEmitter, ObservabilityHook, FinOpsSink, SecretProvider) + supporting records + `AutoConfig` ServiceLoader-driven registry. 36 tests.
+- `data-pipeline-gcp-secrets` — SecretManagerProvider implementing SecretProvider. 4 tests.
+- `data-pipeline-gcp-bigquery` — three impls under one module: BigQueryWarehouse (Warehouse, 12), BigQueryJobControlRepository (JobControlRepository, 17), BigQueryFinOpsSink (FinOpsSink, 11). 40 tests.
+- `data-pipeline-gcp-gcs` — GcsBlobStore (BlobStore). 17 tests.
+- `data-pipeline-gcp-pubsub` — PubSubSource + PubSubSink (Source + Sink). 17 tests.
+- `data-pipeline-gcp-observability` — CloudTraceObservabilityHook + DataCatalogLineageEmitter. 20 tests.
+- `data-pipeline-gcp-dataflow` — DataflowPipeline (Pipeline) + Beam-bridging utility methods. 12 tests.
+- `data-pipeline-tester` — Mockito-helper fixture builders for 5 protocols. 15 tests.
+- `data-pipeline-contract-tests` — abstract JUnit contract test classes (SecretProvider, BlobStore, Warehouse). 1 smoke test.
+
+**Java reactor: ~172 tests across 9 modules.**
+
+### Python libraries (`data-pipeline-*`)
+
+- `data-pipeline-core` — Python Protocols mirroring the Java contracts; `AutoConfig` registry + decorator surface (`@pipeline`, `@stage`, `@source`, `@sink`, `@transform`). 11 tests.
+- `data-pipeline-gcp-bigquery` — BigQueryWarehouse Python equivalent. 10 tests.
+- `data-pipeline-gcp-gcs` — GcsBlobStore Python equivalent. 12 tests.
+- `data-pipeline-gcp-pubsub` — PubSubSource + PubSubSink Python equivalents. 10 tests.
+- `data-pipeline-contract-tests` — pytest mixin classes mirroring the Java abstract contract test classes. 2 smoke tests.
+
+Plus the Stage 1 deprecation shims (`gcp-pipeline-tester`, `gcp-pipeline-transform`, `gcp-pipeline-framework`, `gcp-pipeline-orchestration`) that re-export from the renamed `data-pipeline-*` packages.
+
+### Tooling and process
+
+- `docs/framework-evolution/03-dev-process.md` — orchestrator / advisor / dev-agent role model, sprint-branch workflow, oversized-ticket split rule, standup-comment protocol, 5-minute retro.
+- `docs/framework-evolution/04-sprint-plan.md` — 8-sprint plan.
+- `uat/` — WireMock 3.5.4 harness with `docker-compose.uat.yml` + 3 sample HTTP-style mock endpoints. Internal-demo only.
+
+## Sprint history
+
+| Sprint | Closed | Tickets | Tests added |
+|---|---|---|---|
+| 0 | 2026-05-26 | Plan backlog 8 sprints deep, scaffold sprint-1 modules | — |
+| 1 | 2026-05-26 | #5 secrets / #6 bigquery-warehouse / #7 gcs / #8 bq-job-control / #9 bq-finops | 66 |
+| 2 | 2026-05-27 | #23 pubsub / #24 observability / #25 dataflow / #26 tester | 64 |
+| 3 | 2026-05-27 | Python GCP modules (bigquery + gcs + pubsub) | 32 |
+| 4 | 2026-05-27 | AutoConfig + decorators (Java + Python) | 14 |
+| 5 | 2026-05-27 | Contract test scaffolding (Java + Python) | ~15 |
+| 6 | 2026-05-27 | WireMock UAT harness | — |
+| 7 | 2026-05-27 | Release prep docs (this changelog + RELEASE.md) | — |
+| 8 | 2026-05-27 | AWS / Azure skeletons + book v2 outline (planned) | TBD |
+
+## Not yet shipped
+
+- Publishing to PyPI / Maven Central — see [RELEASE.md](RELEASE.md) for the procedure when ready.
+- Repo rename — see [REPO_RENAME.md](REPO_RENAME.md) for the procedure.
+- Book v1 ship to Leanpub / other channel — separate workflow, not in scope for this changelog.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,68 @@
+# Release procedure
+
+Internal procedure for publishing Culvert framework releases. **Not automated.** Joseph triggers each step manually.
+
+## Prerequisites (one-time)
+
+- **PyPI:** Create an API token at https://pypi.org/manage/account/token/. Store as the `PYPI_TOKEN` env var or in `~/.pypirc`.
+- **Maven Central / Sonatype Central:** Create an account at https://central.sonatype.com/. Register the `com.enrichmeai.culvert` namespace (verification via DNS TXT on `enrichmeai.com`). Generate a user token. Set up GPG: `gpg --gen-key`, `gpg --export-secret-keys --armor <KEY_ID>` and add to `~/.m2/settings.xml` under the `central` server.
+- **Re-enable GitHub Actions workflows** (see #14): `for id in 243664542 243664544 ...; do gh workflow enable $id; done`. The workflows themselves are wired and just disabled.
+
+## Publishing Python packages to PyPI
+
+For each `data-pipeline-*` directory under `data-pipeline-libraries/`:
+
+```bash
+cd data-pipeline-libraries/<package>
+python3 -m pip install --upgrade build twine
+python3 -m build  # produces dist/*.whl and dist/*.tar.gz
+python3 -m twine upload --repository pypi dist/*
+```
+
+Order matters because of inter-package dependencies:
+
+1. `data-pipeline-core` (no deps inside the framework)
+2. `data-pipeline-contract-tests` (depends on core)
+3. `data-pipeline-tester` (depends on core)
+4. `data-pipeline-gcp-bigquery`, `data-pipeline-gcp-gcs`, `data-pipeline-gcp-pubsub` (depend on core)
+5. `data-pipeline-transform`, `data-pipeline-framework`, `data-pipeline-orchestration` (renamed legacy)
+6. The deprecation-shim `gcp-pipeline-*` distributions (depend on renamed packages)
+
+## Publishing Java artefacts to Maven Central
+
+From `data-pipeline-libraries-java/`:
+
+```bash
+# Validates GPG + Sonatype credentials before deploying.
+mvn -P release clean deploy
+```
+
+The `release` profile is already configured in the parent POM:
+- Signs all artefacts with GPG.
+- Uploads via `central-publishing-maven-plugin` to the central staging repo.
+- `autoPublish=false` means a manual close+release step at https://central.sonatype.com/ after upload completes.
+
+To publish a single module:
+
+```bash
+mvn -P release -pl data-pipeline-gcp-bigquery-java -am clean deploy
+```
+
+## Versioning
+
+Currently all artefacts are version `0.1.0`. Bumps happen via:
+
+- **Java:** `mvn versions:set -DnewVersion=0.2.0 -DgenerateBackupPoms=false` from `data-pipeline-libraries-java/`. Commit and push before deploy.
+- **Python:** Edit each `pyproject.toml`'s `version = "..."`. Or use `bumpver` / `hatch version` if you adopt one.
+
+The two languages currently version in lockstep; that may change post-1.0.
+
+## Post-release checklist
+
+- Tag the release: `git tag v0.1.0 && git push --tags`.
+- Update [CHANGELOG.md](CHANGELOG.md) to move the `[0.1.0] — unreleased` heading to a dated release.
+- Announce: GitHub release notes, blog post, book chapter linking the published artefacts.
+
+## What CANNOT be automated until the rename happens
+
+Maven artefact `groupId` is `com.enrichmeai.culvert` — that's stable. PyPI package names are `data-pipeline-*` — also stable. The GitHub repo name `gcp-pipeline-reference` is misleading post-Stage-2; see [REPO_RENAME.md](REPO_RENAME.md). The repo rename does NOT block publishing.

--- a/REPO_RENAME.md
+++ b/REPO_RENAME.md
@@ -1,0 +1,62 @@
+# GitHub repository rename procedure
+
+The repo was created as `enrichmeai/gcp-pipeline-reference` when the framework was GCP-coupled. After Stage-2 split it's a polyglot, cloud-neutral framework. The repo name is misleading.
+
+**Not automated.** Joseph decides the new name and triggers the rename.
+
+## Suggested names
+
+Pick one. Order = my recommendation, your call.
+
+1. **`culvert-framework`** — matches the brand (Culvert) and the artefact prefix (`data-pipeline-*`). Most discoverable.
+2. **`data-pipeline-framework`** — matches the artefact prefix exactly; brand-neutral.
+3. **`culvert`** — terse. Risk: too generic on GitHub search.
+
+## Rename steps
+
+1. **Decide.** Update this doc with the chosen name.
+2. **Rename on GitHub.** Settings → Repository name → Save. GitHub auto-redirects the old URL.
+3. **Update remotes locally:**
+   ```bash
+   git remote set-url origin git@github.com:enrichmeai/<NEW_NAME>.git
+   ```
+4. **Update repo references in source.** These files reference `gcp-pipeline-reference` and need rewriting:
+   - `data-pipeline-libraries-java/pom.xml` (`<scm>` block, `<url>`)
+   - `data-pipeline-libraries-java/*/pom.xml` (per-module)
+   - Each `data-pipeline-libraries/*/pyproject.toml` `Homepage`, `Repository`, `Bug Tracker`
+   - `CHANGELOG.md`, `README.md`, `RELEASE.md`, this file
+   - `docs/framework-evolution/*.md`
+   - The book source (when v1 ships)
+
+   Quick find:
+   ```bash
+   grep -rl "gcp-pipeline-reference" . --include="*.md" --include="*.toml" --include="*.xml"
+   ```
+
+5. **Bulk rewrite** (verify with a dry-run diff first):
+   ```bash
+   grep -rl "gcp-pipeline-reference" . --include="*.md" --include="*.toml" --include="*.xml" \
+     | xargs sed -i '' "s/gcp-pipeline-reference/<NEW_NAME>/g"
+   ```
+6. **Commit and push:**
+   ```bash
+   git add -A
+   git commit -m "chore: rename repo references gcp-pipeline-reference -> <NEW_NAME>"
+   git push origin main
+   ```
+7. **Update Maven Central deployment** (if already published): the `<scm>` block in published POMs cannot be retroactively edited. Future releases pick up the new URL automatically.
+8. **Update book v1 references** before publishing the book.
+
+## What this does NOT do
+
+- Change artefact / package names. `com.enrichmeai.culvert:data-pipeline-*` and PyPI `data-pipeline-*` stay the same.
+- Change PyPI URLs. `pip install` works against the package name, not the repo.
+- Break old git URLs. GitHub redirects `gcp-pipeline-reference` → new name automatically; old clones can still `git pull` until they `git remote set-url`.
+
+## Decision log
+
+| Date | Status | Notes |
+|---|---|---|
+| 2026-05-26 | Decided to rename eventually; new name TBD by Joseph. | Sprint-1 dev-process locked the Culvert brand + `data-pipeline-*` artefact convention. Repo rename deferred. |
+| TBD | Joseph picks the new name | This doc gets updated. |
+| TBD | Rename happens | Steps above executed. |


### PR DESCRIPTION
Sprint-7 wave-1. Three new top-level docs covering the release procedure (PyPI + Maven Central + repo rename) without triggering any actual publish step. Per user direction: 'we don't need to publish'.