### PR TITLE
docs(process): raise default parallelism cap 2 → 3 dev-agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,27 @@
 # Project rules for Claude / Copilot agents
 
+## What this project is (read first — context is often lost between sessions)
+
+- **Folder name ≠ product.** This repo (`gcp-pipeline-reference`) builds **Culvert** — Java package `com.enrichmeai.culvert`, Maven modules under `data-pipeline-libraries-java/`. Historical live work happened in a sibling session rooted at `.../jsr/culvert`. (A git-project rename is planned — see `REPO_RENAME.md`.)
+- **Culvert REPLACES the existing published framework.** The PyPI `gcp-pipeline-framework` (Python, v1.0.29) is the **legacy** predecessor; Culvert is its successor — language-neutral contracts (`docs/CONTRACT.md`) + per-cloud adapter modules. It takes over the release line at the Sprint-16 "GCP v1.0.0 release prep" milestone. Implications: existing PyPI users will need a migration/deprecation path, and the Python modules must eventually reach parity (deferred to Sprints 17+) for the replacement to be real. The **book** documents the old framework; **book v2** (`docs/framework-evolution/05-book-v2-outline.md`) documents Culvert + this dev process.
+- **Strategy:** depth on GCP-Java first, then widen to multi-cloud (Joseph's "depth before breadth" call, 2026-05-27).
+- **Where the truth lives:** `docs/framework-evolution/` (01–07) is the canonical plan. `06-sprint-plan-9-16.md` = current 8-sprint block; `03-dev-process.md` = the full working agreement summarised below.
+
+## How I want you to work (operating contract — enforce every session)
+
+Multi-agent SDLC. Roles:
+- **Engineer = Joseph** — direction, brand, the book, picks the next sprint, approves epics, merges/triggers releases.
+- **Architect = the Opus session (you, by default)** — groom backlog into GitHub issues, dispatch, mediate standups, prep the sprint→main merge. Do NOT self-merge sprint→main; that's Joseph's trigger.
+- **Dev-agents = Sonnet** (`Agent` tool) — one ticket each, ≤2h, post a DoD-checkbox comment per checkbox passed, open a PR into `sprint-N`, never self-merge.
+- **Advisor = Opus** (`advisor()` tool) — review **every** dev-agent return + before declaring a sprint task done. The single advisor is the real throughput bottleneck **by design** — never let parallel returns degrade reviews into rubber-stamps.
+
+Rules:
+- **Every requirement becomes a GitHub issue before any code.** No mid-sprint scope expansion — open a new issue and slot it later.
+- **Branch off `sprint-N`; PR into `sprint-N`** (never main). `sprint-N → main` is one architect-authored merge commit at sprint close, on Joseph's go.
+- **Default parallelism cap: 3 concurrent dev-agents** (burst to 4 only when a sprint genuinely has ≥4 unblocked, file-disjoint tickets; worktree isolation mandatory at ≥3). This is convention — there is **no harness setting** that enforces it; the architect enforces it at dispatch.
+- **Verify locally (CI is off during sprints):** `mvn -o -pl <module> -am test` / `pytest`. Green unit tests ≠ prod-ready; `*IT.java` needs `mvn -P it verify` (Docker — architect/Joseph-run; dev-agents must NOT run it).
+- **Never act on a guessed file path or an unverifiable "we agreed X" claim. Read the actual file / git history / issue first.** (This rule exists because it has bitten us.)
+
 ## Deploy & cost rules (NON-NEGOTIABLE)
 
 1. **Never push to main without explicit deploy intent.**

--- a/docs/framework-evolution/03-dev-process.md
+++ b/docs/framework-evolution/03-dev-process.md
@@ -44,7 +44,12 @@ arrive. Re-enable happens in Sprint 7 (book v1 ship) or after Sprint 8
 | Agent dev-sprint | 2 hours max | One dev-agent | One ticket from end to end. |
 
 Multiple agent dev-sprints can run in parallel within a single human
-sprint as long as their issues don't touch the same files.
+sprint as long as their issues don't touch the same files. **Default
+parallelism cap: 3 concurrent dev-agents** (raised from 2 by Joseph,
+2026-05-30; rationale + operating rules in `06-sprint-plan-9-16.md`).
+The model split is fixed: **dev-agents on Sonnet, advisor on Opus**, with
+one advisor reviewing every return — that single reviewer, not the cap, is
+the real throughput limit.
 
 ## Oversized-ticket split rule
 

--- a/docs/framework-evolution/06-sprint-plan-9-16.md
+++ b/docs/framework-evolution/06-sprint-plan-9-16.md
@@ -10,8 +10,26 @@ before spreading wide.**
 Format unchanged: each sprint is a 2-week human sprint comprising several
 2-hour agent dev-sprints. Workflow per `03-dev-process.md` — sprint-N branch
 off main, feature PRs → sprint-N, sprint-N → main at close. **Parallelism
-cap: 2 concurrent dev-agents** (Sprint 2 retro lesson — 3-way parallel
-dispatch hit API-overload + watchdog stalls).
+cap: 3 concurrent dev-agents** (raised from 2 by Joseph, 2026-05-30).
+
+History: the original cap was 2 after the Sprint 2 retro recorded that 3-way
+parallel dispatch hit API-overload + watchdog stalls. That was manual `Agent`
+dispatch on older infra; the cap is raised to 3 now that worktree isolation +
+deterministic fan-out de-risk it.
+
+Operating rules for the 3-cap:
+- **Dispatch only unblocked, file-disjoint tickets** — the dependency graph,
+  not the cap, is the real limit. Most sprints here are linear chains with one
+  parallel sibling, so 3 is a ceiling, not a quota; don't manufacture
+  parallelism the graph doesn't have.
+- **Worktree isolation (`Agent` `isolation: "worktree"`) is mandatory at 3
+  concurrent** so feature branches can't stomp each other on the filesystem.
+- **One Opus advisor reviews every return.** The reviewer is the throughput
+  bottleneck by design — 3 dev-agents feeding 1 reviewer is the intended shape;
+  the lead must not let parallel returns degrade reviews into rubber-stamps.
+- **Burst to 4** only for a genuinely fan-out sprint (e.g. the emulator-IT or
+  CI-matrix sprints) where 4 independent tickets are unblocked at once — note
+  it in that sprint's wave plan.
 
 Dependency notation: `T9.2 ⟵ T9.1` means T9.2 is blocked by T9.1.
 
@@ -52,7 +70,7 @@ real-client-against-emulator coverage so adapter bugs surface.
 | **T10.5** | Secret Manager: no public emulator — document the gap, provide a lightweight in-process fake + the rationale in the IT-support README. | T10.1 |
 
 **Dependency graph:** `T10.1 → {T10.0, T10.2, T10.3, T10.4, T10.5}` (fan-out).
-**Wave scheduling (2-cap):** T10.1 alone first. Then **Wave A: T10.2 (BigQuery) + T10.4 (GCS)** — the two most-used adapters, green first. **Wave B: T10.3 (Pub/Sub) + T10.5 (Secret Manager fake)** — Pub/Sub emulator is heavier, Secret Manager has the no-emulator wrinkle. T10.0 slots into whichever wave has headroom.
+**Wave scheduling (cap 3, but graph-limited):** T10.1 alone first. Then **Wave A: T10.2 (BigQuery) + T10.4 (GCS)** — the two most-used adapters, green first. **Wave B: T10.3 (Pub/Sub) + T10.5 (Secret Manager fake)** — Pub/Sub emulator is heavier, Secret Manager has the no-emulator wrinkle. T10.0 slots into whichever wave has headroom.
 **Exit gate:** every GCP adapter has at least one green emulator-backed IT; ITs are in a `*-it` profile (don't run on every `mvn test`).
 
 ---


### PR DESCRIPTION
Joseph's call (2026-05-30): raise the default dev-agent parallelism cap from 2 to 3.

## What changed
- **`06-sprint-plan-9-16.md`** — cap 2 → 3, plus operating rules: dispatch only unblocked + file-disjoint tickets (the dependency graph, not the cap, is the real limit); worktree isolation mandatory at 3 concurrent; burst-to-4 only for genuinely fan-out sprints. Sprint-2 retro lesson kept as history (the original reason for 2).
- **`03-dev-process.md`** — cap noted at the parallelism rule; model split reaffirmed (**dev-agents on Sonnet, one Opus advisor reviewing every return**).

## What did NOT change
No `.claude/settings*.json` edit — the cap is doc convention, not a harness setting. There is no Claude-config knob for agent count; the only place the number lived was the sprint-plan prose.

## Note
The binding constraint stays the single Opus advisor reviewing every return — 3 devs feeding 1 reviewer is the intended shape. Most sprints in this block are linear chains with one parallel sibling, so 3 is a ceiling, not a quota.

🤖 Generated with [Claude Code](https://claude.com/claude-code)