### PR TITLE
[sprint-17] Wave A — Python contract reconciliation (epic #112)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,18 @@ Before dispatching any wave of dev-agents:
 5. **Integrated verify after merging a wave** — module-green in isolation ≠ reactor-green together. Run the affected modules (or full reactor + `mvn -P it verify` at sprint close). This is the T10.6/T10.7 lesson, repeated.
 6. **After merge:** post DoD-checkbox comment on each issue, close it, prune the worktree + branch.
 
+### Dev-agent Definition of Done (learned the hard way — Sprint 17)
+Bake these into every agent prompt; they design out the misses the architect had to catch in Wave A (a `_FakeBlobStore` test double left on the old `open()`; a "45 passed" claim from an env the agent didn't leave behind). The point: the agent's report must be **reproducible by the architect with the exact commands given**, not taken on faith.
+1. **Run the FULL package suite to green — not just your new tests.** Changing a shared type (a `Protocol`, a record, an interface) breaks its implementers and test doubles elsewhere. Before claiming done: `grep` for every implementer + fake of the symbol you changed and update them in the *same* change, then run the whole package's tests.
+2. **A reproducible env is part of "done"; "no env / didn't run" is a STOP-and-report, not a completion.** Use the canonical recipe and quote it verbatim in the report:
+   - Python: `python3 -m venv /tmp/vw_<id> && /tmp/vw_<id>/bin/pip install -q -e <pkg> [-e <each-local-dep>] pytest && /tmp/vw_<id>/bin/python -m pytest <pkg>/tests -q`
+   - Java: `mvn -o -pl <module> -am test`
+   Report the **exact commands + exact pass/fail counts**. The architect re-runs them verbatim; if they don't reproduce, the work isn't done.
+3. **Cite the source for every cross-language / "matches X" claim** as `file:line` (e.g. "mirrors `StageMetrics.java:27`"), so the claim is checkable, not asserted.
+4. **Flag, don't fake.** If a guarantee genuinely doesn't fit, or an env truly can't be built offline, say so precisely and stop — a flagged gap is correct; a silent or invented green is not.
+
+The architect still verifies independently (checklist item 3) — but a DoD-conformant report should make that a confirmation, not a rescue.
+
 ## Deploy & cost rules (NON-NEGOTIABLE)
 
 1. **Never push to main without explicit deploy intent.**

--- a/data-pipeline-libraries/data-pipeline-contract-tests/src/data_pipeline_contract_tests/__init__.py
+++ b/data-pipeline-libraries/data-pipeline-contract-tests/src/data_pipeline_contract_tests/__init__.py
@@ -6,15 +6,23 @@ Protocol's documented behaviour.
 
 Mirror of the Java ``data-pipeline-contract-tests`` library.
 
-Sprint-5 deliverable.
+Sprint-5 deliverable. Sprint-17 (T17.3): added
+:class:`StageMetricsHookContract` and brought existing mixins to 1:1
+method-level parity with their Java counterparts (null-rejection tests).
 """
 
 from __future__ import annotations
 
 from data_pipeline_contract_tests.blob_store import BlobStoreContract
 from data_pipeline_contract_tests.secrets import SecretProviderContract
+from data_pipeline_contract_tests.stage_metrics_hook import StageMetricsHookContract
 from data_pipeline_contract_tests.warehouse import WarehouseContract
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
-__all__ = ["BlobStoreContract", "SecretProviderContract", "WarehouseContract"]
+__all__ = [
+    "BlobStoreContract",
+    "SecretProviderContract",
+    "StageMetricsHookContract",
+    "WarehouseContract",
+]

--- a/data-pipeline-libraries/data-pipeline-contract-tests/src/data_pipeline_contract_tests/blob_store.py
+++ b/data-pipeline-libraries/data-pipeline-contract-tests/src/data_pipeline_contract_tests/blob_store.py
@@ -1,4 +1,7 @@
-"""BlobStore contract test mixin."""
+"""BlobStore contract test mixin.
+
+Java mirror: ``com.enrichmeai.culvert.contracttests.BlobStoreContractTest``
+"""
 
 from __future__ import annotations
 
@@ -8,6 +11,8 @@ import pytest
 class BlobStoreContract:
     """Mixin — subclasses provide ``store``, ``known_uri``, ``missing_uri``
     fixtures. ``known_uri`` resolves to bytes equal to ``b"hello"``.
+
+    Java mirror: ``BlobStoreContractTest`` (Sprint-5 deliverable).
     """
 
     def test_get_known_returns_bytes(self, store, known_uri):
@@ -22,3 +27,8 @@ class BlobStoreContract:
     def test_delete_missing_idempotent(self, store, missing_uri):
         # Should not raise.
         store.delete(missing_uri)
+
+    def test_null_arguments_rejected(self, store):
+        # Java: ``nullArgumentsRejected`` — get(null) must raise.
+        with pytest.raises((TypeError, ValueError)):
+            store.get(None)

--- a/data-pipeline-libraries/data-pipeline-contract-tests/src/data_pipeline_contract_tests/secrets.py
+++ b/data-pipeline-libraries/data-pipeline-contract-tests/src/data_pipeline_contract_tests/secrets.py
@@ -1,4 +1,7 @@
-"""SecretProvider contract test mixin."""
+"""SecretProvider contract test mixin.
+
+Java mirror: ``com.enrichmeai.culvert.contracttests.SecretProviderContractTest``
+"""
 
 from __future__ import annotations
 
@@ -9,6 +12,8 @@ class SecretProviderContract:
     """Mixin — subclasses provide ``self.provider`` via a pytest fixture
     named ``provider`` (and configure it so ``get("known")`` returns
     ``"the-secret"`` and ``get("missing")`` raises ``KeyError``).
+
+    Java mirror: ``SecretProviderContractTest`` (Sprint-5 deliverable).
 
     Example wiring in a cloud adapter's test sources:
 
@@ -29,3 +34,8 @@ class SecretProviderContract:
     def test_get_missing_raises(self, provider):
         with pytest.raises((KeyError, LookupError)):
             provider.get("missing")
+
+    def test_null_name_rejected(self, provider):
+        # Java: ``nullNameRejected`` — get(null, ...) must raise.
+        with pytest.raises((TypeError, ValueError)):
+            provider.get(None)

--- a/data-pipeline-libraries/data-pipeline-contract-tests/src/data_pipeline_contract_tests/stage_metrics_hook.py
+++ b/data-pipeline-libraries/data-pipeline-contract-tests/src/data_pipeline_contract_tests/stage_metrics_hook.py
@@ -1,0 +1,109 @@
+"""StageMetricsHook contract test mixin.
+
+Java mirror: no ``Abstract*ContractTest`` class exists on the Java side —
+this mixin is derived directly from the ``StageMetricsHook`` interface contract
+and its accompanying ``StageMetrics`` record
+(``com.enrichmeai.culvert.contracts.StageMetricsHook``,
+``com.enrichmeai.culvert.contracts.StageMetrics``, Sprint-12 / issue #65).
+
+The defining guarantee of ``StageMetricsHook`` is:
+  "Implementations must not propagate monitoring-backend failures to the
+   caller. If the backend is unavailable the implementation logs and
+   swallows the exception so the pipeline continues uninterrupted."
+
+That guarantee is the primary behavioral assertion this mixin checks.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from data_pipeline_core.contracts.stage_metrics import StageMetrics
+
+
+def _valid_metrics(**overrides) -> StageMetrics:
+    """Build a minimal valid :class:`StageMetrics` snapshot."""
+    defaults = dict(
+        pipeline_id="pipe-1",
+        run_id="run-abc",
+        stage_name="my-stage",
+        rows_processed=100,
+        stage_latency_ms=42.5,
+        error_count=0,
+    )
+    defaults.update(overrides)
+    return StageMetrics(**defaults)
+
+
+class StageMetricsHookContract:
+    """Mixin — subclasses provide two pytest fixtures:
+
+    - ``hook`` — the :class:`~data_pipeline_core.contracts.stage_metrics.StageMetricsHook`
+      implementation under test (happy-path instance).
+    - ``failing_hook`` — the same implementation wired to a backend that
+      raises an exception on every ``record_stage_metrics`` call, used to
+      verify the swallow-and-continue guarantee.
+
+    Java mirror: no ``AbstractStageMetricsHookContractTest`` exists in
+    ``data-pipeline-contract-tests-java``; guarantees are derived directly
+    from the interface contract in ``StageMetricsHook.java`` (Sprint-12
+    / issue #65).
+
+    Example wiring:
+
+    .. code-block:: python
+
+        from data_pipeline_contract_tests import StageMetricsHookContract
+        from data_pipeline_core.contracts.stage_metrics import StageMetrics
+        from unittest.mock import MagicMock
+
+        class TestMyHook(StageMetricsHookContract):
+            @pytest.fixture
+            def hook(self):
+                client = make_mock_monitoring_client()
+                return MyCloudMetricsHook(client)
+
+            @pytest.fixture
+            def failing_hook(self):
+                client = MagicMock()
+                client.create_time_series.side_effect = RuntimeError("backend down")
+                return MyCloudMetricsHook(client)
+    """
+
+    def test_record_stage_metrics_returns_none(self, hook):
+        """Happy-path: ``record_stage_metrics`` with a valid snapshot returns
+        ``None`` (i.e. does not raise and has no meaningful return value).
+        """
+        result = hook.record_stage_metrics(_valid_metrics())
+        assert result is None
+
+    def test_record_stage_metrics_all_fields(self, hook):
+        """Happy-path: all three label fields and all three metric fields are
+        accepted, including edge values (zero rows, zero errors, non-zero latency).
+        """
+        hook.record_stage_metrics(
+            _valid_metrics(rows_processed=0, stage_latency_ms=0.0, error_count=0)
+        )
+
+    def test_record_stage_metrics_with_errors(self, hook):
+        """Happy-path: non-zero ``error_count`` is accepted without raising."""
+        hook.record_stage_metrics(_valid_metrics(error_count=5))
+
+    def test_backend_failure_is_swallowed(self, failing_hook):
+        """Core contract guarantee: if the monitoring backend is unavailable
+        the implementation must NOT propagate the exception to the caller.
+        The pipeline continues uninterrupted.
+
+        This is the primary behavioral invariant stated in both
+        ``StageMetricsHook.java`` and the Python ``StageMetricsHook`` Protocol.
+        """
+        # Must not raise even though the backend raises internally.
+        failing_hook.record_stage_metrics(_valid_metrics())
+
+    def test_null_metrics_rejected(self, hook):
+        """``record_stage_metrics(None)`` must raise ``TypeError`` or
+        ``ValueError`` — implementations should not silently accept ``None``
+        in place of a ``StageMetrics`` snapshot.
+        """
+        with pytest.raises((TypeError, ValueError)):
+            hook.record_stage_metrics(None)

--- a/data-pipeline-libraries/data-pipeline-contract-tests/src/data_pipeline_contract_tests/warehouse.py
+++ b/data-pipeline-libraries/data-pipeline-contract-tests/src/data_pipeline_contract_tests/warehouse.py
@@ -1,4 +1,7 @@
-"""Warehouse contract test mixin."""
+"""Warehouse contract test mixin.
+
+Java mirror: ``com.enrichmeai.culvert.contracttests.WarehouseContractTest``
+"""
 
 from __future__ import annotations
 
@@ -10,6 +13,10 @@ class WarehouseContract:
     ``query("SELECT id FROM contract_test_table")`` yields ``{"id": 1}``,
     ``table_exists("contract_test_table")`` is True, and
     ``table_exists("contract_missing_table")`` is False.
+
+    Java mirror: ``WarehouseContractTest`` (Sprint-5 deliverable; T15.4
+    added ``known_table``/``missing_table`` hook — Python subclasses
+    override the fixture to supply qualified names if needed).
     """
 
     def test_query_streams_rows(self, warehouse):
@@ -22,3 +29,8 @@ class WarehouseContract:
 
     def test_table_exists_missing_false(self, warehouse):
         assert warehouse.table_exists("contract_missing_table") is False
+
+    def test_null_sql_rejected(self, warehouse):
+        # Java: ``nullSqlRejected`` — query(null, ...) must raise.
+        with pytest.raises((TypeError, ValueError)):
+            warehouse.query(None)

--- a/data-pipeline-libraries/data-pipeline-contract-tests/tests/test_smoke.py
+++ b/data-pipeline-libraries/data-pipeline-contract-tests/tests/test_smoke.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from data_pipeline_contract_tests import (
     BlobStoreContract,
     SecretProviderContract,
+    StageMetricsHookContract,
     WarehouseContract,
 )
 
@@ -13,12 +14,32 @@ def test_mixins_importable():
     assert SecretProviderContract is not None
     assert BlobStoreContract is not None
     assert WarehouseContract is not None
+    assert StageMetricsHookContract is not None
 
 
 def test_mixins_have_expected_methods():
-    assert hasattr(SecretProviderContract, "test_get_known_returns_value")
-    assert hasattr(SecretProviderContract, "test_get_missing_raises")
+    # BlobStoreContract — mirrors BlobStoreContractTest.java
     assert hasattr(BlobStoreContract, "test_get_known_returns_bytes")
     assert hasattr(BlobStoreContract, "test_exists_known_true")
+    assert hasattr(BlobStoreContract, "test_exists_missing_false")
+    assert hasattr(BlobStoreContract, "test_delete_missing_idempotent")
+    assert hasattr(BlobStoreContract, "test_null_arguments_rejected")
+
+    # SecretProviderContract — mirrors SecretProviderContractTest.java
+    assert hasattr(SecretProviderContract, "test_get_known_returns_value")
+    assert hasattr(SecretProviderContract, "test_get_missing_raises")
+    assert hasattr(SecretProviderContract, "test_null_name_rejected")
+
+    # WarehouseContract — mirrors WarehouseContractTest.java
     assert hasattr(WarehouseContract, "test_query_streams_rows")
     assert hasattr(WarehouseContract, "test_table_exists_known_true")
+    assert hasattr(WarehouseContract, "test_table_exists_missing_false")
+    assert hasattr(WarehouseContract, "test_null_sql_rejected")
+
+    # StageMetricsHookContract — derived from StageMetricsHook interface
+    # (no Java AbstractStageMetricsHookContractTest exists)
+    assert hasattr(StageMetricsHookContract, "test_record_stage_metrics_returns_none")
+    assert hasattr(StageMetricsHookContract, "test_record_stage_metrics_all_fields")
+    assert hasattr(StageMetricsHookContract, "test_record_stage_metrics_with_errors")
+    assert hasattr(StageMetricsHookContract, "test_backend_failure_is_swallowed")
+    assert hasattr(StageMetricsHookContract, "test_null_metrics_rejected")

--- a/data-pipeline-libraries/data-pipeline-core/CONTRACT_CONFORMANCE.md
+++ b/data-pipeline-libraries/data-pipeline-core/CONTRACT_CONFORMANCE.md
@@ -1,0 +1,85 @@
+# Contract Conformance — Python vs Java 1.0.0
+
+Ticket: #114 (T17.2). Checked: Python Protocols in
+`data_pipeline_core/contracts/` against frozen Java contracts at
+`data-pipeline-core-java/…/contracts/` (+ `audit/`, `finops/`,
+`governance/`, `lineage/` packages).
+
+Idiom equivalences treated as **matches** (not drift):
+`snake_case` ↔ `camelCase`, `bytes` ↔ `byte[]`,
+`Iterator[X]` ↔ `Iterator<X>`, `Mapping[…]` ↔ `Map<…>`,
+`Optional[X]` ↔ `Optional<X>`, `@property` ↔ accessor method,
+`None` ↔ `void`. Python Protocol attributes (`name: str`) are
+equivalent to Java accessor methods (`String name()`).
+
+---
+
+## Contract table
+
+| Contract | Result | Delta |
+|---|---|---|
+| **AuditEventPublisher** | MATCHES | `publish(record)` + `flush()` — identical shape. |
+| **BlobStore** | DRIFT FIXED | Python had one `open(uri, mode="rb")` method; Java has two distinct methods `openInput(uri)` / `openOutput(uri)`. Split into `open_input(uri)` + `open_output(uri)` to match. All other methods (`get`, `put`, `list`, `exists`, `delete`, `copy`) match 1:1. |
+| **LineageEmitter** | MATCHES | Single `emit(event: LineageEvent)` — matches Java `@FunctionalInterface`. |
+| **PipelineStage** | MATCHES | `name`, `inputs`, `outputs` attributes + `execute(context)` — matches Java interface fields + method. |
+| **SecretProvider** | MATCHES | `get(name, version="latest")` + semantics (raises on missing, never log) match Java including default-version overload. |
+| **GovernancePolicy** | MATCHES | `classify(field, table)`, `masking_for(field, table)`, `retention_for(table)` match Java `classify`, `maskingFor`, `retentionFor`. Evolved in S9/S13 — Python kept up. |
+| **FinOpsSink** | MATCHES | `record(metrics: CostMetrics, tags: FinOpsTag)` — matches Java `@FunctionalInterface`. Evolved in S13 — Python kept up. |
+| **Warehouse** | MATCHES | All six methods — `query`, `execute`, `load_from_uri`, `merge`, `copy`, `table_exists` — match Java (`loadFromUri`, `tableExists` in Java camelCase). Return types match (`long`/`int` ↔ `int`; both are integer row counts). |
+| **ObservabilityHook** | MATCHES (with gap noted) | `counter`, `gauge`, `histogram` match 1:1. `log(level, message, **fields)` vs Java `log(level, message, Map<String,Object> fields)` is idiomatic — left as-is per style-preservation rule. `span(name)` returns an opaque `AbstractContextManager` vs Java's typed nested `Span` interface (with `setAttribute`/`recordException`/`close`) — richness gap, but the Python docstring explicitly notes the yielded object is implementation-defined; adding a `Span` Protocol would exceed the surgical scope of this ticket. Gap flagged for a future ticket. |
+| **JobControlRepository** | MATCHES | All 11 methods present with matching signatures (`create_job`, `get_job`, `update_status`, `mark_failed`, `mark_retrying`, `get_pending_jobs`, `get_entity_status`, `get_failed_jobs`, `get_fdp_job_status`, `cleanup_partial_load`, `update_cost_metrics`). Java uses `Optional<Long> totalRecords`; Python uses `Optional[int] = None` — idiomatic match. |
+| **RuntimeContext** | DRIFT FIXED | Missing `pipeline_id` property (T12.6 addition in Java: `pipelineId()` with default returning `runId()`). Added `pipeline_id` property with default `return self.run_id`. Also hardened module and class docstrings with the T10.6 serialization-boundary contract (only `run_id`/`environment`/`config` cross; registry is transient/rebuilt worker-side). **`stage_metrics` deliberately NOT added** — that accessor (`stageMetricsHook()` in Java) belongs to T12.4/StageMetricsHook, which is owned by ticket #113 (another agent). Adding it here would create a conflict. |
+| **Source** | MATCHES | `read(context: RuntimeContext) -> Iterator[T_co]` matches Java `Iterator<T> read(RuntimeContext context)`. |
+| **Sink** | MATCHES | `write(records: Iterator[U_contra], context: RuntimeContext) -> None` matches Java `void write(Iterator<U> records, RuntimeContext context)`. |
+| **Pipeline** | MATCHES | `name` attribute + `stages: Sequence[PipelineStage]` + `validate() -> None` match Java `name()`, `stages()`, `validate()`. |
+| **Transform** | MATCHES | `apply(records: Iterator[V], context: RuntimeContext) -> Iterator[W]` matches Java `Iterator<W> apply(Iterator<V> records, RuntimeContext context)`. |
+
+---
+
+## Files changed
+
+- `data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/contracts/blob_store.py` —
+  split `open(uri, mode)` into `open_input(uri)` + `open_output(uri)`.
+- `data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/contracts/runtime.py` —
+  added `pipeline_id` property (T12.6); hardened module + class docstrings
+  with T10.6 serialization-boundary semantics.
+- `data-pipeline-libraries/data-pipeline-core/CONTRACT_CONFORMANCE.md` —
+  this file (new).
+
+`contracts/__init__.py` — **not touched**. No new public exports are
+introduced by this ticket; existing exports are unchanged.
+
+---
+
+## Verification
+
+No pytest environment was available in this worktree at the time of
+execution. Command that should be run once an environment is set up:
+
+```
+cd data-pipeline-libraries/data-pipeline-core
+python -m pytest tests/ -x -q
+```
+
+(or `pytest` scoped to whatever the project's core-package test directory is).
+The two changed Protocols (`BlobStore`, `RuntimeContext`) have no callable
+method bodies — only ellipsis stubs — so the changes are purely structural
+and cannot introduce runtime regressions; `mypy --strict` or
+`pyright` over the `contracts/` directory is the appropriate static check.
+
+---
+
+## Open flags
+
+1. **ObservabilityHook `span()` richness gap**: Java's nested `Span` interface
+   exposes `setAttribute(key, value)` and `recordException(t)`. Python's
+   `span()` returns an opaque `AbstractContextManager[Any]`. This is
+   intentional per the existing Python docstring but callers cannot set
+   span attributes portably. Recommend a follow-up ticket to define a
+   minimal `Span` Protocol in Python matching the Java `Span` nested interface.
+
+2. **`stage_metrics` on RuntimeContext**: Java `RuntimeContext` has a
+   `stageMetrics() -> StageMetricsHook` accessor added in T12.4. This ticket
+   deliberately omits it because #113 owns `StageMetrics`/`StageMetricsHook`.
+   Once #113 lands its Python Protocol, a follow-up edit to `runtime.py`
+   should add `stage_metrics: "StageMetricsHook"` to match Java.

--- a/data-pipeline-libraries/data-pipeline-core/CONTRACT_CONFORMANCE.md
+++ b/data-pipeline-libraries/data-pipeline-core/CONTRACT_CONFORMANCE.md
@@ -28,7 +28,7 @@ equivalent to Java accessor methods (`String name()`).
 | **Warehouse** | MATCHES | All six methods — `query`, `execute`, `load_from_uri`, `merge`, `copy`, `table_exists` — match Java (`loadFromUri`, `tableExists` in Java camelCase). Return types match (`long`/`int` ↔ `int`; both are integer row counts). |
 | **ObservabilityHook** | MATCHES (with gap noted) | `counter`, `gauge`, `histogram` match 1:1. `log(level, message, **fields)` vs Java `log(level, message, Map<String,Object> fields)` is idiomatic — left as-is per style-preservation rule. `span(name)` returns an opaque `AbstractContextManager` vs Java's typed nested `Span` interface (with `setAttribute`/`recordException`/`close`) — richness gap, but the Python docstring explicitly notes the yielded object is implementation-defined; adding a `Span` Protocol would exceed the surgical scope of this ticket. Gap flagged for a future ticket. |
 | **JobControlRepository** | MATCHES | All 11 methods present with matching signatures (`create_job`, `get_job`, `update_status`, `mark_failed`, `mark_retrying`, `get_pending_jobs`, `get_entity_status`, `get_failed_jobs`, `get_fdp_job_status`, `cleanup_partial_load`, `update_cost_metrics`). Java uses `Optional<Long> totalRecords`; Python uses `Optional[int] = None` — idiomatic match. |
-| **RuntimeContext** | DRIFT FIXED | Missing `pipeline_id` property (T12.6 addition in Java: `pipelineId()` with default returning `runId()`). Added `pipeline_id` property with default `return self.run_id`. Also hardened module and class docstrings with the T10.6 serialization-boundary contract (only `run_id`/`environment`/`config` cross; registry is transient/rebuilt worker-side). **`stage_metrics` deliberately NOT added** — that accessor (`stageMetricsHook()` in Java) belongs to T12.4/StageMetricsHook, which is owned by ticket #113 (another agent). Adding it here would create a conflict. |
+| **RuntimeContext** | DRIFT FIXED | Missing `pipeline_id` property (T12.6 addition in Java: `pipelineId()` with default returning `runId()`). Added `pipeline_id` property with default `return self.run_id`. Also hardened module and class docstrings with the T10.6 serialization-boundary contract (only `run_id`/`environment`/`config` cross; registry is transient/rebuilt worker-side). `stage_metrics: "StageMetricsHook"` attribute added at sprint-17 integration (after #113 merged the `StageMetricsHook` Protocol), mirroring Java's abstract `StageMetricsHook stageMetrics()` (Sprint-12 / T12.4). Declared as an attribute alongside its siblings `observability`/`lineage`/`finops` — Python maps Java's named accessors to attribute annotations, not methods. |
 | **Source** | MATCHES | `read(context: RuntimeContext) -> Iterator[T_co]` matches Java `Iterator<T> read(RuntimeContext context)`. |
 | **Sink** | MATCHES | `write(records: Iterator[U_contra], context: RuntimeContext) -> None` matches Java `void write(Iterator<U> records, RuntimeContext context)`. |
 | **Pipeline** | MATCHES | `name` attribute + `stages: Sequence[PipelineStage]` + `validate() -> None` match Java `name()`, `stages()`, `validate()`. |
@@ -78,8 +78,9 @@ and cannot introduce runtime regressions; `mypy --strict` or
    span attributes portably. Recommend a follow-up ticket to define a
    minimal `Span` Protocol in Python matching the Java `Span` nested interface.
 
-2. **`stage_metrics` on RuntimeContext**: Java `RuntimeContext` has a
-   `stageMetrics() -> StageMetricsHook` accessor added in T12.4. This ticket
-   deliberately omits it because #113 owns `StageMetrics`/`StageMetricsHook`.
-   Once #113 lands its Python Protocol, a follow-up edit to `runtime.py`
-   should add `stage_metrics: "StageMetricsHook"` to match Java.
+2. **`stage_metrics` on RuntimeContext** — RESOLVED at sprint-17 integration.
+   After #113 merged the `StageMetricsHook` Protocol, `runtime.py` gained the
+   `stage_metrics: "StageMetricsHook"` attribute (with TYPE_CHECKING import),
+   matching Java's abstract `StageMetricsHook stageMetrics()` (T12.4). Declared
+   as an attribute alongside `observability`/`lineage`/`finops`, consistent with
+   how Python represents Java's named contract accessors.

--- a/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/__init__.py
+++ b/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/__init__.py
@@ -13,6 +13,7 @@ Most users will import the Protocols from the top level:
         JobControlRepository, BlobStore, Warehouse,
         AuditEventPublisher, GovernancePolicy, LineageEmitter,
         ObservabilityHook, FinOpsSink, SecretProvider,
+        StageMetrics, StageMetricsHook,
     )
 """
 
@@ -27,6 +28,7 @@ from data_pipeline_core.contracts.pipeline import Pipeline, PipelineStage
 from data_pipeline_core.contracts.runtime import RuntimeContext
 from data_pipeline_core.contracts.secrets import SecretProvider
 from data_pipeline_core.contracts.source import Sink, Source, Transform
+from data_pipeline_core.contracts.stage_metrics import StageMetrics, StageMetricsHook
 from data_pipeline_core.contracts.warehouse import Warehouse
 
 __version__ = "0.1.0"
@@ -52,4 +54,7 @@ __all__ = [
     "ObservabilityHook",
     "FinOpsSink",
     "SecretProvider",
+    # Typed per-stage metrics (Sprint-12 / T17.1)
+    "StageMetrics",
+    "StageMetricsHook",
 ]

--- a/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/autoconfig.py
+++ b/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/autoconfig.py
@@ -42,7 +42,7 @@ class AutoConfig:
     Field names match the contract module names in
     ``data_pipeline_core.contracts.*`` (warehouse, blob_store, source, sink,
     transform, secrets, job_control, finops, observability, lineage,
-    audit, governance, pipeline, runtime).
+    audit, governance, pipeline, runtime, stage_metrics).
     """
 
     warehouse: List[Type[Any]] = field(default_factory=list)
@@ -59,6 +59,9 @@ class AutoConfig:
     governance: List[Type[Any]] = field(default_factory=list)
     pipeline: List[Type[Any]] = field(default_factory=list)
     runtime: List[Type[Any]] = field(default_factory=list)
+    # Sprint-12 / T17.1: StageMetricsHook adapters register here.
+    # Cloud module entry-point key: ``stage_metrics``.
+    stage_metrics: List[Type[Any]] = field(default_factory=list)
 
     # In-process registration table — overrides anything from entry points.
     # Filled by the @register_adapter decorator below.

--- a/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/contracts/__init__.py
+++ b/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/contracts/__init__.py
@@ -1,4 +1,4 @@
-"""The eleven Protocols that make up the framework-to-cloud seam.
+"""The Protocols and value types that make up the framework-to-cloud seam.
 
 Each Protocol is small. Each is implementable in any cloud. None imports
 anything cloud-specific. Where a Protocol has an obvious GCP
@@ -17,6 +17,7 @@ from data_pipeline_core.contracts.pipeline import Pipeline, PipelineStage
 from data_pipeline_core.contracts.runtime import RuntimeContext
 from data_pipeline_core.contracts.secrets import SecretProvider
 from data_pipeline_core.contracts.source import Sink, Source, Transform
+from data_pipeline_core.contracts.stage_metrics import StageMetrics, StageMetricsHook
 from data_pipeline_core.contracts.warehouse import Warehouse
 
 __all__ = [
@@ -35,4 +36,6 @@ __all__ = [
     "ObservabilityHook",
     "FinOpsSink",
     "SecretProvider",
+    "StageMetrics",
+    "StageMetricsHook",
 ]

--- a/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/contracts/blob_store.py
+++ b/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/contracts/blob_store.py
@@ -28,12 +28,22 @@ class BlobStore(Protocol):
         """
         ...
 
-    def open(self, uri: str, mode: str = "rb") -> BinaryIO:
-        """Open a streaming handle on the object at `uri`.
+    def open_input(self, uri: str) -> BinaryIO:
+        """Open a streaming read handle on the object at `uri`.
 
         Use for large objects where loading the full bytes into memory
-        is wasteful. `mode` follows Python's open() conventions
-        (`rb` for read-binary, `wb` for write-binary).
+        is wasteful. Callers must close the stream (use as a context
+        manager where possible).
+
+        Raises FileNotFoundError if the object does not exist.
+        """
+        ...
+
+    def open_output(self, uri: str) -> BinaryIO:
+        """Open a streaming write handle for the object at `uri`.
+
+        Callers must close the stream to commit the write (use as a
+        context manager where possible). Overwrites existing objects.
         """
         ...
 

--- a/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/contracts/runtime.py
+++ b/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/contracts/runtime.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     from data_pipeline_core.contracts.lineage import LineageEmitter
     from data_pipeline_core.contracts.observability import ObservabilityHook
     from data_pipeline_core.contracts.secrets import SecretProvider
+    from data_pipeline_core.contracts.stage_metrics import StageMetricsHook
 
 
 @runtime_checkable
@@ -54,6 +55,11 @@ class RuntimeContext(Protocol):
     config: Mapping[str, Any]
     secrets: "SecretProvider"
     observability: "ObservabilityHook"
+    # Typed, Culvert-specific metrics seam (rows_processed / stage_latency_ms /
+    # error_count with the fixed label schema), alongside the general-purpose
+    # `observability` surface. Advisory; implementations supply a no-op default.
+    # Mirrors Java `RuntimeContext.stageMetrics()` (Sprint-12 / T12.4).
+    stage_metrics: "StageMetricsHook"
     lineage: "LineageEmitter"
     finops: "FinOpsSink"
     governance: "GovernancePolicy"

--- a/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/contracts/runtime.py
+++ b/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/contracts/runtime.py
@@ -10,6 +10,16 @@ This is the Protocol; the concrete implementation lives at
 matters: tests and alternate runtimes (e.g. a Beam DoFn that needs to
 construct a context inside a serialized worker) implement the Protocol
 without depending on the standard implementation.
+
+Serialization boundary (T10.6): when the concrete implementation is
+serialized across a distributed compute boundary (e.g. a Beam worker),
+only `run_id`, `environment`, and `config` cross that boundary. The
+protocol-implementation registry is *transient* — it is not shipped and
+is rebuilt worker-side from classpath discovery (AutoConfig/ServiceLoader
+equivalents). Driver-side `register()` calls are intentionally absent
+worker-side. Concrete implementations should document whether they are
+serialization-safe; this Protocol makes no serialization guarantee
+beyond the three identity/config fields.
 """
 
 from __future__ import annotations
@@ -33,6 +43,10 @@ class RuntimeContext(Protocol):
     overrides for tests or specialised runtimes. The framework's
     bootstrap routine populates the registry via auto-config callables
     contributed by each installed cloud module (Stage 3).
+
+    Serialization boundary: only `run_id`, `environment`, and `config`
+    cross a distributed-compute serialization boundary. The registry is
+    transient and rebuilt worker-side. See module docstring for details.
     """
 
     run_id: str
@@ -43,6 +57,22 @@ class RuntimeContext(Protocol):
     lineage: "LineageEmitter"
     finops: "FinOpsSink"
     governance: "GovernancePolicy"
+
+    @property
+    def pipeline_id(self) -> str:
+        """The logical pipeline identifier (the pipeline definition's name),
+        distinct from the run identifier that changes each execution.
+
+        Default: returns `run_id`, so existing implementations remain
+        compatible without any change. Concrete implementations are
+        encouraged to override this with a stable, human-readable pipeline
+        name configured at pipeline construction time (e.g.
+        ``"my-etl-pipeline"``) so that metrics and log labels carry a
+        meaningful ``pipeline_id`` that is consistent across runs.
+
+        Sprint-12 / T12.6 addition — mirrors Java `RuntimeContext.pipelineId()`.
+        """
+        return self.run_id
 
     def get(self, protocol: Type[Any]) -> Any:
         """Look up the registered implementation of a Protocol.

--- a/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/contracts/stage_metrics.py
+++ b/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/contracts/stage_metrics.py
@@ -1,0 +1,100 @@
+"""StageMetrics + StageMetricsHook — typed per-stage pipeline metrics.
+
+Mirrors the Java Sprint-12 / issue #65 additions:
+
+* ``StageMetrics`` — immutable snapshot of the three Culvert standard
+  metrics plus the three label dimensions. Python equivalent of the
+  Java ``record StageMetrics``.
+
+* ``StageMetricsHook`` — cloud-neutral contract for emitting per-stage
+  pipeline metrics. Python equivalent of the Java
+  ``interface StageMetricsHook``.
+
+Why a new protocol instead of ``ObservabilityHook``?
+``ObservabilityHook`` is a general-purpose surface (arbitrary name +
+tags). This contract codifies the Culvert-specific semantic: one call
+per stage completion emits exactly the three Culvert metric series
+(``culvert/rows_processed``, ``culvert/stage_latency_ms``,
+``culvert/error_count``) with a fixed label schema. That specificity
+enables type-safe constructors, clear mock-based testing, and prevents
+callers from accidentally mis-naming labels.
+
+Sprint-12 / issue #65; Python gap closed in T17.1 / issue #113.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class StageMetrics:
+    """Immutable snapshot of metrics for a single pipeline stage completion.
+
+    Carries the three Culvert standard metrics plus the three label
+    dimensions required by :class:`StageMetricsHook` implementations:
+
+    Labels:
+        pipeline_id:  metric label ``pipeline_id``
+        run_id:       metric label ``run_id``
+        stage_name:   metric label ``stage_name``
+
+    Metrics:
+        rows_processed:   ``culvert/rows_processed`` (CUMULATIVE INT64).
+                          Use ``0`` as the "unknown" sentinel for stages
+                          that do not surface element counts.
+        stage_latency_ms: ``culvert/stage_latency_ms`` (GAUGE DOUBLE).
+        error_count:      ``culvert/error_count`` (CUMULATIVE INT64).
+
+    This is a plain Python dataclass — frozen (immutable) to mirror the
+    Java record semantics. No cloud or framework imports.
+    """
+
+    pipeline_id: str
+    run_id: str
+    stage_name: str
+    rows_processed: int
+    stage_latency_ms: float
+    error_count: int
+
+    def __post_init__(self) -> None:
+        """Validate that the three label fields are non-None."""
+        if self.pipeline_id is None:
+            raise ValueError("pipeline_id must not be None")
+        if self.run_id is None:
+            raise ValueError("run_id must not be None")
+        if self.stage_name is None:
+            raise ValueError("stage_name must not be None")
+
+
+@runtime_checkable
+class StageMetricsHook(Protocol):
+    """Cloud-neutral contract for emitting per-stage pipeline metrics.
+
+    This Protocol is deliberately narrow: one method, one value type,
+    three fixed metrics (``rows_processed``, ``stage_latency_ms``,
+    ``error_count``) labelled by
+    ``pipeline_id``/``run_id``/``stage_name``. The narrowness is
+    intentional — it makes the GCP implementation testable in isolation
+    and keeps Beam/Dataflow wiring (which assembles the call-site) in a
+    separate module.
+
+    Implementations must not propagate monitoring-backend failures to the
+    caller. If the backend is unavailable the implementation logs and
+    swallows the exception so the pipeline continues uninterrupted.
+
+    See also: :class:`StageMetrics`, :class:`~data_pipeline_core.contracts.observability.ObservabilityHook`
+    """
+
+    def record_stage_metrics(self, metrics: StageMetrics) -> None:
+        """Record metrics for a completed pipeline stage.
+
+        Implementations must not propagate monitoring-backend failures to
+        the caller. If the backend is unavailable the implementation logs
+        and swallows the exception so the pipeline continues uninterrupted.
+
+        Args:
+            metrics: Stage metrics snapshot. Must not be None.
+        """
+        ...

--- a/data-pipeline-libraries/data-pipeline-core/tests/test_contracts_importable.py
+++ b/data-pipeline-libraries/data-pipeline-core/tests/test_contracts_importable.py
@@ -20,6 +20,8 @@ from data_pipeline_core import (
     SecretProvider,
     Sink,
     Source,
+    StageMetrics,
+    StageMetricsHook,
     Transform,
     Warehouse,
 )
@@ -29,7 +31,8 @@ def test_version() -> None:
     assert data_pipeline_core.__version__ == "0.1.0"
 
 
-def test_all_eleven_protocols_exported() -> None:
+def test_all_seventeen_contracts_exported() -> None:
+    """All 17 contracts (15 original + StageMetrics + StageMetricsHook) are exported."""
     expected = {
         "Source",
         "Sink",
@@ -46,6 +49,9 @@ def test_all_eleven_protocols_exported() -> None:
         "ObservabilityHook",
         "FinOpsSink",
         "SecretProvider",
+        # Sprint-12 / T17.1 additions
+        "StageMetrics",
+        "StageMetricsHook",
     }
     actual = set(data_pipeline_core.__all__) - {"__version__"}
     assert actual == expected, f"missing: {expected - actual}, extra: {actual - expected}"
@@ -79,3 +85,14 @@ def test_protocols_have_expected_methods() -> None:
     assert hasattr(ObservabilityHook, "span")
     assert hasattr(FinOpsSink, "record")
     assert hasattr(SecretProvider, "get")
+    # Sprint-12 / T17.1: StageMetrics fields (checked on an instance because
+    # frozen-dataclass fields are instance attrs, not class attrs) and
+    # StageMetricsHook Protocol method (class-level).
+    sample = StageMetrics("p", "r", "s", 0, 0.0, 0)
+    assert hasattr(sample, "pipeline_id")
+    assert hasattr(sample, "run_id")
+    assert hasattr(sample, "stage_name")
+    assert hasattr(sample, "rows_processed")
+    assert hasattr(sample, "stage_latency_ms")
+    assert hasattr(sample, "error_count")
+    assert hasattr(StageMetricsHook, "record_stage_metrics")

--- a/data-pipeline-libraries/data-pipeline-core/tests/test_runtime_checkable.py
+++ b/data-pipeline-libraries/data-pipeline-core/tests/test_runtime_checkable.py
@@ -41,7 +41,10 @@ class _FakeBlobStore:
     def get(self, uri: str) -> bytes:
         return self._store[uri]
 
-    def open(self, uri: str, mode: str = "rb") -> Any:
+    def open_input(self, uri: str) -> Any:
+        raise NotImplementedError
+
+    def open_output(self, uri: str) -> Any:
         raise NotImplementedError
 
     def put(self, uri: str, data: bytes) -> None:

--- a/data-pipeline-libraries/data-pipeline-core/tests/test_stage_metrics.py
+++ b/data-pipeline-libraries/data-pipeline-core/tests/test_stage_metrics.py
@@ -1,0 +1,185 @@
+"""Tests for StageMetrics + StageMetricsHook contracts.
+
+Coverage mirrors the Java DefaultRuntimeContextTest (stageMetricsHook*
+tests) and StageTransformInstrumentationTest (RecordingStageMetricsHook /
+CapturingStageMetricsHook patterns), translated to the Python contract
+layer.
+
+Sprint-12 / T17.1 / issue #113.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from data_pipeline_core.contracts.stage_metrics import StageMetrics, StageMetricsHook
+
+
+# ---------------------------------------------------------------------------
+# StageMetrics construction and field access
+# ---------------------------------------------------------------------------
+
+
+def test_stage_metrics_field_access() -> None:
+    """All six fields are set and readable."""
+    m = StageMetrics(
+        pipeline_id="pipe-1",
+        run_id="run-abc",
+        stage_name="ingest",
+        rows_processed=100,
+        stage_latency_ms=42.5,
+        error_count=0,
+    )
+    assert m.pipeline_id == "pipe-1"
+    assert m.run_id == "run-abc"
+    assert m.stage_name == "ingest"
+    assert m.rows_processed == 100
+    assert m.stage_latency_ms == 42.5
+    assert m.error_count == 0
+
+
+def test_stage_metrics_is_immutable() -> None:
+    """StageMetrics is frozen — mutation raises FrozenInstanceError."""
+    m = StageMetrics("p", "r", "s", 0, 0.0, 0)
+    with pytest.raises((AttributeError, TypeError)):
+        m.rows_processed = 99  # type: ignore[misc]
+
+
+def test_stage_metrics_zero_rows_sentinel() -> None:
+    """rows_processed == 0 is the ROWS_PROCESSED_UNKNOWN sentinel (valid, not magic)."""
+    m = StageMetrics("p", "r", "stage", 0, 1.0, 0)
+    assert m.rows_processed == 0
+
+
+def test_stage_metrics_error_count_positive() -> None:
+    """error_count can be positive (error path)."""
+    m = StageMetrics("p", "r", "stage", 50, 200.0, 3)
+    assert m.error_count == 3
+
+
+def test_stage_metrics_rejects_none_pipeline_id() -> None:
+    """None pipeline_id raises ValueError (mirrors Java requireNonNull)."""
+    with pytest.raises((ValueError, TypeError)):
+        StageMetrics(None, "r", "s", 0, 0.0, 0)  # type: ignore[arg-type]
+
+
+def test_stage_metrics_rejects_none_run_id() -> None:
+    """None run_id raises ValueError."""
+    with pytest.raises((ValueError, TypeError)):
+        StageMetrics("p", None, "s", 0, 0.0, 0)  # type: ignore[arg-type]
+
+
+def test_stage_metrics_rejects_none_stage_name() -> None:
+    """None stage_name raises ValueError."""
+    with pytest.raises((ValueError, TypeError)):
+        StageMetrics("p", "r", None, 0, 0.0, 0)  # type: ignore[arg-type]
+
+
+def test_stage_metrics_equality() -> None:
+    """Two StageMetrics with identical fields are equal (frozen dataclass)."""
+    a = StageMetrics("p", "r", "s", 10, 5.0, 1)
+    b = StageMetrics("p", "r", "s", 10, 5.0, 1)
+    assert a == b
+
+
+# ---------------------------------------------------------------------------
+# StageMetricsHook — runtime_checkable structural typing
+# ---------------------------------------------------------------------------
+
+
+class _RecordingStageMetricsHook:
+    """In-memory recording hook — structurally satisfies StageMetricsHook."""
+
+    def __init__(self) -> None:
+        self.captured: list[StageMetrics] = []
+
+    def record_stage_metrics(self, metrics: StageMetrics) -> None:
+        self.captured.append(metrics)
+
+
+class _PartialStageMetricsHook:
+    """Missing record_stage_metrics — should NOT satisfy StageMetricsHook."""
+
+    def emit(self, metrics: StageMetrics) -> None:  # wrong method name
+        pass
+
+
+def test_recording_hook_satisfies_protocol() -> None:
+    """A class with record_stage_metrics passes isinstance against StageMetricsHook."""
+    hook = _RecordingStageMetricsHook()
+    assert isinstance(hook, StageMetricsHook)
+
+
+def test_partial_hook_does_not_satisfy_protocol() -> None:
+    """A class missing record_stage_metrics fails isinstance."""
+    assert not isinstance(_PartialStageMetricsHook(), StageMetricsHook)
+
+
+def test_hook_records_metrics_correctly() -> None:
+    """The recording hook captures emitted StageMetrics (mirrors CapturingStageMetricsHook)."""
+    hook = _RecordingStageMetricsHook()
+    m = StageMetrics("pipe-x", "run-1", "my-stage", 50, 100.0, 0)
+    hook.record_stage_metrics(m)
+
+    assert len(hook.captured) == 1
+    captured = hook.captured[0]
+    assert captured.stage_name == "my-stage"
+    assert captured.rows_processed == 50
+
+
+def test_hook_distinguishes_error_count(self=None) -> None:
+    """error_count > 0 is distinguishable from the success path."""
+    hook = _RecordingStageMetricsHook()
+    success = StageMetrics("p", "r", "stage-ok", 100, 50.0, 0)
+    failure = StageMetrics("p", "r", "stage-err", 0, 10.0, 1)
+
+    hook.record_stage_metrics(success)
+    hook.record_stage_metrics(failure)
+
+    assert hook.captured[0].error_count == 0
+    assert hook.captured[1].error_count == 1
+
+
+def test_multiple_stages_captured_independently() -> None:
+    """Two stages each emit their own StageMetrics record."""
+    hook = _RecordingStageMetricsHook()
+    alpha = StageMetrics("p", "r", "alpha", 10, 20.0, 0)
+    beta = StageMetrics("p", "r", "beta", 20, 30.0, 0)
+    hook.record_stage_metrics(alpha)
+    hook.record_stage_metrics(beta)
+
+    assert len(hook.captured) == 2
+    stage_names = {m.stage_name for m in hook.captured}
+    assert stage_names == {"alpha", "beta"}
+
+
+def test_lambda_satisfies_protocol() -> None:
+    """A lambda cannot satisfy the Protocol (no record_stage_metrics attribute)."""
+    # Lambdas have no named attributes matching the Protocol — confirm
+    # StageMetricsHook is strict about method name.
+    not_a_hook = lambda m: None  # noqa: E731
+    assert not isinstance(not_a_hook, StageMetricsHook)
+
+
+# ---------------------------------------------------------------------------
+# AutoConfig field registration
+# ---------------------------------------------------------------------------
+
+
+def test_autoconfig_has_stage_metrics_field() -> None:
+    """AutoConfig exposes a stage_metrics field (mirrors Java stageMetricsHooks list)."""
+    from data_pipeline_core.autoconfig import AutoConfig
+
+    config = AutoConfig()
+    assert hasattr(config, "stage_metrics")
+    assert isinstance(config.stage_metrics, list)
+    assert config.stage_metrics == []
+
+
+def test_autoconfig_discover_returns_empty_stage_metrics_on_bare_classpath() -> None:
+    """discover() returns empty stage_metrics when no entry-points are registered."""
+    from data_pipeline_core.autoconfig import discover
+
+    config = discover()
+    assert config.all("stage_metrics") == []
+    assert config.first("stage_metrics") is None

--- a/data-pipeline-libraries/data-pipeline-gcp-bigquery/src/data_pipeline_gcp_bigquery/warehouse.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-bigquery/src/data_pipeline_gcp_bigquery/warehouse.py
@@ -34,10 +34,22 @@ class BigQueryWarehouse:
     ) -> Iterator[Mapping[str, Any]]:
         """Execute a SELECT and stream rows as dicts.
 
-        Lazy: rows are yielded one at a time as BigQuery streams them.
+        Argument validation is eager (runs before any iteration) so that
+        ``query(None)`` raises immediately rather than only when the caller
+        first iterates the returned generator.  This matches the Java
+        contract (``nullSqlRejected``) and is required for
+        ``WarehouseContract.test_null_sql_rejected``.
         """
         if sql is None:
             raise TypeError("sql must not be None")
+        return self._query_rows(sql, params)
+
+    def _query_rows(
+        self,
+        sql: str,
+        params: Optional[Mapping[str, Any]] = None,
+    ) -> Iterator[Mapping[str, Any]]:
+        """Inner generator — called only after sql has been validated."""
         # google-cloud-bigquery's QueryJobConfig accepts ScalarQueryParameter
         # but we pass dict-style params for the cloud-neutral surface and
         # let the caller stay loosely coupled. For full parameter typing,

--- a/data-pipeline-libraries/data-pipeline-gcp-bigquery/tests/test_warehouse.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-bigquery/tests/test_warehouse.py
@@ -6,12 +6,51 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from data_pipeline_contract_tests import WarehouseContract
 from data_pipeline_gcp_bigquery import BigQueryWarehouse
 
 
 @pytest.fixture
 def mock_client():
     return MagicMock()
+
+
+# ---------------------------------------------------------------------------
+# Contract tests — bind WarehouseContract to BigQueryWarehouse
+# ---------------------------------------------------------------------------
+
+class TestBigQueryWarehouseContract(WarehouseContract):
+    """Exercise every WarehouseContract guarantee against a mocked BQ client.
+
+    The mixin requires one fixture:
+      ``warehouse`` — a BigQueryWarehouse configured so that:
+        * ``query("SELECT id FROM contract_test_table")`` yields ``{"id": 1}``
+        * ``table_exists("contract_test_table")`` is True
+        * ``table_exists("contract_missing_table")`` is False
+    """
+
+    @pytest.fixture
+    def warehouse(self):
+        client = MagicMock()
+
+        # query() result: one row with {"id": 1}
+        row = MagicMock()
+        row.items.return_value = [("id", 1)]
+        job = MagicMock()
+        job.result.return_value = [row]
+        client.query.return_value = job
+
+        # table_exists: returns True for the known table, False for missing
+        def _get_table(fqtn):
+            if fqtn == "contract_test_table":
+                return MagicMock()
+            raise Exception(f"Not found: {fqtn}")
+
+        client.get_table.side_effect = _get_table
+
+        return BigQueryWarehouse("test-project", client)
+
+
 
 
 def test_constructor_rejects_none_project():

--- a/data-pipeline-libraries/data-pipeline-gcp-gcs/tests/test_blob_store.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-gcs/tests/test_blob_store.py
@@ -6,12 +6,66 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from data_pipeline_contract_tests import BlobStoreContract
 from data_pipeline_gcp_gcs import GcsBlobStore
 
 
 @pytest.fixture
 def mock_client():
     return MagicMock()
+
+
+# ---------------------------------------------------------------------------
+# Contract tests — bind BlobStoreContract to GcsBlobStore
+# ---------------------------------------------------------------------------
+
+class TestGcsBlobStoreContract(BlobStoreContract):
+    """Exercise every BlobStoreContract guarantee against a mocked GCS client.
+
+    The mixin requires three fixtures:
+      ``store``      — a GcsBlobStore instance
+      ``known_uri``  — a URI whose content is exactly ``b"hello"``
+      ``missing_uri``— a URI that does not exist
+    """
+
+    @pytest.fixture
+    def store(self):
+        """GcsBlobStore backed by a MagicMock client keyed on blob name."""
+        client = MagicMock()
+
+        def _bucket_factory(bucket_name):
+            bucket = MagicMock()
+
+            def _blob_factory(blob_name):
+                blob = MagicMock()
+                if blob_name == "path/known":
+                    blob.download_as_bytes.return_value = b"hello"
+                    blob.exists.return_value = True
+                else:
+                    # missing blob: download raises 404, exists returns False
+                    not_found = Exception("404 not found")
+                    not_found.code = 404
+                    blob.download_as_bytes.side_effect = not_found
+                    blob.exists.return_value = False
+                    # delete is idempotent — raise a 404 that the adapter swallows
+                    delete_err = Exception("not found")
+                    delete_err.code = 404
+                    blob.delete.side_effect = delete_err
+                return blob
+
+            bucket.blob.side_effect = _blob_factory
+            return bucket
+
+        client.bucket.side_effect = _bucket_factory
+        return GcsBlobStore(client)
+
+    @pytest.fixture
+    def known_uri(self):
+        return "gs://test-bucket/path/known"
+
+    @pytest.fixture
+    def missing_uri(self):
+        return "gs://test-bucket/path/missing"
 
 
 def test_constructor_rejects_none():

--- a/docs/framework-evolution/13-python-parity-release.md
+++ b/docs/framework-evolution/13-python-parity-release.md
@@ -1,0 +1,159 @@
+# 13 — Python parity → coordinated polyglot release
+
+**Status:** scoped, not started. Successor to the 9–16 Java block (Sprints 11–16
+executed; Java reactor at `1.0.0` on `main`).
+
+**One-line:** Culvert is one polyglot, cloud-agnostic framework with GCP as its
+first implementation. Java is built to `1.0.0` but does **not** ship alone — the
+release gate is **Java *and* Python both ready**, then a single coordinated
+publish to Maven Central (`com.enrichmeai.culvert:*`) **and** PyPI (`culvert`).
+This epic closes the Python side and ships the coordinated `1.0.0`.
+
+---
+
+## 1. Strategic frame (decided 2026-06-14)
+
+One framework, two languages, **not doing the same job**. The contracts are the
+shared seam; each runtime owns the layers it's best at.
+
+| Layer | Strategy | Why / repo evidence |
+|---|---|---|
+| **Contracts** | **Both** implement the same spec | `docs/CONTRACT.md` is language-neutral. Java: 17 interfaces in `data-pipeline-core-java`. Python: 15 Protocols already in `data-pipeline-core/contracts/`. |
+| **dbt / transform** | **Reuse** (language-neutral) | It's SQL + macros, not "Java" or "Python". `data-pipeline-transform` is Python-packaged but the assets are dbt; there is deliberately **no** Java transform module. |
+| **Dataflow / execution** | **Java** (Beam) | `data-pipeline-gcp-dataflow-java` = `DataflowPipeline` + `StageTransform`. Legacy Python Beam is **not** being ported. |
+| **Orchestration** | **Reuse** — complementary, not duplicate | Python owns the runtime side (`operators/ sensors/ hooks/ routing/ factories/`); Java owns the cloud-neutral model + renderers (`DagSpec`/`TaskSpec`, `AirflowDagRenderer`/`ComposerDagRenderer`). |
+
+**Cloud-agnostic by contract; GCP is the first implementation.** AWS/Azure
+exist as Java skeletons (`data-pipeline-aws-s3-java`, `data-pipeline-azure-blob-java`)
+to prove the design is cloud-neutral; Python cloud-neutral skeletons are **out of
+scope** for this release (defer to a later block).
+
+## 2. Release gate
+
+```
+Java 1.0.0 (built, frozen)  ─┐
+                             ├─►  coordinated 1.0.0  ──►  Maven Central + PyPI (culvert), together
+Python parity (this epic)  ──┘                       └─►  legacy gcp-pipeline-framework: deprecate-in-place
+```
+
+- Java 1.0.0 is **built but held**. It does not publish to Maven Central on its
+  own. **Action: freeze it now** — tag/branch `java-1.0.0` so the coordinated
+  release ships exactly what was tested, and the Java side can't silently drift
+  under the epic and publish something un-re-verified.
+- Publish is **from git / GitHub Actions** for both ecosystems (per Joseph):
+  Maven Central via the existing `release` profile (gpg + central-publishing),
+  PyPI via Actions (OIDC / trusted publishing preferred — no long-lived token).
+- **Irreversible.** PyPI version numbers can't be reused; Maven Central is
+  immutable. The publish itself stays a Joseph-gated manual trigger.
+
+## 3. Current state — Python vs Java 1.0.0 (content-verified 2026-06-14)
+
+**Python already has more than a filename scan suggests.** Verified by grepping
+class definitions, not directory names.
+
+### Present in Python today
+- **Contracts (15 of 17 Protocols)** in `data-pipeline-core/contracts/`:
+  BlobStore, AuditEventPublisher, LineageEmitter, PipelineStage, SecretProvider,
+  GovernancePolicy, FinOpsSink, Warehouse, ObservabilityHook,
+  JobControlRepository, RuntimeContext, Source, Pipeline, **Sink** (in
+  `source.py`), **Transform** (in `source.py`). Plus `autoconfig.py`,
+  `decorators.py`, and the `audit/ lineage/ governance_api/ finops_api/
+  job_control_api/ schema/` model packages.
+- **Adapters**: `data-pipeline-gcp-bigquery`, `-gcs`, `-pubsub`,
+  `-orchestration` (runtime), `-transform` (dbt), `-tester`, `-contract-tests`.
+
+### Confirmed gaps vs Java 1.0.0
+| Gap | Kind | Note |
+|---|---|---|
+| `StageMetrics` / `StageMetricsHook` | **Contract** | The only genuine contract gap (added Java-side in S12). |
+| Contract drift on the 15 it has | **Reconcile** | Python Protocols predate the 9–16 Java evolution; verify each matches the final Java shape (esp. `RuntimeContext` T10.6 transient-registry semantics, `AuditEventPublisher`). |
+| `DefaultRuntimeContext` | **Core depth** | Absent in Python. The wiring kernel (S9). |
+| `dataquality` package | **Core depth** | `DataQualityTransform`, `ValidationResult`, quarantine — absent. |
+| Concrete governance policies | **Core depth** | `PiiMaskingGovernancePolicy`, `BudgetGovernancePolicy` — Python has `governance_api` models, not the policies. |
+| FinOps cost model + trackers | **Core/adapter depth** | `CostMetrics`/`FinOpsTag` + per-service `*CostTracker` (bigquery/gcs/pubsub) — absent. |
+| `gcp-secrets` Python package | **Adapter** | No Python `SecretManagerProvider` (Protocol exists, adapter doesn't). |
+| `gcp-observability` Python package | **Adapter** | No Python CloudTrace/DataCatalog/CloudMonitoring impls. |
+| `culvert`-named distribution | **Packaging** | Nothing ships as `culvert` yet; PyPI name is free. |
+| Python publish-from-git | **CI/release** | Actions PyPI job + trusted publishing not set up. |
+
+## 4. Epic scope — ticket groups
+
+Sequenced so each wave is independently mergeable (one concern per branch; PR
+within ~30 min; worktrees pre-created off the sprint branch per `CLAUDE.md`).
+
+**A. Contract reconciliation** *(blocks everything — do first, single wave)*
+- A1: Add `StageMetrics` + `StageMetricsHook` Protocols to Python core.
+- A2: Diff each of the 15 existing Protocols against final Java contracts; fix
+  drift. Output a short conformance note per contract.
+- A3: Extend `data-pipeline-contract-tests` (pytest mixins) to cover the
+  reconciled set 1:1 with the Java abstract contract tests.
+
+**B. Core depth (the 9–16 work, Python side)**
+- B1: `DefaultRuntimeContext` + `JobControlRepository` wiring.
+- B2: `dataquality` package (`DataQualityTransform`, `ValidationResult`,
+  `FieldViolation`, quarantine routing).
+- B3: Concrete governance policies (`PiiMaskingGovernancePolicy`,
+  `BudgetGovernancePolicy`) + masking/retention.
+- B4: FinOps cost model (`CostMetrics`, `FinOpsTag`, budget violation modes).
+
+**C. Adapter parity (GCP)**
+- C1: `data-pipeline-gcp-secrets` Python (`SecretManagerProvider`).
+- C2: `data-pipeline-gcp-observability` Python (CloudTrace hook, DataCatalog
+  lineage, CloudMonitoring metrics).
+- C3: Per-service cost trackers into Python bigquery/gcs/pubsub.
+
+**D. Packaging & naming**
+- D1: Decide distribution shape — single `culvert` package vs `culvert` +
+  namespace sub-packages (recommend: `culvert` core + `culvert-gcp-*` extras to
+  mirror the Maven module split). **Open decision, see §6.**
+- D2: Rename/repackage Python distributions to the `culvert` name; keep import
+  shims from `data_pipeline_*` for one release.
+
+**E. CI / release**
+- E1: Python test matrix already in `ci.yml` — extend to the reconciled module
+  set; add the new adapter packages.
+- E2: PyPI publish job (Actions, OIDC/trusted publishing), Joseph-gated.
+- E3: Coordinated-release runbook update in `RELEASE.md` (Maven + PyPI in one
+  procedure).
+
+**F. Legacy disposition (deprecate-in-place — NOT delete)**
+- F1: Final `gcp-pipeline-framework` release: README = deprecation banner
+  pointing to `culvert`, "no further updates".
+- F2: Yank legacy releases so new `pip install` resolution skips them; existing
+  pins keep working. **Do not hard-delete** (irreversible, version numbers
+  unreusable, breaks pinned dependents for zero benefit).
+
+**G. Docs / CHANGELOG**
+- G1: Reframe the `1.0.0` CHANGELOG entry — Java is **built and held for the
+  coordinated polyglot release**, not "done/shipped". Currently it reads as a
+  Java-only milestone already complete, which is premature under the both-ready
+  gate.
+- G2: README pass (the deferred "update all README" work) folds in here, now
+  that the polyglot story is settled.
+
+## 5. Sequencing (sprints)
+
+- **S17** — Wave A (contract reconciliation) + Java freeze tag + G1.
+- **S18** — Wave B (core depth).
+- **S19** — Wave C (adapter parity) + E1.
+- **S20** — Wave D (packaging) + E2/E3 + F + G2 → **coordinated release dry-run**,
+  then Joseph-gated publish.
+
+(Boundaries are nominal; collapse if waves come in light.)
+
+## 6. Open decisions for Joseph
+
+1. **Python distribution shape (D1):** single `culvert` mega-package, or
+   `culvert` core + `culvert-gcp-bigquery`/`-gcs`/… extras mirroring the Maven
+   modules? Recommend the split — keeps install footprint small and matches the
+   Java story. *(Decide before Wave D.)*
+2. **Release publish trigger:** confirm both publishes ride the same Joseph
+   trigger / commit-message gate, and that PyPI uses trusted publishing (no
+   stored token).
+
+## Constraints carried from the operating model
+
+- Dev-agents do **not** run `mvn -P it verify` / Docker-heavy ITs (architect/Joseph).
+- Do **not** self-merge sprint→main — Joseph's trigger.
+- GPG passphrase + Sonatype/PyPI credentials are Joseph's secrets.
+- Publish is irreversible — confirm before executing; nothing auto-publishes.


### PR DESCRIPTION
Sprint-17 integration branch → main (Joseph's merge trigger). Part of epic #112.

**Java frozen** at tag `java-1.0.0` before this work.

### Landed on this branch
- **Epic doc** `docs/framework-evolution/13-python-parity-release.md` — polyglot release plan, division of labour, coordinated-release gate.
- **T17.1** — `StageMetrics` + `StageMetricsHook` Python Protocols, mirroring Java exactly.
- **T17.2** — reconciled the 15 existing Python Protocols vs frozen Java. Drift fixed: `BlobStore.open()` → `open_input()`/`open_output()`; `RuntimeContext.pipeline_id` + T10.6 docstrings. See `CONTRACT_CONFORMANCE.md`.
- **T17.3** — Python contract-test mixins to 1:1 parity with Java (null-rejection + new StageMetricsHook mixin).
- **Integration** — `stage_metrics: StageMetricsHook` wired onto `RuntimeContext` (mirrors Java's abstract `stageMetrics()`). Confirmed no concrete `RuntimeContextImpl` exists, so the new required attribute is safe.
- **T17.4** — bound the contract mixins to the two existing adapters (`GcsBlobStore`, `BigQueryWarehouse`). **Caught + fixed a real latent bug**: `BigQueryWarehouse.query` was a generator, so its null-guard ran only on iteration — `query(None)` returned a generator instead of raising. Split into an eager validating wrapper + inner generator.

### Verification
Full combined suite (core + contract-tests + both bound adapters): **78 passed**. Every agent claim about Java signatures independently checked against `java-1.0.0`; one agent-introduced test-double break caught by re-running and fixed; the warehouse bug fix reproduced empirically.

### Deferred to Wave C (no adapter/mixin yet)
Binding SecretProvider / StageMetricsHook / Source / Sink contracts lands when those Python adapters + mixins exist.

Closes #113, #114, #115, #116. (Epic #112 stays open — multi-wave.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)