### PR TITLE
Sprint 9 → main: execution core (RuntimeContext + Beam transform translation)

### DIFF
--- a/data-pipeline-libraries-java/data-pipeline-core-java/src/main/java/com/enrichmeai/culvert/runtime/DefaultRuntimeContext.java
+++ b/data-pipeline-libraries-java/data-pipeline-core-java/src/main/java/com/enrichmeai/culvert/runtime/DefaultRuntimeContext.java
@@ -1,0 +1,273 @@
+package com.enrichmeai.culvert.runtime;
+
+import com.enrichmeai.culvert.autoconfig.AutoConfig;
+import com.enrichmeai.culvert.contracts.FinOpsSink;
+import com.enrichmeai.culvert.contracts.GovernancePolicy;
+import com.enrichmeai.culvert.contracts.LineageEmitter;
+import com.enrichmeai.culvert.contracts.ObservabilityHook;
+import com.enrichmeai.culvert.contracts.RuntimeContext;
+import com.enrichmeai.culvert.contracts.SecretProvider;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Cloud-neutral concrete {@link RuntimeContext}: the framework's default
+ * dependency-injection container.
+ *
+ * <p>Holds a {@code runId}, an {@code environment}, an immutable {@code config}
+ * map, and a {@link ConcurrentHashMap} registry keyed by protocol interface
+ * class. {@link #get(Class)} reads the registry; {@link #register(Class, Object)}
+ * overrides an entry (last write wins). The convenience accessors
+ * ({@link #secrets()}, {@link #observability()}, etc.) are thin wrappers over
+ * the registry for the five well-known cross-cutting protocols.
+ *
+ * <h2>Defaulting policy</h2>
+ *
+ * <p>The accessors split into two groups:
+ *
+ * <ul>
+ *   <li><strong>Advisory protocols</strong> — {@link #observability()},
+ *       {@link #lineage()}, {@link #finops()}, {@link #governance()} — fall
+ *       back to a silent {@linkplain NoOpDefaults no-op} when nothing is
+ *       registered, so a minimal context is usable out of the box. A pipeline
+ *       runs correctly whether or not these emit anywhere.</li>
+ *   <li><strong>Hard dependencies</strong> — {@link #secrets()} (and any
+ *       arbitrary protocol fetched via {@link #get(Class)}) — throw
+ *       {@link IllegalStateException} when absent. Silently returning a fake
+ *       secret would mask a misconfiguration as a data bug far from its cause.</li>
+ * </ul>
+ *
+ * <h2>Construction</h2>
+ *
+ * <p>Use {@link #builder(String, String)} for explicit wiring (tests,
+ * specialised runtimes) or {@link #fromAutoConfig(String, String, Map, AutoConfig)}
+ * to pre-populate the registry from a Sprint-4 {@link AutoConfig} discovery
+ * (the first discovered impl of each protocol is registered).
+ *
+ * <h2>Serialization</h2>
+ *
+ * <p>This class is {@link Serializable} because the GCP Dataflow adapter
+ * captures a {@code RuntimeContext} inside Beam {@code DoFn}s, which Beam
+ * serializes to its workers. Registered impls must therefore also be
+ * {@code Serializable} — the bundled {@linkplain NoOpDefaults no-op defaults}
+ * are; adapter impls that get registered are expected to be too. The registry
+ * is a {@link ConcurrentHashMap}, which serializes its entries.
+ *
+ * <p>Cloud-neutral by construction: depends only on the contracts, the
+ * auto-config registry, and {@code java.util}. No Beam, no GCP.
+ *
+ * <p>Sprint-9 deliverable (T9.1).
+ */
+public final class DefaultRuntimeContext implements RuntimeContext, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String runId;
+    private final String environment;
+    /**
+     * Read-only config. The declared {@code Map<String, Object>} value type
+     * can't be proven {@code Serializable} at compile time; the map is built
+     * via {@link Map#copyOf} (a serializable immutable map) and callers are
+     * expected to supply serializable values.
+     */
+    @SuppressWarnings("serial")
+    private final Map<String, Object> config;
+    /**
+     * Keyed by protocol interface class; values are protocol impls. The
+     * declared {@code Object} value type can't be proven {@code Serializable}
+     * at compile time, but every value placed here at runtime is
+     * (the no-op defaults are; adapter impls are expected to be). The map
+     * itself ({@link ConcurrentHashMap}) is {@code Serializable}.
+     */
+    @SuppressWarnings("serial")
+    private final ConcurrentHashMap<Class<?>, Object> registry;
+
+    private DefaultRuntimeContext(Builder builder) {
+        this.runId = Objects.requireNonNull(builder.runId, "runId must not be null");
+        this.environment = Objects.requireNonNull(builder.environment, "environment must not be null");
+        this.config = Map.copyOf(builder.config);
+        this.registry = new ConcurrentHashMap<>(builder.registry);
+    }
+
+    /**
+     * Start building a context with the required identity fields.
+     *
+     * @param runId       The run identifier. Required, non-blank.
+     * @param environment The deployment environment. Required, non-blank.
+     */
+    public static Builder builder(String runId, String environment) {
+        return new Builder(runId, environment);
+    }
+
+    /**
+     * Build a context pre-populated from an {@link AutoConfig} discovery.
+     *
+     * <p>For each cross-cutting protocol that AutoConfig discovered on the
+     * classpath, the <em>first</em> impl is registered. Protocols with no
+     * discovered impl are simply not registered — the advisory accessors then
+     * fall back to their no-op defaults and {@link #secrets()} throws on use.
+     *
+     * <p>Both the singular cross-cutting protocols (SecretProvider,
+     * ObservabilityHook, LineageEmitter, FinOpsSink, GovernancePolicy) and the
+     * list-based data protocols (Warehouse, BlobStore, JobControlRepository,
+     * AuditEventPublisher, Source/Sink/Transform) are registered where present,
+     * so stages can fetch them via {@link #get(Class)}.
+     *
+     * @param runId       The run identifier. Required, non-blank.
+     * @param environment The deployment environment. Required, non-blank.
+     * @param config      Read-only application configuration. Required (may be empty).
+     * @param autoConfig  A discovered {@link AutoConfig}. Required.
+     */
+    public static DefaultRuntimeContext fromAutoConfig(String runId,
+                                                       String environment,
+                                                       Map<String, Object> config,
+                                                       AutoConfig autoConfig) {
+        Objects.requireNonNull(config, "config must not be null");
+        Objects.requireNonNull(autoConfig, "autoConfig must not be null");
+        Builder builder = new Builder(runId, environment).config(config);
+
+        // Singular cross-cutting protocols: register the first discovered impl.
+        autoConfig.secretProvider().ifPresent(
+                impl -> builder.register(SecretProvider.class, impl));
+        autoConfig.observabilityHook().ifPresent(
+                impl -> builder.register(ObservabilityHook.class, impl));
+        autoConfig.lineageEmitter().ifPresent(
+                impl -> builder.register(LineageEmitter.class, impl));
+        autoConfig.finOpsSink().ifPresent(
+                impl -> builder.register(FinOpsSink.class, impl));
+        autoConfig.governancePolicy().ifPresent(
+                impl -> builder.register(GovernancePolicy.class, impl));
+
+        // List-based data protocols: register the first of each present.
+        registerFirst(builder, com.enrichmeai.culvert.contracts.Warehouse.class,
+                autoConfig.warehouses());
+        registerFirst(builder, com.enrichmeai.culvert.contracts.BlobStore.class,
+                autoConfig.blobStores());
+        registerFirst(builder, com.enrichmeai.culvert.contracts.JobControlRepository.class,
+                autoConfig.jobControls());
+        registerFirst(builder, com.enrichmeai.culvert.contracts.AuditEventPublisher.class,
+                autoConfig.auditEventPublishers());
+
+        return builder.build();
+    }
+
+    private static <T> void registerFirst(Builder builder, Class<T> type, java.util.List<? extends T> impls) {
+        if (impls != null && !impls.isEmpty()) {
+            builder.register(type, impls.get(0));
+        }
+    }
+
+    @Override
+    public String runId() {
+        return runId;
+    }
+
+    @Override
+    public String environment() {
+        return environment;
+    }
+
+    @Override
+    public Map<String, Object> config() {
+        return config;
+    }
+
+    @Override
+    public SecretProvider secrets() {
+        Object impl = registry.get(SecretProvider.class);
+        if (impl == null) {
+            throw new IllegalStateException(
+                    "No SecretProvider registered; install a SecretProvider adapter "
+                            + "or call register(SecretProvider.class, ...). There is no "
+                            + "no-op default for secrets by design.");
+        }
+        return (SecretProvider) impl;
+    }
+
+    @Override
+    public ObservabilityHook observability() {
+        return (ObservabilityHook) registry.computeIfAbsent(
+                ObservabilityHook.class, k -> new NoOpDefaults.NoOpObservabilityHook());
+    }
+
+    @Override
+    public LineageEmitter lineage() {
+        return (LineageEmitter) registry.computeIfAbsent(
+                LineageEmitter.class, k -> new NoOpDefaults.NoOpLineageEmitter());
+    }
+
+    @Override
+    public FinOpsSink finops() {
+        return (FinOpsSink) registry.computeIfAbsent(
+                FinOpsSink.class, k -> new NoOpDefaults.NoOpFinOpsSink());
+    }
+
+    @Override
+    public GovernancePolicy governance() {
+        return (GovernancePolicy) registry.computeIfAbsent(
+                GovernancePolicy.class, k -> new NoOpDefaults.NoOpGovernancePolicy());
+    }
+
+    @Override
+    public <T> T get(Class<T> protocolType) {
+        Objects.requireNonNull(protocolType, "protocolType must not be null");
+        Object impl = registry.get(protocolType);
+        if (impl == null) {
+            throw new IllegalStateException(
+                    "No implementation registered for " + protocolType.getName()
+                            + "; call register(" + protocolType.getSimpleName()
+                            + ".class, ...) or supply one via AutoConfig.");
+        }
+        return protocolType.cast(impl);
+    }
+
+    @Override
+    public <T> void register(Class<T> protocolType, T impl) {
+        Objects.requireNonNull(protocolType, "protocolType must not be null");
+        Objects.requireNonNull(impl, "impl must not be null");
+        registry.put(protocolType, impl);
+    }
+
+    /** Fluent builder for {@link DefaultRuntimeContext}. */
+    public static final class Builder {
+
+        private final String runId;
+        private final String environment;
+        private Map<String, Object> config = Map.of();
+        private final ConcurrentHashMap<Class<?>, Object> registry = new ConcurrentHashMap<>();
+
+        private Builder(String runId, String environment) {
+            Objects.requireNonNull(runId, "runId must not be null");
+            Objects.requireNonNull(environment, "environment must not be null");
+            if (runId.isBlank()) {
+                throw new IllegalArgumentException("runId must not be blank");
+            }
+            if (environment.isBlank()) {
+                throw new IllegalArgumentException("environment must not be blank");
+            }
+            this.runId = runId;
+            this.environment = environment;
+        }
+
+        /** Set the read-only configuration map (defensively copied at build). */
+        public Builder config(Map<String, Object> config) {
+            this.config = Objects.requireNonNull(config, "config must not be null");
+            return this;
+        }
+
+        /** Register a protocol impl. Later registrations override earlier ones. */
+        public <T> Builder register(Class<T> protocolType, T impl) {
+            Objects.requireNonNull(protocolType, "protocolType must not be null");
+            Objects.requireNonNull(impl, "impl must not be null");
+            this.registry.put(protocolType, impl);
+            return this;
+        }
+
+        public DefaultRuntimeContext build() {
+            return new DefaultRuntimeContext(this);
+        }
+    }
+}

--- a/data-pipeline-libraries-java/data-pipeline-core-java/src/main/java/com/enrichmeai/culvert/runtime/NoOpDefaults.java
+++ b/data-pipeline-libraries-java/data-pipeline-core-java/src/main/java/com/enrichmeai/culvert/runtime/NoOpDefaults.java
@@ -1,0 +1,139 @@
+package com.enrichmeai.culvert.runtime;
+
+import com.enrichmeai.culvert.contracts.FinOpsSink;
+import com.enrichmeai.culvert.contracts.GovernancePolicy;
+import com.enrichmeai.culvert.contracts.LineageEmitter;
+import com.enrichmeai.culvert.contracts.ObservabilityHook;
+import com.enrichmeai.culvert.finops.CostMetrics;
+import com.enrichmeai.culvert.finops.FinOpsTag;
+import com.enrichmeai.culvert.governance.DataClassification;
+import com.enrichmeai.culvert.governance.MaskingPolicy;
+import com.enrichmeai.culvert.governance.RetentionPolicy;
+import com.enrichmeai.culvert.lineage.LineageEvent;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Cloud-neutral no-op implementations of the framework's cross-cutting
+ * protocols, used by {@link DefaultRuntimeContext} when no real adapter is
+ * registered.
+ *
+ * <p><strong>Why no-ops exist for some protocols but not others.</strong>
+ * Observability, lineage, finops, and governance are all <em>advisory</em> —
+ * a pipeline can run correctly without emitting metrics, lineage events, cost
+ * records, or consulting a governance catalog. So the framework supplies
+ * silent no-op defaults for those four, letting a minimal {@code RuntimeContext}
+ * be constructed and used out of the box.
+ *
+ * <p>There is deliberately <strong>no</strong> no-op {@code SecretProvider}:
+ * a stage that asks for a secret has a hard data dependency, and silently
+ * returning {@code null} (or an empty string) would mask a misconfiguration
+ * as a runtime data bug far from its cause. {@link DefaultRuntimeContext#secrets()}
+ * therefore throws {@link IllegalStateException} when no provider is registered.
+ *
+ * <p>Every nested impl is {@link Serializable} because a {@code RuntimeContext}
+ * (and therefore the registered impls it carries) is captured by Beam
+ * {@code DoFn}s in the Dataflow adapter and must survive serialization to the
+ * worker. They hold no state, so serialization is trivial.
+ */
+final class NoOpDefaults {
+
+    private NoOpDefaults() {
+    }
+
+    /** A {@link ObservabilityHook} that discards every metric, log, and span. */
+    static final class NoOpObservabilityHook implements ObservabilityHook, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public void counter(String name, long value, Map<String, String> tags) {
+            // no-op
+        }
+
+        @Override
+        public void gauge(String name, double value, Map<String, String> tags) {
+            // no-op
+        }
+
+        @Override
+        public void histogram(String name, double value, Map<String, String> tags) {
+            // no-op
+        }
+
+        @Override
+        public void log(String level, String message, Map<String, Object> fields) {
+            // no-op
+        }
+
+        @Override
+        public Span span(String name) {
+            return new NoOpSpan();
+        }
+    }
+
+    /** A {@link ObservabilityHook.Span} that records nothing. */
+    static final class NoOpSpan implements ObservabilityHook.Span, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public void setAttribute(String key, String value) {
+            // no-op
+        }
+
+        @Override
+        public void recordException(Throwable t) {
+            // no-op
+        }
+
+        @Override
+        public void close() {
+            // no-op
+        }
+    }
+
+    /** A {@link LineageEmitter} that discards every event. */
+    static final class NoOpLineageEmitter implements LineageEmitter, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public void emit(LineageEvent event) {
+            // no-op
+        }
+    }
+
+    /** A {@link FinOpsSink} that discards every cost record. */
+    static final class NoOpFinOpsSink implements FinOpsSink, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public void record(CostMetrics metrics, FinOpsTag tags) {
+            // no-op
+        }
+    }
+
+    /**
+     * A {@link GovernancePolicy} with no attached policies: everything is
+     * {@link DataClassification#INTERNAL}, nothing is masked, nothing has a
+     * retention limit. This mirrors the contract's documented defaults.
+     */
+    static final class NoOpGovernancePolicy implements GovernancePolicy, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public DataClassification classify(String field, String table) {
+            return DataClassification.INTERNAL;
+        }
+
+        @Override
+        public Optional<MaskingPolicy> maskingFor(String field, String table) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<RetentionPolicy> retentionFor(String table) {
+            return Optional.empty();
+        }
+    }
+}

--- a/data-pipeline-libraries-java/data-pipeline-core-java/src/test/java/com/enrichmeai/culvert/runtime/DefaultRuntimeContextTest.java
+++ b/data-pipeline-libraries-java/data-pipeline-core-java/src/test/java/com/enrichmeai/culvert/runtime/DefaultRuntimeContextTest.java
@@ -1,0 +1,193 @@
+package com.enrichmeai.culvert.runtime;
+
+import com.enrichmeai.culvert.autoconfig.AutoConfig;
+import com.enrichmeai.culvert.contracts.FinOpsSink;
+import com.enrichmeai.culvert.contracts.GovernancePolicy;
+import com.enrichmeai.culvert.contracts.LineageEmitter;
+import com.enrichmeai.culvert.contracts.ObservabilityHook;
+import com.enrichmeai.culvert.contracts.SecretProvider;
+import com.enrichmeai.culvert.governance.DataClassification;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link DefaultRuntimeContext} (Sprint-9 T9.1).
+ */
+class DefaultRuntimeContextTest {
+
+    @Test
+    void builderCarriesIdentityAndConfig() {
+        DefaultRuntimeContext ctx = DefaultRuntimeContext
+                .builder("run-1", "dev")
+                .config(Map.of("table", "events"))
+                .build();
+
+        assertThat(ctx.runId()).isEqualTo("run-1");
+        assertThat(ctx.environment()).isEqualTo("dev");
+        assertThat(ctx.config()).containsEntry("table", "events");
+    }
+
+    @Test
+    void configIsImmutable() {
+        DefaultRuntimeContext ctx = DefaultRuntimeContext
+                .builder("run-1", "dev")
+                .config(Map.of("k", "v"))
+                .build();
+
+        assertThatThrownBy(() -> ctx.config().put("x", "y"))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void blankRunIdRejected() {
+        assertThatThrownBy(() -> DefaultRuntimeContext.builder(" ", "dev"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void secretsThrowsWhenAbsent() {
+        DefaultRuntimeContext ctx = DefaultRuntimeContext.builder("r", "dev").build();
+        assertThatThrownBy(ctx::secrets)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("SecretProvider");
+    }
+
+    @Test
+    void secretsReturnsRegisteredProvider() {
+        SecretProvider provider = (name, version) -> "shh";
+        DefaultRuntimeContext ctx = DefaultRuntimeContext
+                .builder("r", "dev")
+                .register(SecretProvider.class, provider)
+                .build();
+
+        assertThat(ctx.secrets().get("any")).isEqualTo("shh");
+    }
+
+    @Test
+    void advisoryProtocolsHaveNoOpDefaults() {
+        DefaultRuntimeContext ctx = DefaultRuntimeContext.builder("r", "dev").build();
+
+        // None of these should throw; the no-op defaults absorb the calls.
+        ObservabilityHook obs = ctx.observability();
+        assertThat(obs).isNotNull();
+        obs.counter("rows", 1L, Map.of());
+        obs.gauge("g", 1.0, Map.of());
+        obs.histogram("h", 1.0, Map.of());
+        obs.log("INFO", "hello", Map.of());
+        try (ObservabilityHook.Span span = obs.span("stage")) {
+            span.setAttribute("k", "v");
+        }
+
+        assertThat(ctx.lineage()).isNotNull();
+        assertThat(ctx.finops()).isNotNull();
+
+        GovernancePolicy gov = ctx.governance();
+        assertThat(gov.classify("col", "tbl")).isEqualTo(DataClassification.INTERNAL);
+        assertThat(gov.maskingFor("col", "tbl")).isEmpty();
+        assertThat(gov.retentionFor("tbl")).isEmpty();
+    }
+
+    @Test
+    void registeredAdvisoryImplWins() {
+        LineageEmitter custom = event -> { /* records nowhere, but identity matters */ };
+        FinOpsSink customSink = (metrics, tags) -> { };
+        DefaultRuntimeContext ctx = DefaultRuntimeContext
+                .builder("r", "dev")
+                .register(LineageEmitter.class, custom)
+                .register(FinOpsSink.class, customSink)
+                .build();
+
+        assertThat(ctx.lineage()).isSameAs(custom);
+        assertThat(ctx.finops()).isSameAs(customSink);
+    }
+
+    @Test
+    void getThrowsWhenUnregistered() {
+        DefaultRuntimeContext ctx = DefaultRuntimeContext.builder("r", "dev").build();
+        assertThatThrownBy(() -> ctx.get(Runnable.class))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Runnable");
+    }
+
+    @Test
+    void getReturnsRegisteredAndRegisterOverrides() {
+        Runnable first = () -> { };
+        Runnable second = () -> { };
+        DefaultRuntimeContext ctx = DefaultRuntimeContext
+                .builder("r", "dev")
+                .register(Runnable.class, first)
+                .build();
+
+        assertThat(ctx.get(Runnable.class)).isSameAs(first);
+        ctx.register(Runnable.class, second);
+        assertThat(ctx.get(Runnable.class)).isSameAs(second);
+    }
+
+    @Test
+    void fromAutoConfigBuildsUsableContextWithEmptyClasspath() {
+        // The core test classpath has no provider entries, so AutoConfig
+        // discovers nothing; the context must still build and the advisory
+        // accessors must still return no-op defaults.
+        DefaultRuntimeContext ctx = DefaultRuntimeContext.fromAutoConfig(
+                "run-ac", "staging", Map.of("a", 1), AutoConfig.discover());
+
+        assertThat(ctx.runId()).isEqualTo("run-ac");
+        assertThat(ctx.environment()).isEqualTo("staging");
+        assertThat(ctx.observability()).isNotNull();
+        assertThatThrownBy(ctx::secrets).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void contextWithNoOpDefaultsIsSerializable() throws Exception {
+        DefaultRuntimeContext ctx = DefaultRuntimeContext
+                .builder("run-ser", "prod")
+                .config(Map.of("k", "v"))
+                .register(SecretProvider.class, new SerializableSecret())
+                .build();
+        // Touch the advisory accessors so the no-op defaults are materialised
+        // into the registry before serialization.
+        ctx.observability();
+        ctx.lineage();
+        ctx.finops();
+        ctx.governance();
+
+        DefaultRuntimeContext roundTripped = roundTrip(ctx);
+
+        assertThat(roundTripped.runId()).isEqualTo("run-ser");
+        assertThat(roundTripped.environment()).isEqualTo("prod");
+        assertThat(roundTripped.config()).containsEntry("k", "v");
+        assertThat(roundTripped.secrets().get("x")).isEqualTo("secret-x");
+        assertThat(roundTripped.governance().classify("c", "t"))
+                .isEqualTo(DataClassification.INTERNAL);
+    }
+
+    private static DefaultRuntimeContext roundTrip(DefaultRuntimeContext ctx) throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {
+            out.writeObject(ctx);
+        }
+        try (ObjectInputStream in = new ObjectInputStream(
+                new ByteArrayInputStream(bytes.toByteArray()))) {
+            return (DefaultRuntimeContext) in.readObject();
+        }
+    }
+
+    /** A serializable secret provider for the round-trip test. */
+    static final class SerializableSecret implements SecretProvider, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public String get(String name, String version) {
+            return "secret-" + name;
+        }
+    }
+}

--- a/data-pipeline-libraries-java/data-pipeline-gcp-dataflow-java/src/main/java/com/enrichmeai/culvert/gcp/dataflow/DataflowPipeline.java
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-dataflow-java/src/main/java/com/enrichmeai/culvert/gcp/dataflow/DataflowPipeline.java
@@ -1,7 +1,10 @@
 package com.enrichmeai.culvert.gcp.dataflow;
 
+import com.enrichmeai.culvert.autoconfig.AutoConfig;
 import com.enrichmeai.culvert.contracts.Pipeline;
 import com.enrichmeai.culvert.contracts.PipelineStage;
+import com.enrichmeai.culvert.contracts.RuntimeContext;
+import com.enrichmeai.culvert.runtime.DefaultRuntimeContext;
 import org.apache.beam.runners.dataflow.DataflowRunner;
 // Note: Beam 2.x uses `DataflowRunner` (not `DataflowPipelineRunner` —
 // that was the old 1.x name kept around in pre-merge Beam).
@@ -10,8 +13,10 @@ import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -19,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
 
 /**
  * {@link Pipeline} implementation that bridges Culvert's topology contract
@@ -144,17 +150,16 @@ public final class DataflowPipeline implements Pipeline {
     }
 
     /**
-     * Build a Beam {@link org.apache.beam.sdk.Pipeline} from this
-     * topology with default {@link PipelineOptions}.
+     * Build a Beam {@link org.apache.beam.sdk.Pipeline} from this topology
+     * with default {@link PipelineOptions} and a default {@link RuntimeContext}.
      *
-     * <p>Each Culvert {@link PipelineStage} is currently translated as a
-     * Beam {@code Pipeline} root node; concrete per-stage transform
-     * translation arrives in sprint-4 with the auto-config layer that
-     * supplies a runtime context for each stage's {@code execute} call.
+     * <p>The default context is a {@link DefaultRuntimeContext} populated from
+     * {@link AutoConfig#discover()} with {@code runId = "local-" +} a random
+     * UUID, {@code environment = "local"}, and an empty config map. Use
+     * {@link #buildBeam(PipelineOptions, RuntimeContext)} to supply your own.
      *
-     * @return A configured Beam pipeline ready to be passed to a Beam
-     *         runner. The caller may further customise it before calling
-     *         {@code run()}.
+     * @return A configured Beam pipeline with one {@link StageTransform} per
+     *         stage applied in topological order, ready to {@code run()}.
      */
     public org.apache.beam.sdk.Pipeline buildBeam() {
         return buildBeam(PipelineOptionsFactory.create());
@@ -162,16 +167,50 @@ public final class DataflowPipeline implements Pipeline {
 
     /**
      * Build a Beam {@link org.apache.beam.sdk.Pipeline} with caller-supplied
-     * options.
+     * options and a default {@link RuntimeContext} (see {@link #buildBeam()}
+     * for the default's parameters).
      *
      * @param options Beam pipeline options. Required.
      */
     public org.apache.beam.sdk.Pipeline buildBeam(PipelineOptions options) {
+        return buildBeam(options, defaultRuntimeContext());
+    }
+
+    /**
+     * Build a Beam {@link org.apache.beam.sdk.Pipeline} with caller-supplied
+     * options and runtime context.
+     *
+     * <p>Validates the topology, computes a topological execution order from
+     * the stage input/output edges, then applies one {@link StageTransform}
+     * per stage <em>in that order</em>. Declaration order is irrelevant — a
+     * stage is wired after all the stages it depends on.
+     *
+     * <p>Each {@link StageTransform} is rooted at {@code PBegin}, so the stages
+     * are independent roots in the Beam graph. The topological apply order
+     * documents the dependency intent and is the anchor for richer
+     * element-level data flow in a future sprint; today Beam schedules the
+     * independent roots itself.
+     *
+     * @param options Beam pipeline options. Required.
+     * @param context The runtime context handed to every stage's
+     *                {@code execute}. Required; must be serializable to run on
+     *                a distributed runner.
+     */
+    public org.apache.beam.sdk.Pipeline buildBeam(PipelineOptions options, RuntimeContext context) {
         Objects.requireNonNull(options, "options must not be null");
+        Objects.requireNonNull(context, "context must not be null");
         validate();
-        return org.apache.beam.sdk.Pipeline.create(options);
-        // TODO sprint-4: walk the stage graph and apply each stage's
-        // transform to the Beam pipeline. Requires a RuntimeContext factory.
+
+        org.apache.beam.sdk.Pipeline beam = org.apache.beam.sdk.Pipeline.create(options);
+        Map<String, PipelineStage> byName = new HashMap<>();
+        for (PipelineStage stage : stages) {
+            byName.put(stage.name(), stage);
+        }
+        for (String stageName : topologicalOrder()) {
+            PipelineStage stage = byName.get(stageName);
+            beam.apply(StageTransform.of(stage, context));
+        }
+        return beam;
     }
 
     /**
@@ -188,13 +227,97 @@ public final class DataflowPipeline implements Pipeline {
      *         whose {@code waitUntilFinish()} blocks for completion.
      */
     public PipelineResult runOnDataflow(DataflowPipelineOptions options) {
+        return runOnDataflow(options, defaultRuntimeContext());
+    }
+
+    /**
+     * Convenience: submit this pipeline to Google Cloud Dataflow with a
+     * caller-supplied runtime context.
+     *
+     * @param options Dataflow-specific options. Required.
+     * @param context The runtime context handed to every stage. Required.
+     * @return The Beam {@link PipelineResult} from {@code pipeline.run()}.
+     */
+    public PipelineResult runOnDataflow(DataflowPipelineOptions options, RuntimeContext context) {
         Objects.requireNonNull(options, "options must not be null");
+        Objects.requireNonNull(context, "context must not be null");
         options.setRunner(DataflowRunner.class);
-        org.apache.beam.sdk.Pipeline beam = buildBeam(options);
+        org.apache.beam.sdk.Pipeline beam = buildBeam(options, context);
         return beam.run();
     }
 
     // --- helpers -----------------------------------------------------------
+
+    /**
+     * The default {@link RuntimeContext} backing the no-context
+     * {@code buildBeam}/{@code runOnDataflow} overloads: a
+     * {@link DefaultRuntimeContext} from {@link AutoConfig#discover()} with a
+     * generated {@code runId}, {@code environment = "local"}, and an empty
+     * config map.
+     */
+    private static RuntimeContext defaultRuntimeContext() {
+        return DefaultRuntimeContext.fromAutoConfig(
+                "local-" + UUID.randomUUID(),
+                "local",
+                Map.of(),
+                AutoConfig.discover());
+    }
+
+    /**
+     * Compute a topological execution order over the stage dependency graph
+     * using Kahn's algorithm. {@link #validate()} has already proven the graph
+     * is acyclic, so this always succeeds. Ties (stages with no remaining
+     * dependencies) are broken by declaration order for determinism.
+     *
+     * @return Stage names, dependencies before dependents.
+     */
+    private List<String> topologicalOrder() {
+        Map<String, String> outputToProducer = new HashMap<>();
+        for (PipelineStage stage : stages) {
+            for (String output : stage.outputs()) {
+                outputToProducer.put(output, stage.name());
+            }
+        }
+        // edges: producer -> consumers; inDegree: # of producers a stage waits on.
+        Map<String, List<String>> dependents = new HashMap<>();
+        Map<String, Integer> inDegree = new HashMap<>();
+        for (PipelineStage stage : stages) {
+            inDegree.putIfAbsent(stage.name(), 0);
+            dependents.putIfAbsent(stage.name(), new ArrayList<>());
+        }
+        for (PipelineStage stage : stages) {
+            for (String input : stage.inputs()) {
+                String producer = outputToProducer.get(input);
+                if (producer != null && !producer.equals(stage.name())) {
+                    dependents.get(producer).add(stage.name());
+                    inDegree.merge(stage.name(), 1, Integer::sum);
+                }
+            }
+        }
+        // Seed the queue with zero-in-degree stages in declaration order.
+        Deque<String> ready = new ArrayDeque<>();
+        for (PipelineStage stage : stages) {
+            if (inDegree.get(stage.name()) == 0) {
+                ready.add(stage.name());
+            }
+        }
+        List<String> order = new ArrayList<>(stages.size());
+        while (!ready.isEmpty()) {
+            String current = ready.poll();
+            order.add(current);
+            for (String dependent : dependents.get(current)) {
+                if (inDegree.merge(dependent, -1, Integer::sum) == 0) {
+                    ready.add(dependent);
+                }
+            }
+        }
+        if (order.size() != stages.size()) {
+            // Unreachable: validate() rejects cycles. Defensive guard only.
+            throw new IllegalStateException(
+                    "Topological sort incomplete; the graph has a cycle");
+        }
+        return order;
+    }
 
     private Map<String, List<String>> buildDependencyGraph(
             Map<String, String> outputToProducer) {

--- a/data-pipeline-libraries-java/data-pipeline-gcp-dataflow-java/src/main/java/com/enrichmeai/culvert/gcp/dataflow/DataflowPipeline.java
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-dataflow-java/src/main/java/com/enrichmeai/culvert/gcp/dataflow/DataflowPipeline.java
@@ -207,7 +207,8 @@ public final class DataflowPipeline implements Pipeline {
             byName.put(stage.name(), stage);
         }
         for (String stageName : topologicalOrder()) {
-            PipelineStage stage = byName.get(stageName);
+            PipelineStage stage = Objects.requireNonNull(
+                    byName.get(stageName), () -> "no stage named " + stageName);
             beam.apply(StageTransform.of(stage, context));
         }
         return beam;
@@ -271,7 +272,10 @@ public final class DataflowPipeline implements Pipeline {
      *
      * @return Stage names, dependencies before dependents.
      */
-    private List<String> topologicalOrder() {
+    // Package-private so tests can assert the computed dependency order
+    // directly (apply order is driver-side metadata; a runner schedules the
+    // independent PBegin roots itself — see StageTransform).
+    List<String> topologicalOrder() {
         Map<String, String> outputToProducer = new HashMap<>();
         for (PipelineStage stage : stages) {
             for (String output : stage.outputs()) {

--- a/data-pipeline-libraries-java/data-pipeline-gcp-dataflow-java/src/main/java/com/enrichmeai/culvert/gcp/dataflow/StageTransform.java
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-dataflow-java/src/main/java/com/enrichmeai/culvert/gcp/dataflow/StageTransform.java
@@ -1,0 +1,128 @@
+package com.enrichmeai.culvert.gcp.dataflow;
+
+import com.enrichmeai.culvert.contracts.PipelineStage;
+import com.enrichmeai.culvert.contracts.RuntimeContext;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PDone;
+
+import java.util.Objects;
+
+/**
+ * Adapts a Culvert {@link PipelineStage} into a Beam {@link PTransform} that
+ * triggers the stage's {@link PipelineStage#execute(RuntimeContext) execute}
+ * hook inside the Beam graph.
+ *
+ * <h2>Shape: {@code PTransform<PBegin, PDone>}</h2>
+ *
+ * <p>{@link PipelineStage#execute(RuntimeContext)} is {@code void} and
+ * side-effecting: a stage reads and writes through the adapters carried on the
+ * {@link RuntimeContext} (Source/Sink/Warehouse/BlobStore), it does not map a
+ * {@code PCollection} of elements. So this transform does not consume or
+ * produce a typed {@code PCollection}; it is rooted at {@link PBegin} and
+ * terminates at {@link PDone}. Its single job is to <em>trigger</em> the stage
+ * exactly once when the Beam pipeline runs.
+ *
+ * <p>Richer element-level translation — where a stage maps an input
+ * {@code PCollection} to an output {@code PCollection} so Beam can fuse and
+ * parallelise the data flow — is deliberately out of Sprint-9 scope. It will
+ * arrive when stages expose a Beam-aware element contract (Sprint-future).
+ *
+ * <h2>Execution semantics: exactly once per run</h2>
+ *
+ * <p>The transform expands to {@code Create.of(<single trigger token>)}
+ * followed by a {@link ParDo} whose {@link DoFn} calls {@code execute} in its
+ * {@code @ProcessElement} method. {@code Create.of} a one-element collection
+ * yields exactly one element, so {@code execute} is invoked exactly once for
+ * the pipeline run. (A {@code DoFn} {@code @Setup}/{@code @StartBundle} hook
+ * was rejected: those fire per-instance / per-bundle and a runner may create
+ * several instances or bundles, which would run the stage more than once.)
+ *
+ * <h2>Serialization</h2>
+ *
+ * <p>The {@link DoFn} captures both the {@link PipelineStage} and the
+ * {@link RuntimeContext}; Beam serializes a {@code DoFn} to its workers. Both
+ * must therefore be {@code Serializable} at runtime. {@code DefaultRuntimeContext}
+ * is; stub and adapter stages used with this transform are expected to be
+ * (a stage that closes over non-serializable state cannot run on a distributed
+ * runner regardless of this transform).
+ *
+ * <p>Sprint-9 deliverable (T9.2).
+ */
+public final class StageTransform extends PTransform<PBegin, PDone> {
+
+    private static final long serialVersionUID = 1L;
+
+    /** The single token fed through {@code Create.of} to trigger one execution. */
+    private static final String TRIGGER_TOKEN = "execute";
+
+    // Driver-side only: a PTransform is used during pipeline construction,
+    // not serialized to workers, so these can be transient (and thus exempt
+    // from the serial lint).
+    private final transient PipelineStage stage;
+    private final transient RuntimeContext context;
+
+    private StageTransform(PipelineStage stage, RuntimeContext context) {
+        super("Stage[" + stage.name() + "]");
+        this.stage = stage;
+        this.context = context;
+    }
+
+    /**
+     * Wrap a stage + context as a Beam transform.
+     *
+     * @param stage   The stage to execute. Required; must be serializable to
+     *                run on a distributed runner.
+     * @param context The runtime context passed to {@code execute}. Required;
+     *                must be serializable.
+     */
+    public static StageTransform of(PipelineStage stage, RuntimeContext context) {
+        Objects.requireNonNull(stage, "stage must not be null");
+        Objects.requireNonNull(context, "context must not be null");
+        return new StageTransform(stage, context);
+    }
+
+    @Override
+    public PDone expand(PBegin input) {
+        PCollection<String> trigger = input.apply(
+                "Trigger[" + stage.name() + "]", Create.of(TRIGGER_TOKEN));
+        trigger.apply(
+                "Execute[" + stage.name() + "]",
+                ParDo.of(new ExecuteStageFn(stage, context)));
+        return PDone.in(input.getPipeline());
+    }
+
+    /**
+     * The {@link DoFn} that invokes {@link PipelineStage#execute(RuntimeContext)}
+     * once per input element. Driven by a one-element {@code Create.of}, so
+     * {@code execute} runs exactly once per pipeline run.
+     */
+    static final class ExecuteStageFn extends DoFn<String, Void> {
+
+        private static final long serialVersionUID = 1L;
+
+        // Serialized to workers by Beam. PipelineStage / RuntimeContext are
+        // interface types not declared Serializable, but the concrete impls
+        // placed here at runtime must be (DefaultRuntimeContext is). Suppress
+        // the serial lint; a non-serializable impl would fail at run() time,
+        // which is the correct place for that error to surface.
+        @SuppressWarnings("serial")
+        private final PipelineStage stage;
+        @SuppressWarnings("serial")
+        private final RuntimeContext context;
+
+        ExecuteStageFn(PipelineStage stage, RuntimeContext context) {
+            this.stage = stage;
+            this.context = context;
+        }
+
+        @ProcessElement
+        public void processElement() {
+            stage.execute(context);
+        }
+    }
+}

--- a/data-pipeline-libraries-java/data-pipeline-gcp-dataflow-java/src/test/java/com/enrichmeai/culvert/gcp/dataflow/DataflowPipelineExecutionTest.java
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-dataflow-java/src/test/java/com/enrichmeai/culvert/gcp/dataflow/DataflowPipelineExecutionTest.java
@@ -1,0 +1,152 @@
+package com.enrichmeai.culvert.gcp.dataflow;
+
+import com.enrichmeai.culvert.contracts.PipelineStage;
+import com.enrichmeai.culvert.contracts.RuntimeContext;
+import com.enrichmeai.culvert.runtime.DefaultRuntimeContext;
+import org.apache.beam.runners.direct.DirectRunner;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Sprint-9 T9.4 (scope-capped): prove that a {@link DataflowPipeline} built
+ * from <strong>stub</strong> {@link PipelineStage} impls executes its topology
+ * on Beam's {@link DirectRunner}.
+ *
+ * <p>No real BigQuery/GCS/Pub-Sub adapters are wired here — real-adapter
+ * wiring + real-fixture ITs are deferred to Sprint-10 T10.0, once the
+ * IT-support module supplies fixtures. The stubs only record that they ran.
+ *
+ * <p>The test verifies two things, split because of the transform's design:
+ *
+ * <ul>
+ *   <li><strong>Execution:</strong> both stages run to completion on the
+ *       DirectRunner, surviving a real serialization round-trip of the stage
+ *       + {@link RuntimeContext} into the DoFn. Stages are deliberately
+ *       <em>declared out of dependency order</em> to exercise the topological
+ *       wiring in {@code buildBeam}.</li>
+ *   <li><strong>Dependency order:</strong> asserted separately and
+ *       deterministically via {@link DataflowPipeline#topologicalOrder()}.
+ *       Temporal ordering between the independent {@code PBegin}-rooted stage
+ *       transforms is a runner scheduling concern (Sprint-9 stages don't pass
+ *       elements between each other); element-level ordering is sprint-future.</li>
+ * </ul>
+ */
+class DataflowPipelineExecutionTest {
+
+    /**
+     * Static recorder keyed by stage name. Static (not an instance field) so
+     * it is reachable from the worker-side DoFn without being captured into
+     * the serialized graph. On the in-process DirectRunner the worker shares
+     * this JVM, so the markers are observable after {@code waitUntilFinish()}.
+     */
+    static final ConcurrentHashMap<String, Boolean> EXECUTED = new ConcurrentHashMap<>();
+
+    @BeforeEach
+    void resetRecorder() {
+        EXECUTED.clear();
+    }
+
+    @Test
+    void twoStagePipelineExecutesOnDirectRunner() {
+        // Declare OUT of dependency order: "transform" depends on "read"'s
+        // output, but is declared first. buildBeam must topologically sort.
+        PipelineStage read = new RecordingStage("read", List.of(), List.of("rows"));
+        PipelineStage transform = new RecordingStage("transform", List.of("rows"), List.of("clean"));
+        DataflowPipeline pipeline = new DataflowPipeline("two-stage", List.of(transform, read));
+
+        RuntimeContext context = DefaultRuntimeContext
+                .builder("run-t94", "test")
+                .config(Map.of("dataset", "events"))
+                .build();
+
+        PipelineOptions opts = PipelineOptionsFactory.create();
+        opts.setRunner(DirectRunner.class);
+
+        Pipeline beam = pipeline.buildBeam(opts, context);
+        beam.run().waitUntilFinish();
+
+        assertThat(EXECUTED).containsKeys("read", "transform");
+        assertThat(EXECUTED.get("read")).isTrue();
+        assertThat(EXECUTED.get("transform")).isTrue();
+    }
+
+    @Test
+    void buildBeamComputesDependencyOrderRegardlessOfDeclaration() {
+        // a -> b -> c, declared as [c, a, b].
+        PipelineStage a = new RecordingStage("a", List.of(), List.of("x"));
+        PipelineStage b = new RecordingStage("b", List.of("x"), List.of("y"));
+        PipelineStage c = new RecordingStage("c", List.of("y"), List.of());
+        DataflowPipeline pipeline = new DataflowPipeline("linear", List.of(c, a, b));
+
+        pipeline.validate();
+        assertThat(pipeline.topologicalOrder()).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    void topologicalOrderRespectsDiamondDependencies() {
+        // a -> {b, c} -> d. Both b and c depend on a; d depends on b and c.
+        PipelineStage a = new RecordingStage("a", List.of(), List.of("a-out"));
+        PipelineStage b = new RecordingStage("b", List.of("a-out"), List.of("b-out"));
+        PipelineStage c = new RecordingStage("c", List.of("a-out"), List.of("c-out"));
+        PipelineStage d = new RecordingStage("d", List.of("b-out", "c-out"), List.of());
+        DataflowPipeline pipeline = new DataflowPipeline("diamond", List.of(d, c, b, a));
+
+        pipeline.validate();
+        List<String> order = pipeline.topologicalOrder();
+
+        // 'a' first, 'd' last; b and c in between (relative order unspecified).
+        assertThat(order).hasSize(4);
+        assertThat(order.get(0)).isEqualTo("a");
+        assertThat(order.get(3)).isEqualTo("d");
+        assertThat(order).contains("b", "c");
+    }
+
+    /**
+     * A serializable stub stage that records its execution in {@link #EXECUTED}.
+     * Named static class (not anonymous) so it survives Beam serialization.
+     */
+    static final class RecordingStage implements PipelineStage, Serializable {
+        private static final long serialVersionUID = 1L;
+        private final String name;
+        @SuppressWarnings("serial")
+        private final List<String> inputs;
+        @SuppressWarnings("serial")
+        private final List<String> outputs;
+
+        RecordingStage(String name, List<String> inputs, List<String> outputs) {
+            this.name = name;
+            this.inputs = List.copyOf(inputs);
+            this.outputs = List.copyOf(outputs);
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+        @Override
+        public List<String> inputs() {
+            return inputs;
+        }
+
+        @Override
+        public List<String> outputs() {
+            return outputs;
+        }
+
+        @Override
+        public void execute(RuntimeContext context) {
+            EXECUTED.put(name, Boolean.TRUE);
+        }
+    }
+}

--- a/data-pipeline-libraries-java/data-pipeline-gcp-dataflow-java/src/test/java/com/enrichmeai/culvert/gcp/dataflow/DataflowPipelineTest.java
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-dataflow-java/src/test/java/com/enrichmeai/culvert/gcp/dataflow/DataflowPipelineTest.java
@@ -160,26 +160,49 @@ class DataflowPipelineTest {
     }
 
     private static PipelineStage stage(String name, List<String> inputs, List<String> outputs) {
-        return new PipelineStage() {
-            @Override
-            public String name() {
-                return name;
-            }
+        return new StubStage(name, inputs, outputs);
+    }
 
-            @Override
-            public List<String> inputs() {
-                return inputs;
-            }
+    /**
+     * A no-op {@link PipelineStage} stub. Declared as a named, serializable
+     * static class (not an anonymous inner class) so it survives Beam's
+     * serialization when {@code buildBeam} applies a {@link StageTransform}
+     * and the pipeline runs on the DirectRunner.
+     */
+    static final class StubStage implements PipelineStage, java.io.Serializable {
+        private static final long serialVersionUID = 1L;
+        private final String name;
+        // List.copyOf yields a serializable immutable list at runtime; the
+        // declared List type can't be proven serializable at compile time.
+        @SuppressWarnings("serial")
+        private final List<String> inputs;
+        @SuppressWarnings("serial")
+        private final List<String> outputs;
 
-            @Override
-            public List<String> outputs() {
-                return outputs;
-            }
+        StubStage(String name, List<String> inputs, List<String> outputs) {
+            this.name = name;
+            this.inputs = List.copyOf(inputs);
+            this.outputs = List.copyOf(outputs);
+        }
 
-            @Override
-            public void execute(RuntimeContext context) {
-                // no-op for tests
-            }
-        };
+        @Override
+        public String name() {
+            return name;
+        }
+
+        @Override
+        public List<String> inputs() {
+            return inputs;
+        }
+
+        @Override
+        public List<String> outputs() {
+            return outputs;
+        }
+
+        @Override
+        public void execute(RuntimeContext context) {
+            // no-op for tests
+        }
     }
 }


### PR DESCRIPTION
Sprint 9 close. Merges `sprint-9` → `main`.

DefaultRuntimeContext + StageTransform + buildBeam topological apply + DirectRunner execution test. The exec core is the critical-path foundation for Block 2 (Sprints 10-16).

Full reactor: BUILD SUCCESS. Retro on epic #44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)