### PR TITLE
[sprint-18] Wave B — Python core depth (epic #112)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to the Culvert data pipeline framework. See [DEV_PROCESS.md]
 
 ## [1.0.0] — 2026-06-13
 
-**All 15 core contracts have real adapters. The framework's v1.0 feature bar is complete.**
+**All 16 contract interfaces have real Java adapters. The Java v1.0 feature bar is met — built and HELD, not yet published.**
 
-This release spans Sprints 9–16, completing the Culvert framework's initial production-ready milestone. Every contract interface defined in `data-pipeline-core` now has at least one concrete adapter shipping under `com.enrichmeai.culvert:*`.
+This spans Sprints 9–16: every contract interface defined in `data-pipeline-core-java` now has at least one concrete adapter under `com.enrichmeai.culvert:*`. The Java reactor is frozen at tag `java-1.0.0`, but it does **not** publish alone — the release gate is Java **and** Python both ready, then a coordinated `1.0.0` to Maven Central **and** PyPI (`culvert`). See `docs/framework-evolution/13-python-parity-release.md`. The Python parity work (Sprints 17+) is in progress.
 
 ### Java libraries (`com.enrichmeai.culvert:*`) — Sprint 9–16 additions
 
@@ -35,7 +35,8 @@ This release spans Sprints 9–16, completing the Culvert framework's initial pr
 | `AuditEventPublisher` | `BigQueryAuditEventPublisher` |
 | `GovernancePolicy` | `PiiMaskingGovernancePolicy`, `BudgetGovernancePolicy` |
 | `LineageEmitter` | `DataCatalogLineageEmitter` |
-| `ObservabilityHook` | `CloudTraceObservabilityHook`, `CloudMonitoringMetricsHook` |
+| `ObservabilityHook` | `CloudTraceObservabilityHook` |
+| `StageMetricsHook` | `CloudMonitoringMetricsHook` |
 | `FinOpsSink` | `BigQueryFinOpsSink` |
 | `SecretProvider` | `SecretManagerProvider` |
 
@@ -55,7 +56,7 @@ The framework's first feature-complete dev-cycle. **Not yet published to PyPI / 
 
 ### Java libraries (`com.enrichmeai.culvert:*`)
 
-- `data-pipeline-core` — cloud-neutral kernel: 15 contract interfaces (Source, Sink, Transform, Pipeline, PipelineStage, RuntimeContext, JobControlRepository, BlobStore, Warehouse, AuditEventPublisher, GovernancePolicy, LineageEmitter, ObservabilityHook, FinOpsSink, SecretProvider) + supporting records + `AutoConfig` ServiceLoader-driven registry. 36 tests.
+- `data-pipeline-core` — cloud-neutral kernel: 16 contract interfaces (Source, Sink, Transform, Pipeline, PipelineStage, RuntimeContext, JobControlRepository, BlobStore, Warehouse, AuditEventPublisher, GovernancePolicy, LineageEmitter, ObservabilityHook, StageMetricsHook, FinOpsSink, SecretProvider) + supporting records (incl. `StageMetrics`) + `AutoConfig` ServiceLoader-driven registry. 36 tests.
 - `data-pipeline-gcp-secrets` — SecretManagerProvider implementing SecretProvider. 4 tests.
 - `data-pipeline-gcp-bigquery` — three impls under one module: BigQueryWarehouse (Warehouse, 12), BigQueryJobControlRepository (JobControlRepository, 17), BigQueryFinOpsSink (FinOpsSink, 11). 40 tests.
 - `data-pipeline-gcp-gcs` — GcsBlobStore (BlobStore). 17 tests.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ Bake these into every agent prompt; they design out the misses the architect had
    Report the **exact commands + exact pass/fail counts**. The architect re-runs them verbatim; if they don't reproduce, the work isn't done.
 3. **Cite the source for every cross-language / "matches X" claim** as `file:line` (e.g. "mirrors `StageMetrics.java:27`"), so the claim is checkable, not asserted.
 4. **Flag, don't fake.** If a guarantee genuinely doesn't fit, or an env truly can't be built offline, say so precisely and stop — a flagged gap is correct; a silent or invented green is not.
+5. **No redundancy; keep the repo current as part of "done."** Don't leave dead code, superseded files, or stale docs behind. When work changes a fact stated elsewhere (a contract count, a "no X yet"/"future" note, a status line, a feature claim), `grep` the repo for that fact and update **every** reference in the same change — a stale doc reads as truth. Delete what a change makes obsolete rather than leaving it alongside the new version. (Exception: `docs/historical/` and the deprecated legacy framework, which are deprecate-in-place by decision — don't edit those.) This applies to the architect's integration commits too, not just dev-agents.
 
 The architect still verifies independently (checklist item 3) — but a DoD-conformant report should make that a confirmation, not a rescue.
 

--- a/data-pipeline-libraries-java/data-pipeline-core-java/README.md
+++ b/data-pipeline-libraries-java/data-pipeline-core-java/README.md
@@ -50,7 +50,7 @@ Eleven interfaces in `com.enrichmeai.culvert.contracts` — the entire framework
 
 ## What's in v0.1.0 (Polyglot Stage 0)
 
-- `com.enrichmeai.culvert.contracts` — the 15 interfaces.
+- `com.enrichmeai.culvert.contracts` — the 16 interfaces.
 - `com.enrichmeai.culvert.{audit,lineage,finops,governance,jobcontrol,schema}` — the records and enums those interfaces reference.
 - `COMPATIBILITY.md` — per-interface gap analysis against the existing Java port at `deployments/mainframe-segment-transform-java/` and against the Python implementations.
 

--- a/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/dataquality/__init__.py
+++ b/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/dataquality/__init__.py
@@ -1,0 +1,44 @@
+"""dataquality — cloud-neutral data-quality validation for Culvert pipelines.
+
+Port of ``com.enrichmeai.culvert.dataquality.*`` (Java Sprint 14 / issue #73;
+T14.4 / issue #76; T14.7 / issue #100) to Python.  T18.2 / issue #118.
+
+Five types, same shapes, same semantics:
+
+* :class:`ViolationKind`         — enum: MISSING_REQUIRED | TYPE_MISMATCH | OUT_OF_RANGE
+* :class:`NumericRange`          — closed inclusive [min, max] with ``contains()``
+* :class:`FieldViolation`        — (field_name, violation_kind, detail) triple
+* :class:`ValidationResult`      — base; subclasses: :class:`ValidRow`, :class:`InvalidRow`
+* :class:`DataQualityTransform`  — implements Transform[R, ValidationResult[R]]
+
+Typical usage::
+
+    from data_pipeline_core.dataquality import (
+        DataQualityTransform,
+        InvalidRow,
+        NumericRange,
+        ValidRow,
+        ValidationResult,
+        ViolationKind,
+    )
+"""
+
+from data_pipeline_core.dataquality.data_quality_transform import DataQualityTransform
+from data_pipeline_core.dataquality.field_violation import FieldViolation
+from data_pipeline_core.dataquality.numeric_range import NumericRange
+from data_pipeline_core.dataquality.validation_result import (
+    InvalidRow,
+    ValidRow,
+    ValidationResult,
+)
+from data_pipeline_core.dataquality.violation_kind import ViolationKind
+
+__all__ = [
+    "DataQualityTransform",
+    "FieldViolation",
+    "InvalidRow",
+    "NumericRange",
+    "ValidRow",
+    "ValidationResult",
+    "ViolationKind",
+]

--- a/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/dataquality/data_quality_transform.py
+++ b/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/dataquality/data_quality_transform.py
@@ -1,0 +1,360 @@
+"""DataQualityTransform — cloud-neutral Transform that validates rows.
+
+Mirrors ``com.enrichmeai.culvert.dataquality.DataQualityTransform``
+(Java Sprint 14 / issue #73; masking T14.4 / issue #76;
+schema-grounded range validation T14.7 / issue #100).
+
+Port: T18.2 / issue #118.
+
+Design notes vs Java
+--------------------
+* Java uses a lazy inner-class iterator (``ValidatingIterator``); Python
+  uses a generator function which is idiomatically equivalent.
+* Python ``bool`` is a subclass of ``int`` which is a subclass of
+  ``numbers.Number``.  The Java ``WIRE_TYPE_MAP`` keeps ``Boolean`` and
+  ``Number`` disjoint (Java lines 112-117), so INT64/FLOAT64 checks
+  exclude ``bool`` explicitly here.
+* No Python ``Masker`` exists in this package yet (Java counterpart is
+  ``com.enrichmeai.culvert.governance.Masker``; Java lines 247-256).
+  The ``governance_policy`` parameter is accepted for API parity but
+  masking *application* is a FLAG — see class docstring.
+* ``SchemaField.range`` is an additive field added in T18.2 to
+  ``data_pipeline_core.schema.entity.SchemaField`` (mirrors Java T14.7).
+"""
+
+from __future__ import annotations
+
+import numbers
+import time
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generic,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    TypeVar,
+)
+
+from data_pipeline_core.contracts.stage_metrics import StageMetrics
+from data_pipeline_core.dataquality.field_violation import FieldViolation
+from data_pipeline_core.dataquality.numeric_range import NumericRange
+from data_pipeline_core.dataquality.validation_result import (
+    InvalidRow,
+    ValidRow,
+    ValidationResult,
+)
+from data_pipeline_core.dataquality.violation_kind import ViolationKind
+from data_pipeline_core.schema.entity import EntitySchema, SchemaField
+
+# TYPE_CHECKING import to avoid runtime circular dependency on GovernancePolicy.
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from data_pipeline_core.contracts.runtime import RuntimeContext
+
+R = TypeVar("R")
+
+# ---------------------------------------------------------------------------
+# Wire-type → expected Python type map.
+# Mirrors WIRE_TYPE_MAP (Java lines 112-117):
+#   STRING  → str
+#   INT64   → numbers.Number  (but NOT bool — see module docstring)
+#   FLOAT64 → numbers.Number  (but NOT bool)
+#   BOOL    → bool
+# ---------------------------------------------------------------------------
+_WIRE_TYPE_MAP: Dict[str, type] = {
+    "STRING":  str,
+    "INT64":   numbers.Number,
+    "FLOAT64": numbers.Number,
+    "BOOL":    bool,
+}
+
+
+def _is_type_match(wire_type: str, value: Any) -> bool:
+    """Return True iff ``value`` is compatible with ``wire_type``.
+
+    Mirrors Java ``expected.isInstance(value)`` (Java line 210) with the
+    additional guard that ``bool`` is excluded from INT64/FLOAT64 checks
+    (Python-specific: ``bool`` is a subclass of ``int`` and therefore of
+    ``numbers.Number``, but a boolean is not a valid numeric field value
+    in the Java model).
+    """
+    expected = _WIRE_TYPE_MAP.get(wire_type)
+    if expected is None:
+        # Unknown wire type — no type check (mirrors Java's pass-through).
+        return True
+    if expected is bool:
+        return isinstance(value, bool)
+    # For INT64/FLOAT64: must be a Number but must NOT be bool.
+    return isinstance(value, expected) and not isinstance(value, bool)
+
+
+class DataQualityTransform(Generic[R]):
+    """A cloud-neutral Transform that validates rows against an EntitySchema.
+
+    Mirrors ``DataQualityTransform<R>`` (Java lines 108-359).
+
+    Validation rules (applied per field, in order — mirrors Java
+    lines 192-237):
+
+    1. **MISSING_REQUIRED** — a ``REQUIRED`` field with a ``None`` /
+       absent value (Java line 194).
+    2. **TYPE_MISMATCH** — the runtime type is incompatible with the
+       schema wire type (Java lines 208-219).
+    3. **OUT_OF_RANGE** — the field's numeric value falls outside the
+       :class:`~data_pipeline_core.dataquality.NumericRange` attached to
+       the :class:`~data_pipeline_core.schema.entity.SchemaField`
+       (schema-grounded, Java lines 222-236).
+
+    All violations are accumulated; validation does not short-circuit on
+    the first failure (Java lines 48-50).
+
+    PII masking (FLAG):
+        The ``governance_policy`` constructor parameter is accepted to
+        mirror the Java API (``DataQualityTransform.java:161-168``).
+        However, no Python ``Masker`` exists in this package.  When a
+        policy is supplied the transform raises ``NotImplementedError``
+        on the first valid row that has a matching masking policy — do
+        not use in production until a ``Masker`` is ported.
+        Java masking path: lines 247-256.
+
+    Usage — direct row validation::
+
+        schema = EntitySchema(
+            name="order",
+            fields=[
+                SchemaField("id",     "STRING",  mode="REQUIRED"),
+                SchemaField("amount", "FLOAT64", mode="REQUIRED",
+                            range=NumericRange.of(0.0, 1_000_000.0)),
+                SchemaField("note",   "STRING"),
+            ],
+        )
+        dq: DataQualityTransform[Dict[str, Any]] = DataQualityTransform(
+            schema=schema, row_accessor=lambda row: row
+        )
+        result = dq.validate(row)
+        if result.is_valid():
+            ...
+        else:
+            assert isinstance(result, InvalidRow)
+            for v in result.violations:
+                print(v)
+
+    Usage — as a Transform in a pipeline stage::
+
+        results = dq.apply(iter(rows), runtime_context)
+    """
+
+    def __init__(
+        self,
+        schema: EntitySchema,
+        row_accessor: Callable[[R], Optional[Mapping[str, Any]]],
+        governance_policy: Optional[Any] = None,
+    ) -> None:
+        """Create a DataQualityTransform.
+
+        Mirrors both Java constructors (Java lines 141-168).
+
+        Args:
+            schema:            The EntitySchema to validate each row against.
+                               Mirrors ``schema`` (Java line 119).
+            row_accessor:      Callable that extracts a field-name → value
+                               mapping from a row.  Mirrors ``rowAccessor``
+                               (Java line 120).
+            governance_policy: Optional GovernancePolicy for PII masking.
+                               Pass ``None`` to disable masking (default).
+                               Mirrors ``governancePolicy`` (Java line 125-127).
+                               FLAG: masking application is not yet implemented
+                               in Python (no Masker).
+        """
+        if schema is None:
+            raise ValueError("schema must not be None")
+        if row_accessor is None:
+            raise ValueError("row_accessor must not be None")
+        self._schema = schema
+        self._row_accessor = row_accessor
+        self._governance_policy = governance_policy  # None → masking disabled
+
+    # -----------------------------------------------------------------------
+    # Public API: per-row validation
+    # -----------------------------------------------------------------------
+
+    def validate(self, row: R) -> ValidationResult[R]:
+        """Validate a single row against the EntitySchema.
+
+        Mirrors ``DataQualityTransform.validate(R)`` (Java lines 184-259).
+
+        All violations are accumulated; validation does not short-circuit.
+
+        Args:
+            row: The row to validate.  Must not be ``None``.
+
+        Returns:
+            :class:`ValidRow` if no violations were found;
+            :class:`InvalidRow` with all violations otherwise.
+        """
+        if row is None:
+            raise ValueError("row must not be None")
+
+        fields: Optional[Mapping[str, Any]] = self._row_accessor(row)
+        violations: List[FieldViolation] = []
+
+        for sf in self._schema.fields:
+            value = (fields.get(sf.name) if fields is not None else None)
+
+            # 1 — MISSING_REQUIRED (Java lines 193-199)
+            if sf.mode == "REQUIRED" and value is None:
+                violations.append(FieldViolation(
+                    field_name=sf.name,
+                    violation_kind=ViolationKind.MISSING_REQUIRED,
+                    detail=(
+                        f"Field '{sf.name}' is REQUIRED but was None or absent"
+                    ),
+                ))
+                continue  # no point type-checking a None (Java line 199)
+
+            if value is None:
+                # nullable/repeated field with None value — no further checks
+                # (Java lines 202-205)
+                continue
+
+            # 2 — TYPE_MISMATCH (Java lines 208-219)
+            type_mismatch = False
+            if not _is_type_match(sf.type, value):
+                expected = _WIRE_TYPE_MAP.get(sf.type)
+                violations.append(FieldViolation(
+                    field_name=sf.name,
+                    violation_kind=ViolationKind.TYPE_MISMATCH,
+                    detail=(
+                        f"Field '{sf.name}' expected type compatible with "
+                        f"{sf.type} ({expected.__name__ if expected else 'unknown'}) "
+                        f"but got {type(value).__name__} [value={value!r}]"
+                    ),
+                ))
+                type_mismatch = True
+
+            # 3 — OUT_OF_RANGE (Java lines 222-236)
+            # Schema-grounded: bounds come from SchemaField.range (T14.7 / T18.2).
+            # Skipped when value is None or already flagged with TYPE_MISMATCH.
+            if not type_mismatch:
+                numeric_range: Optional[NumericRange] = sf.range  # type: ignore[attr-defined]
+                if (
+                    numeric_range is not None
+                    and isinstance(value, numbers.Number)
+                    and not isinstance(value, bool)
+                ):
+                    d = float(value)
+                    if not numeric_range.contains(d):
+                        violations.append(FieldViolation(
+                            field_name=sf.name,
+                            violation_kind=ViolationKind.OUT_OF_RANGE,
+                            detail=(
+                                f"Field '{sf.name}' value {d} is outside range "
+                                f"[{numeric_range.min}, {numeric_range.max}]"
+                            ),
+                        ))
+
+        if violations:
+            return InvalidRow.of(row=row, violations=violations)
+
+        # ---- Post-validation PII masking (opt-in) --------------------------
+        # FLAG: No Python Masker exists yet (Java: Masker.mask(), lines 247-256).
+        # The governance_policy param is stored for API parity.  If a policy
+        # is supplied we raise NotImplementedError to prevent silent no-ops.
+        # When a Masker is ported, replace this block with the real call.
+        if self._governance_policy is not None and fields is not None:
+            for field_name, val in fields.items():
+                mp = self._governance_policy.masking_for(field_name, self._schema.name)
+                if mp is not None:
+                    raise NotImplementedError(
+                        "PII masking is accepted by the DataQualityTransform API "
+                        "(mirrors Java T14.4 / issue #76) but the Python Masker "
+                        "has not been ported yet (T18.2 flag).  Port "
+                        "data_pipeline_core.dataquality.masker.Masker first."
+                    )
+
+        return ValidRow(row=row)
+
+    # -----------------------------------------------------------------------
+    # Transform[R, ValidationResult[R]] implementation
+    # -----------------------------------------------------------------------
+
+    def apply(
+        self,
+        records: Iterator[R],
+        context: "RuntimeContext",
+    ) -> Iterator[ValidationResult[R]]:
+        """Lazily map :meth:`validate` over the input iterator.
+
+        Mirrors ``DataQualityTransform.apply(Iterator<R>, RuntimeContext)``
+        (Java lines 281-287) and the inner ``ValidatingIterator``
+        (Java lines 293-358).
+
+        The returned generator is lazy — rows are validated on demand.
+        After the iterator is exhausted, one :class:`StageMetrics`
+        snapshot is emitted via ``context.stage_metrics.record_stage_metrics``.
+        Metrics-emission errors are swallowed (mirrors Java lines 352-356).
+
+        Metrics:
+            ``rows_processed`` — total rows validated.
+            ``error_count``    — count of :class:`InvalidRow` results.
+            ``stage_latency_ms`` — wall-clock from first ``next()`` call
+                                   to exhaustion (0 on empty input).
+
+        Args:
+            records: The input rows.  Must not be ``None``.
+            context: Runtime context (for metrics emission).  Must not be ``None``.
+
+        Returns:
+            A lazy iterator of :class:`ValidationResult` instances.
+        """
+        if records is None:
+            raise ValueError("records must not be None")
+        if context is None:
+            raise ValueError("context must not be None")
+        return self._validating_generator(records, context)
+
+    def _validating_generator(
+        self,
+        records: Iterator[R],
+        context: "RuntimeContext",
+    ) -> Iterator[ValidationResult[R]]:
+        """Generator implementation of the validating iterator.
+
+        Mirrors ``ValidatingIterator`` (Java lines 293-358).
+        """
+        rows_processed = 0
+        error_count = 0
+        start_ns: Optional[int] = None
+
+        try:
+            for record in records:
+                if start_ns is None:
+                    start_ns = time.perf_counter_ns()  # first row (Java line 319)
+                result = self.validate(record)
+                rows_processed += 1
+                if not result.is_valid():
+                    error_count += 1
+                yield result
+        finally:
+            # Emit metrics exactly once after the iterator is exhausted
+            # (mirrors Java emitMetrics(), lines 340-357).
+            elapsed_ns = (time.perf_counter_ns() - start_ns) if start_ns is not None else 0
+            latency_ms = elapsed_ns / 1_000_000.0
+            try:
+                context.stage_metrics.record_stage_metrics(
+                    StageMetrics(
+                        pipeline_id=context.pipeline_id,
+                        run_id=context.run_id,
+                        stage_name="DataQualityTransform",  # Java line 349
+                        rows_processed=rows_processed,
+                        stage_latency_ms=latency_ms,
+                        error_count=error_count,
+                    )
+                )
+            except Exception:  # noqa: BLE001
+                # Advisory — never let metrics emission break the pipeline.
+                # Mirrors Java catch(Exception ex) swallow (Java lines 352-356).
+                pass

--- a/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/dataquality/field_violation.py
+++ b/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/dataquality/field_violation.py
@@ -1,0 +1,48 @@
+"""FieldViolation — a single field-level violation found during validation.
+
+Mirrors ``com.enrichmeai.culvert.dataquality.FieldViolation`` (Java
+record, Sprint 14 / issue #73).
+
+Port: T18.2 / issue #118.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from data_pipeline_core.dataquality.violation_kind import ViolationKind
+
+
+@dataclass(frozen=True)
+class FieldViolation:
+    """A single field-level violation produced during data-quality validation.
+
+    Mirrors the Java record ``FieldViolation(String fieldName,
+    ViolationKind violationKind, String detail)`` (Java lines 19-28).
+
+    Instances are collected into a
+    :class:`~data_pipeline_core.dataquality.ValidationResult.InvalidRow`
+    by :class:`~data_pipeline_core.dataquality.DataQualityTransform`.
+
+    All three fields are required and must be non-``None``; ``frozen=True``
+    mirrors Java's ``record`` immutability.
+    """
+
+    field_name: str
+    """Name of the field that failed validation.  Mirrors ``fieldName`` (Java line 21)."""
+
+    violation_kind: ViolationKind
+    """Category of violation.  Mirrors ``violationKind`` (Java line 22)."""
+
+    detail: str
+    """Human-readable description including expected/actual values.
+    Mirrors ``detail`` (Java line 23)."""
+
+    def __post_init__(self) -> None:
+        # Mirrors Java Objects.requireNonNull guards (Java lines 24-27).
+        if self.field_name is None:
+            raise ValueError("field_name must not be None")
+        if self.violation_kind is None:
+            raise ValueError("violation_kind must not be None")
+        if self.detail is None:
+            raise ValueError("detail must not be None")

--- a/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/dataquality/numeric_range.py
+++ b/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/dataquality/numeric_range.py
@@ -1,0 +1,54 @@
+"""NumericRange — closed inclusive numeric range [min, max].
+
+Mirrors ``com.enrichmeai.culvert.dataquality.NumericRange`` (Java
+record, Sprint 14 / issue #73; schema-grounded T14.7 / issue #100).
+
+Port: T18.2 / issue #118.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class NumericRange:
+    """A closed numeric range ``[min, max]`` (both bounds inclusive).
+
+    Used by :class:`~data_pipeline_core.dataquality.DataQualityTransform`
+    to detect ``OUT_OF_RANGE`` field values.  Mirrors the Java record
+    ``NumericRange(double min, double max)`` (Java lines 20–42):
+
+    * Both bounds are ``float`` (Python) / ``double`` (Java).
+    * ``max`` must be ``>=`` ``min`` — ``ValueError`` otherwise (mirrors
+      ``IllegalArgumentException`` at Java line 24).
+    * :meth:`contains` mirrors ``NumericRange.contains(double)`` (Java
+      line 39).
+
+    Attach a ``NumericRange`` to a :class:`~data_pipeline_core.schema.entity.SchemaField`
+    via ``SchemaField(... range=NumericRange.of(lo, hi))`` to opt that
+    field into range validation.
+    """
+
+    min: float
+    max: float
+
+    def __post_init__(self) -> None:
+        # Mirrors Java compact constructor (NumericRange.java:22-27).
+        if self.max < self.min:
+            raise ValueError(
+                f"max ({self.max}) must be >= min ({self.min})"
+            )
+
+    @classmethod
+    def of(cls, min: float, max: float) -> "NumericRange":
+        """Convenience factory — mirrors ``NumericRange.of(double, double)``
+        (Java line 30)."""
+        return cls(min=min, max=max)
+
+    def contains(self, value: float) -> bool:
+        """Return ``True`` iff ``value`` lies within ``[min, max]`` inclusive.
+
+        Mirrors ``NumericRange.contains(double)`` (Java lines 39-41).
+        """
+        return self.min <= value <= self.max

--- a/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/dataquality/validation_result.py
+++ b/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/dataquality/validation_result.py
@@ -1,0 +1,90 @@
+"""ValidationResult — either-style result of validating a single row.
+
+Mirrors ``com.enrichmeai.culvert.dataquality.ValidationResult`` (Java
+sealed interface + two record subtypes, Sprint 14 / issue #73).
+
+Python has no sealed interfaces; we use a frozen-dataclass hierarchy
+with an abstract-base-class sentinel and two concrete subtypes.
+
+Port: T18.2 / issue #118.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Generic, List, Sequence, Tuple, TypeVar
+
+from data_pipeline_core.dataquality.field_violation import FieldViolation
+
+R = TypeVar("R")
+
+
+@dataclass(frozen=True)
+class ValidationResult(Generic[R]):
+    """Abstract base for validation results.
+
+    Mirrors the Java sealed interface ``ValidationResult<R>`` (Java
+    lines 30-76).  Two concrete subtypes:
+
+    * :class:`ValidRow` — every field passed all checks (Java lines 50-54).
+    * :class:`InvalidRow` — one or more fields failed; carries a non-empty
+      tuple of :class:`~data_pipeline_core.dataquality.FieldViolation` instances
+      (Java lines 63-75).
+
+    The base class provides :meth:`is_valid` (mirrors Java default method
+    at line 37-39) and exposes the common ``row`` accessor for symmetric
+    access from both subtypes.
+    """
+
+    row: R
+    """The original row — present in both subtypes. Mirrors ``row()`` (Java line 35)."""
+
+    def is_valid(self) -> bool:
+        """Return ``True`` iff this result is a :class:`ValidRow`.
+
+        Mirrors ``ValidationResult.isValid()`` (Java lines 37-39).
+        """
+        return isinstance(self, ValidRow)
+
+
+@dataclass(frozen=True)
+class ValidRow(ValidationResult[R], Generic[R]):
+    """A row that passed all data-quality checks.
+
+    Mirrors ``ValidationResult.ValidRow<R>`` (Java lines 50-54).
+    ``row`` must not be ``None`` (mirrors Java's ``Objects.requireNonNull``
+    at Java line 52).
+    """
+
+    def __post_init__(self) -> None:
+        if self.row is None:
+            raise ValueError("row must not be None")
+
+
+@dataclass(frozen=True)
+class InvalidRow(ValidationResult[R], Generic[R]):
+    """A row that failed one or more data-quality checks.
+
+    Mirrors ``ValidationResult.InvalidRow<R>`` (Java lines 63-75).
+
+    ``violations`` is stored as an immutable ``tuple`` (mirrors
+    ``List.copyOf`` at Java line 73) and is guaranteed non-empty
+    (mirrors Java's guard at lines 69-72).
+    """
+
+    violations: Tuple[FieldViolation, ...]
+    """Non-empty tuple of field violations, one per failing field."""
+
+    def __post_init__(self) -> None:
+        # Mirrors Java guards (lines 67-73).
+        if self.row is None:
+            raise ValueError("row must not be None")
+        if self.violations is None:
+            raise ValueError("violations must not be None")
+        if len(self.violations) == 0:
+            raise ValueError("InvalidRow must have at least one FieldViolation")
+
+    @classmethod
+    def of(cls, row: R, violations: Sequence[FieldViolation]) -> "InvalidRow[R]":
+        """Convenience factory that accepts any sequence and converts to tuple."""
+        return cls(row=row, violations=tuple(violations))

--- a/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/dataquality/violation_kind.py
+++ b/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/dataquality/violation_kind.py
@@ -1,0 +1,35 @@
+"""ViolationKind — classification of a single field violation.
+
+Mirrors ``com.enrichmeai.culvert.dataquality.ViolationKind`` (Java
+Sprint 14 / issue #73).  Three variants, same names, same semantics.
+
+Port: T18.2 / issue #118.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class ViolationKind(Enum):
+    """Classification of a single field violation found during validation.
+
+    Mirrors ``ViolationKind.java`` (see
+    ``data-pipeline-libraries-java/.../dataquality/ViolationKind.java``):
+
+    * ``MISSING_REQUIRED`` — a field declared ``REQUIRED`` had a ``None``
+      or absent value. (Java line 25)
+    * ``TYPE_MISMATCH``    — the field's runtime type does not match the
+      schema-declared wire type. (Java line 28)
+    * ``OUT_OF_RANGE``     — a numeric field falls outside its declared
+      :class:`NumericRange`. (Java line 31)
+    """
+
+    MISSING_REQUIRED = "MISSING_REQUIRED"
+    """The field is declared REQUIRED but its value is None or missing."""
+
+    TYPE_MISMATCH = "TYPE_MISMATCH"
+    """The field's runtime value type does not match the schema wire type."""
+
+    OUT_OF_RANGE = "OUT_OF_RANGE"
+    """The field's numeric value falls outside its declared NumericRange."""

--- a/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/finops_api/__init__.py
+++ b/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/finops_api/__init__.py
@@ -1,10 +1,27 @@
-"""FinOps data shapes: CostMetrics and FinOpsTag.
+"""FinOps data shapes: CostMetrics, FinOpsTag, and budget governance types.
 
 CostMetrics is what cloud cost trackers produce; FinOpsTag is the
 cost-attribution metadata attached to every emitted metric.
+
+Budget governance concretes (T18.4):
+- BudgetViolationMode   — BLOCK / WARN enum
+- BudgetExceededException — raised in BLOCK mode
+- BudgetGovernancePolicy  — GovernancePolicy that enforces a cost ceiling
 """
 
+from data_pipeline_core.finops_api.budget import (
+    BudgetExceededException,
+    BudgetGovernancePolicy,
+    BudgetViolationMode,
+)
 from data_pipeline_core.finops_api.labels import FinOpsTag
 from data_pipeline_core.finops_api.models import CostMetrics
 
-__all__ = ["CostMetrics", "FinOpsTag"]
+__all__ = [
+    "CostMetrics",
+    "FinOpsTag",
+    # Budget governance concretes (T18.4)
+    "BudgetViolationMode",
+    "BudgetExceededException",
+    "BudgetGovernancePolicy",
+]

--- a/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/finops_api/budget.py
+++ b/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/finops_api/budget.py
@@ -1,0 +1,235 @@
+"""Budget governance types — BudgetViolationMode, BudgetExceededException,
+and BudgetGovernancePolicy.
+
+Mirrors:
+  - ``com.enrichmeai.culvert.finops.BudgetViolationMode``    (BudgetViolationMode.java)
+  - ``com.enrichmeai.culvert.finops.BudgetExceededException`` (BudgetExceededException.java)
+  - ``com.enrichmeai.culvert.finops.BudgetGovernancePolicy``  (BudgetGovernancePolicy.java)
+
+Module placement follows the same rationale as the Java counterpart: this
+code compares ``CostMetrics.estimated_cost_usd`` (a float) against a
+configurable ceiling. It imports only stdlib + sibling core types —
+zero cloud-SDK dependencies.
+"""
+
+from __future__ import annotations
+
+import logging
+from enum import Enum
+from typing import Optional
+
+from data_pipeline_core.contracts.governance import GovernancePolicy
+from data_pipeline_core.finops_api.models import CostMetrics
+from data_pipeline_core.governance_api.classification import DataClassification
+from data_pipeline_core.governance_api.policies import MaskingPolicy, RetentionPolicy
+
+logger = logging.getLogger(__name__)
+
+
+class BudgetViolationMode(str, Enum):
+    """Determines the action taken by :class:`BudgetGovernancePolicy` when a
+    pipeline run's projected cost exceeds the configured ceiling.
+
+    Mirrors ``BudgetViolationMode.java``.
+
+    - ``BLOCK`` — raises :class:`BudgetExceededException`. Use in production
+      or automated CI where runaway spend is unacceptable.
+    - ``WARN``  — logs a ``WARNING`` via :mod:`logging` and allows the run to
+      continue. Use in development or staging where visibility is more
+      important than blocking.
+    """
+
+    BLOCK = "block"
+    """Raise :class:`BudgetExceededException` when the projected cost exceeds
+    the ceiling. The run does not proceed."""
+
+    WARN = "warn"
+    """Log a WARNING when the projected cost exceeds the ceiling. The run
+    continues."""
+
+
+class BudgetExceededException(Exception):
+    """Raised by :class:`BudgetGovernancePolicy` when a pipeline run's
+    projected cost exceeds the configured ceiling and the policy is in
+    ``BLOCK`` mode.
+
+    Mirrors ``BudgetExceededException.java``.
+
+    The message is intentionally human-readable so that an error handler can
+    surface it directly in a log or alert without additional formatting. It
+    includes:
+
+    - the pipeline ``run_id`` that triggered the check,
+    - the ``projected_cost_usd`` reported by :class:`~data_pipeline_core.finops_api.models.CostMetrics`, and
+    - the ``ceiling_usd`` that was exceeded.
+
+    Callers that want structured access should use the typed properties.
+    """
+
+    def __init__(self, run_id: str, projected_cost_usd: float, ceiling_usd: float) -> None:
+        super().__init__(
+            f"Budget ceiling exceeded for run '{run_id}': "
+            f"projected cost ${projected_cost_usd:.4f} USD > ceiling ${ceiling_usd:.4f} USD"
+        )
+        self._run_id = run_id
+        self._projected_cost_usd = projected_cost_usd
+        self._ceiling_usd = ceiling_usd
+
+    @property
+    def run_id(self) -> str:
+        """The pipeline run identifier passed to :meth:`BudgetGovernancePolicy.check_budget`."""
+        return self._run_id
+
+    @property
+    def projected_cost_usd(self) -> float:
+        """The projected cost in USD (from ``CostMetrics.estimated_cost_usd``)."""
+        return self._projected_cost_usd
+
+    @property
+    def ceiling_usd(self) -> float:
+        """The cost ceiling in USD configured on the policy."""
+        return self._ceiling_usd
+
+
+class BudgetGovernancePolicy:
+    """A :class:`~data_pipeline_core.contracts.governance.GovernancePolicy`
+    implementation that enforces a cost ceiling on pipeline runs.
+
+    Mirrors ``BudgetGovernancePolicy.java``.
+
+    How it works
+    ------------
+    1. Before submitting a pipeline run, call
+       :meth:`check_budget` with the estimate produced by
+       ``BigQueryCostTracker.estimate_dry_run()`` (or equivalent).
+    2. In ``BLOCK`` mode, the method raises :class:`BudgetExceededException`
+       if ``projected.estimated_cost_usd > ceiling_usd``. The run does not
+       proceed.
+    3. In ``WARN`` mode, the method logs a ``WARNING`` via :mod:`logging` and
+       returns normally. The run continues.
+
+    GovernancePolicy inherited methods
+    -----------------------------------
+    The three methods inherited from
+    :class:`~data_pipeline_core.contracts.governance.GovernancePolicy`
+    (``classify``, ``masking_for``, ``retention_for``) provide no-op
+    pass-through defaults: every field is
+    :attr:`~data_pipeline_core.governance_api.classification.DataClassification.INTERNAL`,
+    no masking applies, and no retention applies. These can be composed or
+    overridden by wrapping this policy with a delegating implementation when
+    full governance is also needed.
+
+    No cloud-SDK imports
+    --------------------
+    This class intentionally imports only stdlib and sibling core types.
+    """
+
+    def __init__(self, ceiling_usd: float, mode: BudgetViolationMode) -> None:
+        """Construct a new :class:`BudgetGovernancePolicy`.
+
+        Parameters
+        ----------
+        ceiling_usd:
+            The maximum allowed projected cost in USD (inclusive). A projected
+            cost strictly greater than this value triggers the violation action.
+        mode:
+            The action to take on a violation: ``BLOCK`` raises, ``WARN`` logs
+            and continues.
+
+        Raises
+        ------
+        ValueError
+            If ``ceiling_usd`` is negative.
+        TypeError
+            If ``mode`` is not a :class:`BudgetViolationMode`.
+        """
+        if ceiling_usd < 0.0:
+            raise ValueError(f"ceiling_usd must be non-negative, got: {ceiling_usd}")
+        if not isinstance(mode, BudgetViolationMode):
+            raise TypeError(f"mode must be a BudgetViolationMode, got: {type(mode)!r}")
+        self._ceiling_usd = ceiling_usd
+        self._mode = mode
+
+    @property
+    def ceiling_usd(self) -> float:
+        """The configured cost ceiling in USD."""
+        return self._ceiling_usd
+
+    @property
+    def mode(self) -> BudgetViolationMode:
+        """The configured violation mode."""
+        return self._mode
+
+    def check_budget(self, projected: CostMetrics, run_id: str) -> None:
+        """Check whether the projected cost stays within the configured ceiling.
+
+        If ``projected.estimated_cost_usd > ceiling_usd``:
+
+        - ``BLOCK``: raises :class:`BudgetExceededException`.
+        - ``WARN``: logs a ``WARNING`` and returns normally.
+
+        If ``projected.estimated_cost_usd <= ceiling_usd``, this method always
+        returns normally regardless of mode.
+
+        Parameters
+        ----------
+        projected:
+            The projected cost estimate (typically from
+            ``BigQueryCostTracker.estimate_dry_run``).
+        run_id:
+            The pipeline run identifier, used in the exception message and
+            log warning.
+
+        Raises
+        ------
+        BudgetExceededException
+            If in ``BLOCK`` mode and cost exceeds the ceiling.
+        """
+        if projected is None:
+            raise TypeError("projected must not be None")
+        if run_id is None:
+            raise TypeError("run_id must not be None")
+
+        estimated_cost = projected.estimated_cost_usd
+        if estimated_cost <= self._ceiling_usd:
+            return  # within budget — no action needed
+
+        # Cost exceeds ceiling — take the configured action.
+        if self._mode is BudgetViolationMode.BLOCK:
+            raise BudgetExceededException(run_id, estimated_cost, self._ceiling_usd)
+        else:
+            # WARN mode: log and continue
+            logger.warning(
+                "Budget ceiling exceeded for run '%s': projected cost $%.4f USD > "
+                "ceiling $%.4f USD — run will proceed (WARN mode)",
+                run_id,
+                estimated_cost,
+                self._ceiling_usd,
+            )
+
+    # -------------------------------------------------------------------------
+    # GovernancePolicy pass-through methods (no-op defaults)
+    #
+    # This policy's concern is cost enforcement. The three GovernancePolicy
+    # methods below provide inert defaults so BudgetGovernancePolicy can be
+    # used wherever a GovernancePolicy is expected without mixing
+    # masking/retention concerns into this class.
+    # -------------------------------------------------------------------------
+
+    def classify(self, field: str, table: str) -> DataClassification:
+        """Return :attr:`~data_pipeline_core.governance_api.classification.DataClassification.INTERNAL`
+        for every field/table. No data-catalog lookup is performed.
+        """
+        return DataClassification.INTERNAL
+
+    def masking_for(self, field: str, table: str) -> Optional[MaskingPolicy]:
+        """Return ``None`` — no masking policy is enforced by this
+        cost-governance implementation.
+        """
+        return None
+
+    def retention_for(self, table: str) -> Optional[RetentionPolicy]:
+        """Return ``None`` — no retention policy is enforced by this
+        cost-governance implementation.
+        """
+        return None

--- a/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/governance_api/__init__.py
+++ b/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/governance_api/__init__.py
@@ -1,9 +1,21 @@
-"""Governance data shapes: policies and classification."""
+"""Governance data shapes: policies, classification, and concretes."""
 
 from data_pipeline_core.governance_api.classification import DataClassification
+from data_pipeline_core.governance_api.masker import mask
+from data_pipeline_core.governance_api.pii_masking_governance_policy import (
+    PiiMaskingGovernancePolicy,
+)
 from data_pipeline_core.governance_api.policies import (
     MaskingPolicy,
+    MaskingStrategy,
     RetentionPolicy,
 )
 
-__all__ = ["MaskingPolicy", "RetentionPolicy", "DataClassification"]
+__all__ = [
+    "DataClassification",
+    "MaskingPolicy",
+    "MaskingStrategy",
+    "RetentionPolicy",
+    "mask",
+    "PiiMaskingGovernancePolicy",
+]

--- a/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/governance_api/masker.py
+++ b/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/governance_api/masker.py
@@ -1,0 +1,102 @@
+"""Masker — applies a MaskingPolicy to a single field value.
+
+Cloud-neutral utility: no GCP SDK, Cloud DLP, Dataplex, or external
+imports. All masking is structural — based on field-name matching, not
+per-cell content inspection.
+
+Mirrors Java ``com.enrichmeai.culvert.governance.Masker`` (Sprint 14 / T14.4).
+
+Supported strategies
+--------------------
+NONE      — value returned unchanged.
+FULL      — value replaced with policy.replacement (default "*").
+REDACTED  — same as FULL; value replaced with policy.replacement.
+PARTIAL   — all characters replaced with policy.replacement[0] (or '*')
+            except the last 4, which are kept. If the value has 4 or
+            fewer characters, all characters are replaced.  Non-string
+            values are converted via str() first.
+HASH      — deterministic SHA-256 hex digest of (salt + value).  If
+            policy.salt is empty, the constant process-stable salt
+            ``"culvert-pii-salt"`` is used (mirrors Java DEFAULT_SALT).
+
+Null passthrough
+----------------
+If ``value`` is ``None`` the method returns ``None`` regardless of strategy
+— nulls are not fabricated.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Optional
+
+from data_pipeline_core.governance_api.policies import MaskingPolicy, MaskingStrategy
+
+# Mirrors Java ``Masker.DEFAULT_SALT`` (Masker.java:41)
+_DEFAULT_SALT = "culvert-pii-salt"
+
+
+def mask(value: Optional[Any], policy: MaskingPolicy) -> Optional[Any]:
+    """Apply *policy* to *value* and return the masked result.
+
+    Parameters
+    ----------
+    value:
+        The field value to mask.  ``None`` is returned unchanged.
+    policy:
+        The masking policy.  Must not be ``None``.
+
+    Returns
+    -------
+    The masked value, or ``None`` if *value* was ``None``.
+
+    Raises
+    ------
+    TypeError
+        If *policy* is ``None``.
+    """
+    if policy is None:
+        raise TypeError("policy must not be None")
+    if value is None:
+        return None
+
+    strategy = policy.strategy
+
+    if strategy is MaskingStrategy.NONE:
+        return value
+    if strategy in (MaskingStrategy.FULL, MaskingStrategy.REDACTED):
+        return policy.replacement
+    if strategy is MaskingStrategy.PARTIAL:
+        return _mask_partial(str(value), policy.replacement)
+    if strategy is MaskingStrategy.HASH:
+        return _mask_hash(str(value), policy.salt)
+
+    # Unreachable for a well-formed MaskingStrategy enum, but guard anyway.
+    raise ValueError(f"Unsupported MaskingStrategy: {strategy!r}")  # pragma: no cover
+
+
+# ---------------------------------------------------------------------------
+# Strategy helpers — mirrors Java private methods in Masker.java
+# ---------------------------------------------------------------------------
+
+def _mask_partial(s: str, replacement: str) -> str:
+    """Mask all characters except the last 4.
+
+    Mirrors Java ``Masker.maskPartial`` (Masker.java:74-81).
+    """
+    repl_char = replacement[0] if replacement else "*"
+    if len(s) <= 4:
+        return repl_char * len(s)
+    suffix = s[-4:]
+    return repl_char * (len(s) - 4) + suffix
+
+
+def _mask_hash(value: str, salt: str) -> str:
+    """Return a deterministic SHA-256 hex digest of (effective_salt + value).
+
+    Mirrors Java ``Masker.maskHash`` (Masker.java:87-101): salt is prepended
+    to value before hashing.
+    """
+    effective_salt = salt if salt else _DEFAULT_SALT
+    digest = hashlib.sha256((effective_salt + value).encode("utf-8")).hexdigest()
+    return digest

--- a/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/governance_api/pii_masking_governance_policy.py
+++ b/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/governance_api/pii_masking_governance_policy.py
@@ -1,0 +1,173 @@
+"""PiiMaskingGovernancePolicy — structural GovernancePolicy implementation.
+
+Identifies PII fields by column-name membership and/or regex pattern
+matching, then applies a configured MaskingPolicy.
+
+Mirrors Java ``com.enrichmeai.culvert.governance.PiiMaskingGovernancePolicy``
+(Sprint 14 / T14.4 / issue #76).
+
+Matching rules (applied in order; first match wins)
+----------------------------------------------------
+1. **Column-name set** — exact, case-sensitive comparison against the
+   ``pii_columns`` set supplied at construction.
+   E.g. ``{"email", "ssn", "phone"}``.
+2. **Regex patterns** — each pattern in ``pii_patterns`` is tested with
+   ``re.fullmatch()`` (anchored full-field-name match, mirroring Java
+   ``Matcher.matches()``).  E.g. ``[".*_pii$", ".*_secret$"]``.
+
+Classification
+--------------
+A field that matches either rule → ``DataClassification.RESTRICTED``.
+All other fields → ``DataClassification.INTERNAL``.
+
+Masking policy resolution
+--------------------------
+When a field matches:
+1. If ``column_overrides`` contains an entry for that field name, that
+   MaskingPolicy is used.
+2. Otherwise ``default_masking_policy`` is used.
+
+``column_overrides`` only overrides the *policy* for already-matched
+fields. A key present only in the override map (not in the column set
+and not matching any pattern) does NOT by itself make a field match.
+
+Scope cap
+---------
+Structural only — inspects field names, not values. Tag-based policy
+resolution (Dataplex, Cloud DLP, Purview) is out of scope. Do not add
+cloud SDK imports here.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Dict, FrozenSet, List, Mapping, Optional, Sequence
+
+from data_pipeline_core.governance_api.classification import DataClassification
+from data_pipeline_core.governance_api.policies import MaskingPolicy, RetentionPolicy
+
+
+class PiiMaskingGovernancePolicy:
+    """A structural :class:`GovernancePolicy` for PII masking.
+
+    Parameters
+    ----------
+    pii_columns:
+        Exact column names that are PII (case-sensitive).  May be empty.
+    pii_patterns:
+        Regex pattern strings tested against field names via
+        ``re.fullmatch()`` (anchored, mirrors Java ``Matcher.matches()``).
+        May be empty.  Patterns are compiled once at construction time.
+    default_masking_policy:
+        Applied when a field matches and no per-column override exists.
+        Required.
+    column_overrides:
+        Optional per-column policy overrides, applied only to *matched*
+        fields.
+
+    Raises
+    ------
+    ValueError
+        If ``default_masking_policy`` is ``None``.
+    re.error
+        If any pattern in ``pii_patterns`` is invalid.
+    """
+
+    # Mirrors Java PiiMaskingGovernancePolicy (PiiMaskingGovernancePolicy.java:73)
+
+    def __init__(
+        self,
+        pii_columns: Optional[FrozenSet[str] | frozenset | set] = None,
+        pii_patterns: Optional[Sequence[str]] = None,
+        default_masking_policy: Optional[MaskingPolicy] = None,
+        column_overrides: Optional[Mapping[str, MaskingPolicy]] = None,
+    ) -> None:
+        if default_masking_policy is None:
+            raise ValueError("default_masking_policy must not be None")
+
+        self._pii_columns: FrozenSet[str] = frozenset(pii_columns) if pii_columns else frozenset()
+        self._compiled_patterns: List[re.Pattern[str]] = [
+            re.compile(p) for p in (pii_patterns or [])
+        ]
+        self._default_masking_policy: MaskingPolicy = default_masking_policy
+        self._column_overrides: Dict[str, MaskingPolicy] = dict(column_overrides) if column_overrides else {}
+
+    # ------------------------------------------------------------------
+    # GovernancePolicy implementation
+    # ------------------------------------------------------------------
+
+    def classify(self, field: str, table: str) -> DataClassification:
+        """Return RESTRICTED if *field* is PII, INTERNAL otherwise.
+
+        Mirrors Java ``PiiMaskingGovernancePolicy.classify``
+        (PiiMaskingGovernancePolicy.java:137-139).
+        """
+        return DataClassification.RESTRICTED if self._is_pii(field) else DataClassification.INTERNAL
+
+    def masking_for(self, field: str, table: str) -> Optional[MaskingPolicy]:
+        """Return the masking policy for *field*, or None if not PII.
+
+        Column override (if present) takes precedence over the default.
+
+        Mirrors Java ``PiiMaskingGovernancePolicy.maskingFor``
+        (PiiMaskingGovernancePolicy.java:152-157).
+        """
+        if not self._is_pii(field):
+            return None
+        return self._column_overrides.get(field, self._default_masking_policy)
+
+    def retention_for(self, table: str) -> Optional[RetentionPolicy]:
+        """Always returns None — this policy does not manage retention.
+
+        Mirrors Java ``PiiMaskingGovernancePolicy.retentionFor``
+        (PiiMaskingGovernancePolicy.java:163-165).
+        """
+        return None
+
+    # ------------------------------------------------------------------
+    # Accessors (for tests and composition)
+    # ------------------------------------------------------------------
+
+    @property
+    def pii_columns(self) -> FrozenSet[str]:
+        """Unmodifiable view of the explicit PII column-name set."""
+        return self._pii_columns
+
+    @property
+    def default_masking_policy(self) -> MaskingPolicy:
+        """The default masking policy."""
+        return self._default_masking_policy
+
+    @property
+    def column_overrides(self) -> Dict[str, MaskingPolicy]:
+        """Unmodifiable copy of the per-column override map."""
+        return dict(self._column_overrides)
+
+    # ------------------------------------------------------------------
+    # Internal: shared match predicate
+    # ------------------------------------------------------------------
+
+    def _is_pii(self, field_name: str) -> bool:
+        """Return True iff *field_name* is in the column set or matches a regex.
+
+        Single source of truth for both :meth:`classify` and
+        :meth:`masking_for` — mirrors Java ``PiiMaskingGovernancePolicy.isPii``
+        (PiiMaskingGovernancePolicy.java:197-202).
+
+        Uses ``re.fullmatch`` to mirror Java ``Matcher.matches()``
+        (anchored full-string match).
+        """
+        if field_name in self._pii_columns:
+            return True
+        for pattern in self._compiled_patterns:
+            if pattern.fullmatch(field_name):
+                return True
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Runtime_checkable assertion (documented, not enforced here)
+# ---------------------------------------------------------------------------
+# PiiMaskingGovernancePolicy satisfies GovernancePolicy by structural typing
+# (duck typing / Protocol). No explicit inheritance is required.
+# Verified by: isinstance(PiiMaskingGovernancePolicy(...), GovernancePolicy)

--- a/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/runtime.py
+++ b/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/runtime.py
@@ -1,0 +1,414 @@
+"""DefaultRuntimeContext — concrete RuntimeContext for the Culvert framework.
+
+Cloud-neutral DI container that carries ``run_id``, ``environment``,
+``config``, and a mutable registry of protocol-implementation bindings.
+
+Mirrors the Java ``DefaultRuntimeContext`` (Sprint-9 / T9.1; serialization
+boundary hardened in Sprint-10 / T10.6; StageMetricsHook added in
+Sprint-12 / T12.4).
+
+.. note::
+    **Naming**: the Protocol docstring at
+    ``data_pipeline_core.contracts.runtime`` (line 9) specifies the impl as
+    ``data_pipeline_core.runtime.RuntimeContextImpl``.  The name
+    ``DefaultRuntimeContext`` is provided as an alias so cross-language docs
+    and tickets that reference the Java name continue to work.
+
+Serialization boundary (T10.6)
+--------------------------------
+Only ``run_id``, ``environment``, and ``config`` are serialization-safe.
+The ``_registry`` dict is **excluded** from ``__getstate__`` — it is not
+shipped across process/worker boundaries and must be rebuilt worker-side.
+
+In the Java implementation worker-side rebuild uses ``AutoConfig.discover()``
+(classpath ``ServiceLoader``), which yields ready-made *instances*.  The
+Python ``AutoConfig.discover()`` (``autoconfig.py:85-116``) yields *classes*,
+not instances — they require constructor arguments that are not available
+worker-side.  Equivalent auto-rebuild is therefore **not implemented here**;
+worker-side callers are expected to reconstruct the registry explicitly (e.g.
+via ``register()``) or by adaptor-specific means.  This deliberate divergence
+is flagged per the T18.1 DoD.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from types import MappingProxyType
+from typing import Any, Mapping, Optional, Type
+
+# ---------------------------------------------------------------------------
+# No-op helpers (advisory protocols — fall back silently when absent)
+# ---------------------------------------------------------------------------
+# Mirrors Java NoOpDefaults inner classes (DefaultRuntimeContext.java, the
+# anonymous lambda / no-op impls used in computeIfAbsent calls at :251-289).
+# ---------------------------------------------------------------------------
+
+
+class _NoOpObservabilityHook:
+    """Silent no-op for ObservabilityHook.
+
+    Mirrors Java ``NoOpDefaults.NoOpObservabilityHook``.
+    ``span()`` returns a ``nullcontext`` context manager (not None) because
+    ``ObservabilityHook.span`` is typed as ``AbstractContextManager``
+    (``observability.py:71``).
+    """
+
+    def counter(self, name: str, value: int = 1, tags: Mapping[str, str] = {}) -> None:
+        pass
+
+    def gauge(self, name: str, value: float, tags: Mapping[str, str] = {}) -> None:
+        pass
+
+    def histogram(self, name: str, value: float, tags: Mapping[str, str] = {}) -> None:
+        pass
+
+    def log(self, level: str, message: str, **fields: Any) -> None:
+        pass
+
+    def span(self, name: str) -> Any:
+        return contextlib.nullcontext()
+
+
+class _NoOpStageMetricsHook:
+    """Silent no-op for StageMetricsHook (T12.4 advisory protocol).
+
+    Mirrors Java ``NoOpDefaults.NoOpStageMetricsHook``.
+    """
+
+    def record_stage_metrics(self, metrics: Any) -> None:  # noqa: ANN401
+        pass
+
+
+class _NoOpLineageEmitter:
+    """Silent no-op for LineageEmitter.
+
+    Mirrors Java ``NoOpDefaults.NoOpLineageEmitter``.
+    """
+
+    def emit(self, event: Any) -> None:  # noqa: ANN401
+        pass
+
+
+class _NoOpFinOpsSink:
+    """Silent no-op for FinOpsSink.
+
+    Mirrors Java ``NoOpDefaults.NoOpFinOpsSink``.
+    """
+
+    def record(self, metrics: Any, tags: Any) -> None:  # noqa: ANN401
+        pass
+
+
+class _NoOpGovernancePolicy:
+    """Minimal no-op for GovernancePolicy.
+
+    ``classify()`` returns ``DataClassification.INTERNAL`` as the safe
+    default (``governance.py:30-36``).  Masking/retention return ``None``
+    (no policy attached).
+
+    Mirrors Java ``NoOpDefaults.NoOpGovernancePolicy``.
+    """
+
+    def classify(self, field: str, table: str) -> Any:  # noqa: ANN401
+        from data_pipeline_core.governance_api.classification import DataClassification
+        return DataClassification.INTERNAL
+
+    def masking_for(self, field: str, table: str) -> Optional[Any]:
+        return None
+
+    def retention_for(self, table: str) -> Optional[Any]:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Protocol keys used by the registry (advisory hooks)
+# ---------------------------------------------------------------------------
+# These are looked up lazily (import at first access) to avoid circular-import
+# issues while keeping the structural-typing check clean.
+
+def _observability_key() -> type:
+    from data_pipeline_core.contracts.observability import ObservabilityHook
+    return ObservabilityHook
+
+
+def _stage_metrics_key() -> type:
+    from data_pipeline_core.contracts.stage_metrics import StageMetricsHook
+    return StageMetricsHook
+
+
+def _lineage_key() -> type:
+    from data_pipeline_core.contracts.lineage import LineageEmitter
+    return LineageEmitter
+
+
+def _finops_key() -> type:
+    from data_pipeline_core.contracts.finops import FinOpsSink
+    return FinOpsSink
+
+
+def _governance_key() -> type:
+    from data_pipeline_core.contracts.governance import GovernancePolicy
+    return GovernancePolicy
+
+
+def _secrets_key() -> type:
+    from data_pipeline_core.contracts.secrets import SecretProvider
+    return SecretProvider
+
+
+# ---------------------------------------------------------------------------
+# RuntimeContextImpl
+# ---------------------------------------------------------------------------
+
+
+class RuntimeContextImpl:
+    """Cloud-neutral concrete RuntimeContext — the framework's DI container.
+
+    Holds a ``run_id``, an ``environment``, an immutable ``config``
+    mapping, and a mutable dict registry keyed by protocol class.
+    ``get(protocol)`` reads the registry; ``register(protocol, impl)``
+    overrides an entry (last write wins).  The six named hook properties
+    (``secrets``, ``observability``, ``stage_metrics``, ``lineage``,
+    ``finops``, ``governance``) are thin wrappers over the registry.
+
+    Mirrors ``DefaultRuntimeContext`` (Java, :82).
+
+    Defaulting policy
+    -----------------
+    * **Advisory protocols** — ``observability``, ``stage_metrics``,
+      ``lineage``, ``finops``, ``governance`` — fall back to a silent no-op
+      when nothing is registered (mirrors Java ``computeIfAbsent`` pattern,
+      :251–289).
+    * **Hard dependency** — ``secrets`` — raises ``RuntimeError`` when
+      absent (mirrors Java ``IllegalStateException``, :240–249).
+
+    Usage::
+
+        ctx = RuntimeContextImpl("run-001", "prod", {"timeout": 30})
+        ctx.register(SecretProvider, MySecretProvider())
+        secret = ctx.secrets.get("db-password")
+    """
+
+    def __init__(
+        self,
+        run_id: str,
+        environment: str,
+        config: Optional[Mapping[str, Any]] = None,
+        *,
+        registry: Optional[dict[type, Any]] = None,
+    ) -> None:
+        """Construct a RuntimeContextImpl.
+
+        Args:
+            run_id: The run identifier.  Required, non-blank.
+                    Mirrors Java Builder :316–327.
+            environment: The deployment environment (e.g. ``"prod"``).
+                         Required, non-blank.
+            config: Read-only application configuration.  Defensively
+                    copied to an immutable ``MappingProxyType``.
+                    Mirrors Java ``Map.copyOf`` at :118.
+            registry: Optional seed registry (used internally / for
+                      testing).  Copied — mutations to the supplied dict
+                      do not affect the instance.
+        """
+        if not run_id:
+            raise ValueError("run_id must not be blank")
+        if not environment:
+            raise ValueError("environment must not be blank")
+
+        self.run_id: str = run_id
+        self.environment: str = environment
+        # Serialization boundary (T10.6): only the three identity/config
+        # fields cross worker boundaries (Java :92-102).
+        self.config: Mapping[str, Any] = MappingProxyType(dict(config or {}))
+
+        # Transient registry — not serialized (Java `transient volatile`, :113).
+        self._registry: dict[type, Any] = dict(registry or {})
+
+    # ------------------------------------------------------------------
+    # pipeline_id property (Sprint-12 / T12.6)
+    # ------------------------------------------------------------------
+
+    @property
+    def pipeline_id(self) -> str:
+        """The logical pipeline identifier.
+
+        Default: ``run_id``.  Override by subclassing or registering a
+        pipeline-aware context.  Mirrors Java ``RuntimeContext.pipelineId()``
+        and the Protocol default at ``contracts/runtime.py:81``.
+        """
+        return self.run_id
+
+    # ------------------------------------------------------------------
+    # Registry accessors
+    # ------------------------------------------------------------------
+
+    def get(self, protocol: Type[Any]) -> Any:
+        """Return the registered implementation of *protocol*.
+
+        Raises:
+            KeyError: if no implementation has been registered.
+                      (Mirrors the Python Protocol docstring at
+                      ``contracts/runtime.py:86-88``; Java raises
+                      ``IllegalStateException`` — Python uses ``KeyError``
+                      to match the Protocol contract.)
+        """
+        if protocol not in self._registry:
+            raise KeyError(
+                f"No implementation registered for {protocol!r}; "
+                "call register(protocol, impl) first."
+            )
+        return self._registry[protocol]
+
+    def register(self, protocol: Type[Any], impl: Any) -> None:
+        """Register *impl* as the implementation of *protocol*.
+
+        Later registrations override earlier ones (last-write-wins).
+        Mirrors Java ``DefaultRuntimeContext.register`` at :305–309 and
+        ``Builder.register`` at :339–344.
+        """
+        if protocol is None:
+            raise ValueError("protocol must not be None")
+        if impl is None:
+            raise ValueError("impl must not be None")
+        self._registry[protocol] = impl
+
+    # ------------------------------------------------------------------
+    # Named hook properties
+    # ------------------------------------------------------------------
+    # Six properties mirror the six Java accessor methods (:224–289).
+    # Advisory protocols (observability, stage_metrics, lineage, finops,
+    # governance) install a no-op into the registry on first access when
+    # absent — mirrors Java's computeIfAbsent pattern (:251–289).
+    # `secrets` is the hard dependency; it raises when absent (:240–249).
+
+    @property
+    def secrets(self) -> Any:
+        """Return the registered SecretProvider.
+
+        Raises:
+            RuntimeError: if no SecretProvider has been registered.
+                          Mirrors Java ``IllegalStateException`` at :240–249.
+                          There is no no-op default for secrets by design —
+                          silently returning a fake would mask a
+                          misconfiguration.
+        """
+        key = _secrets_key()
+        impl = self._registry.get(key)
+        if impl is None:
+            raise RuntimeError(
+                "No SecretProvider registered; call "
+                "register(SecretProvider, ...) before accessing secrets. "
+                "There is no no-op default for secrets by design."
+            )
+        return impl
+
+    @property
+    def observability(self) -> Any:
+        """Return the registered ObservabilityHook, or a no-op default.
+
+        Mirrors Java ``DefaultRuntimeContext.observability()`` at :252–255.
+        """
+        key = _observability_key()
+        if key not in self._registry:
+            self._registry[key] = _NoOpObservabilityHook()
+        return self._registry[key]
+
+    @property
+    def stage_metrics(self) -> Any:
+        """Return the registered StageMetricsHook, or a no-op default.
+
+        Advisory protocol (T12.4).  Mirrors Java
+        ``DefaultRuntimeContext.stageMetrics()`` at :268–271.
+        """
+        key = _stage_metrics_key()
+        if key not in self._registry:
+            self._registry[key] = _NoOpStageMetricsHook()
+        return self._registry[key]
+
+    @property
+    def lineage(self) -> Any:
+        """Return the registered LineageEmitter, or a no-op default.
+
+        Mirrors Java ``DefaultRuntimeContext.lineage()`` at :274–277.
+        """
+        key = _lineage_key()
+        if key not in self._registry:
+            self._registry[key] = _NoOpLineageEmitter()
+        return self._registry[key]
+
+    @property
+    def finops(self) -> Any:
+        """Return the registered FinOpsSink, or a no-op default.
+
+        Mirrors Java ``DefaultRuntimeContext.finops()`` at :279–282.
+        """
+        key = _finops_key()
+        if key not in self._registry:
+            self._registry[key] = _NoOpFinOpsSink()
+        return self._registry[key]
+
+    @property
+    def governance(self) -> Any:
+        """Return the registered GovernancePolicy, or a no-op default.
+
+        Mirrors Java ``DefaultRuntimeContext.governance()`` at :284–288.
+        """
+        key = _governance_key()
+        if key not in self._registry:
+            self._registry[key] = _NoOpGovernancePolicy()
+        return self._registry[key]
+
+    # ------------------------------------------------------------------
+    # Serialization boundary (T10.6)
+    # ------------------------------------------------------------------
+
+    def __getstate__(self) -> dict[str, Any]:
+        """Serialization: only the three identity/config fields cross the
+        boundary.
+
+        The registry is *excluded* — it is transient and must be rebuilt
+        worker-side.  Mirrors the Java ``transient`` annotation on
+        ``registry`` at :113 and the T10.6 serialization contract.
+
+        .. note::
+            Unlike the Java implementation, worker-side auto-rebuild from
+            ``AutoConfig.discover()`` is not implemented here (see module
+            docstring for the reason).  After deserialization ``_registry``
+            is empty; callers must re-register protocol implementations.
+        """
+        return {
+            "run_id": self.run_id,
+            "environment": self.environment,
+            "config": dict(self.config),
+        }
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        """Deserialization: rebuild from the three identity/config fields only.
+
+        ``_registry`` starts empty — the caller is responsible for
+        re-registering protocol implementations.  Mirrors the Java
+        post-deserialization state where ``registry`` is ``null`` and
+        rebuilt lazily on first access.
+        """
+        self.run_id = state["run_id"]
+        self.environment = state["environment"]
+        self.config = MappingProxyType(state.get("config", {}))
+        self._registry = {}
+
+    # ------------------------------------------------------------------
+    # Dunder
+    # ------------------------------------------------------------------
+
+    def __repr__(self) -> str:
+        return (
+            f"RuntimeContextImpl(run_id={self.run_id!r}, "
+            f"environment={self.environment!r}, "
+            f"config_keys={list(self.config)!r})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Alias so cross-language docs / tickets that reference the Java name work.
+# ---------------------------------------------------------------------------
+DefaultRuntimeContext = RuntimeContextImpl

--- a/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/schema/entity.py
+++ b/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/schema/entity.py
@@ -9,10 +9,18 @@ function (Stage 2).
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 from data_pipeline_core.governance_api.classification import DataClassification
 from data_pipeline_core.governance_api.policies import MaskingPolicy
+
+if TYPE_CHECKING:
+    # Guarded to avoid a circular import at runtime:
+    # dataquality.NumericRange is in a peer sub-package that itself imports
+    # SchemaField.  At type-check time (mypy/pyright) the import is fine;
+    # at runtime the annotation is a string-forward-ref thanks to
+    # `from __future__ import annotations`.
+    from data_pipeline_core.dataquality.numeric_range import NumericRange
 
 
 @dataclass(frozen=True)
@@ -26,6 +34,11 @@ class SchemaField:
     `classification` and `masking` are optional metadata used by the
     `@governed` and `@masked` decorators (Stage 3) to apply
     field-level policy without requiring an explicit decorator call.
+
+    `range` is an optional :class:`~data_pipeline_core.dataquality.NumericRange`
+    that opts this field into OUT_OF_RANGE validation inside
+    :class:`~data_pipeline_core.dataquality.DataQualityTransform`.
+    Mirrors ``SchemaField.range()`` (Java T14.7 / issue #100).
     """
 
     name: str
@@ -34,6 +47,10 @@ class SchemaField:
     description: Optional[str] = None
     classification: Optional[DataClassification] = None
     masking: Optional[MaskingPolicy] = None
+    # Sprint-18 / T18.2: added additively to support schema-grounded range
+    # validation in DataQualityTransform.  Existing callers that omit this
+    # field are unaffected (default None → range validation skipped).
+    range: Optional["NumericRange"] = None
 
 
 @dataclass(frozen=True)

--- a/data-pipeline-libraries/data-pipeline-core/tests/test_budget_governance.py
+++ b/data-pipeline-libraries/data-pipeline-core/tests/test_budget_governance.py
@@ -1,0 +1,214 @@
+"""Tests for BudgetViolationMode, BudgetExceededException, BudgetGovernancePolicy.
+
+Mirrors the semantics of the Java counterparts:
+  - BudgetViolationMode.java    — BLOCK / WARN enum
+  - BudgetExceededException.java — checked exception with typed accessors
+  - BudgetGovernancePolicy.java  — BLOCK raises, WARN logs and continues;
+                                    GovernancePolicy pass-through no-ops
+"""
+
+import logging
+from typing import Optional
+
+import pytest
+
+from data_pipeline_core.contracts.governance import GovernancePolicy
+from data_pipeline_core.finops_api import (
+    BudgetExceededException,
+    BudgetGovernancePolicy,
+    BudgetViolationMode,
+    CostMetrics,
+)
+from data_pipeline_core.governance_api.classification import DataClassification
+from data_pipeline_core.governance_api.policies import MaskingPolicy, RetentionPolicy
+
+
+# ---------------------------------------------------------------------------
+# BudgetViolationMode
+# ---------------------------------------------------------------------------
+
+
+def test_budget_violation_mode_values() -> None:
+    """Enum has BLOCK and WARN members, matching Java's BudgetViolationMode."""
+    assert BudgetViolationMode.BLOCK.value == "block"
+    assert BudgetViolationMode.WARN.value == "warn"
+    assert len(BudgetViolationMode) == 2
+
+
+# ---------------------------------------------------------------------------
+# BudgetExceededException
+# ---------------------------------------------------------------------------
+
+
+def test_budget_exceeded_exception_message() -> None:
+    """Human-readable message includes run_id, projected, and ceiling."""
+    exc = BudgetExceededException("run-42", 12.3456, 10.0)
+    msg = str(exc)
+    assert "run-42" in msg
+    assert "12.3456" in msg
+    assert "10.0000" in msg
+
+
+def test_budget_exceeded_exception_typed_accessors() -> None:
+    """Typed properties return the values passed to the constructor."""
+    exc = BudgetExceededException("r1", 7.5, 5.0)
+    assert exc.run_id == "r1"
+    assert exc.projected_cost_usd == pytest.approx(7.5)
+    assert exc.ceiling_usd == pytest.approx(5.0)
+
+
+def test_budget_exceeded_exception_is_exception() -> None:
+    """BudgetExceededException is a subclass of Exception."""
+    assert issubclass(BudgetExceededException, Exception)
+
+
+# ---------------------------------------------------------------------------
+# BudgetGovernancePolicy — construction
+# ---------------------------------------------------------------------------
+
+
+def test_budget_policy_construction_valid() -> None:
+    policy = BudgetGovernancePolicy(50.0, BudgetViolationMode.BLOCK)
+    assert policy.ceiling_usd == pytest.approx(50.0)
+    assert policy.mode is BudgetViolationMode.BLOCK
+
+
+def test_budget_policy_zero_ceiling_allowed() -> None:
+    """ceiling_usd == 0.0 is valid — any positive cost triggers the mode."""
+    policy = BudgetGovernancePolicy(0.0, BudgetViolationMode.WARN)
+    assert policy.ceiling_usd == pytest.approx(0.0)
+
+
+def test_budget_policy_negative_ceiling_raises() -> None:
+    with pytest.raises(ValueError, match="non-negative"):
+        BudgetGovernancePolicy(-1.0, BudgetViolationMode.BLOCK)
+
+
+def test_budget_policy_invalid_mode_raises() -> None:
+    with pytest.raises(TypeError):
+        BudgetGovernancePolicy(50.0, "BLOCK")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# BudgetGovernancePolicy — check_budget, BLOCK mode
+# ---------------------------------------------------------------------------
+
+
+def test_check_budget_block_within_ceiling_no_raise() -> None:
+    """Projected cost at exactly the ceiling must NOT raise."""
+    policy = BudgetGovernancePolicy(10.0, BudgetViolationMode.BLOCK)
+    metrics = CostMetrics(run_id="r", estimated_cost_usd=10.0)
+    policy.check_budget(metrics, "r")  # must not raise
+
+
+def test_check_budget_block_below_ceiling_no_raise() -> None:
+    policy = BudgetGovernancePolicy(10.0, BudgetViolationMode.BLOCK)
+    metrics = CostMetrics(run_id="r", estimated_cost_usd=9.99)
+    policy.check_budget(metrics, "r")  # must not raise
+
+
+def test_check_budget_block_exceeds_ceiling_raises() -> None:
+    """Projected cost > ceiling in BLOCK mode raises BudgetExceededException."""
+    policy = BudgetGovernancePolicy(10.0, BudgetViolationMode.BLOCK)
+    metrics = CostMetrics(run_id="r", estimated_cost_usd=10.0001)
+    with pytest.raises(BudgetExceededException) as exc_info:
+        policy.check_budget(metrics, "run-abc")
+    exc = exc_info.value
+    assert exc.run_id == "run-abc"
+    assert exc.projected_cost_usd == pytest.approx(10.0001)
+    assert exc.ceiling_usd == pytest.approx(10.0)
+
+
+def test_check_budget_block_uses_run_id_argument_not_metrics_run_id() -> None:
+    """The run_id argument to check_budget is used in the exception, not
+    metrics.run_id — matching Java's BudgetGovernancePolicy.checkBudget."""
+    policy = BudgetGovernancePolicy(5.0, BudgetViolationMode.BLOCK)
+    metrics = CostMetrics(run_id="metrics-run", estimated_cost_usd=99.0)
+    with pytest.raises(BudgetExceededException) as exc_info:
+        policy.check_budget(metrics, "arg-run-id")
+    assert exc_info.value.run_id == "arg-run-id"
+
+
+# ---------------------------------------------------------------------------
+# BudgetGovernancePolicy — check_budget, WARN mode
+# ---------------------------------------------------------------------------
+
+
+def test_check_budget_warn_within_ceiling_no_log(caplog) -> None:
+    policy = BudgetGovernancePolicy(10.0, BudgetViolationMode.WARN)
+    metrics = CostMetrics(run_id="r", estimated_cost_usd=5.0)
+    with caplog.at_level(logging.WARNING):
+        policy.check_budget(metrics, "r")
+    assert caplog.records == []
+
+
+def test_check_budget_warn_exceeds_ceiling_logs_no_raise(caplog) -> None:
+    """In WARN mode, exceeding the ceiling logs a warning and does not raise."""
+    policy = BudgetGovernancePolicy(10.0, BudgetViolationMode.WARN)
+    metrics = CostMetrics(run_id="r", estimated_cost_usd=15.0)
+    with caplog.at_level(logging.WARNING):
+        policy.check_budget(metrics, "run-warn")  # must NOT raise
+    assert any("run-warn" in r.message for r in caplog.records)
+    assert any("15.0000" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# BudgetGovernancePolicy — None-arg guards
+# ---------------------------------------------------------------------------
+
+
+def test_check_budget_none_projected_raises() -> None:
+    policy = BudgetGovernancePolicy(10.0, BudgetViolationMode.BLOCK)
+    with pytest.raises(TypeError):
+        policy.check_budget(None, "r")  # type: ignore[arg-type]
+
+
+def test_check_budget_none_run_id_raises() -> None:
+    policy = BudgetGovernancePolicy(10.0, BudgetViolationMode.BLOCK)
+    metrics = CostMetrics(run_id="r", estimated_cost_usd=99.0)
+    with pytest.raises(TypeError):
+        policy.check_budget(metrics, None)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# BudgetGovernancePolicy — GovernancePolicy pass-through no-ops
+# ---------------------------------------------------------------------------
+
+
+def test_budget_policy_satisfies_governance_protocol() -> None:
+    """BudgetGovernancePolicy must satisfy the GovernancePolicy Protocol."""
+    policy = BudgetGovernancePolicy(50.0, BudgetViolationMode.WARN)
+    assert isinstance(policy, GovernancePolicy)
+
+
+def test_classify_returns_internal() -> None:
+    policy = BudgetGovernancePolicy(50.0, BudgetViolationMode.WARN)
+    assert policy.classify("some_field", "some_table") is DataClassification.INTERNAL
+
+
+def test_masking_for_returns_none() -> None:
+    policy = BudgetGovernancePolicy(50.0, BudgetViolationMode.WARN)
+    result: Optional[MaskingPolicy] = policy.masking_for("f", "t")
+    assert result is None
+
+
+def test_retention_for_returns_none() -> None:
+    policy = BudgetGovernancePolicy(50.0, BudgetViolationMode.WARN)
+    result: Optional[RetentionPolicy] = policy.retention_for("t")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Public surface: importable from finops_api top-level
+# ---------------------------------------------------------------------------
+
+
+def test_budget_types_importable_from_finops_api_package() -> None:
+    from data_pipeline_core.finops_api import (
+        BudgetExceededException as Exc,
+        BudgetGovernancePolicy as Policy,
+        BudgetViolationMode as Mode,
+    )
+    assert Mode.BLOCK is BudgetViolationMode.BLOCK
+    assert Policy is BudgetGovernancePolicy
+    assert Exc is BudgetExceededException

--- a/data-pipeline-libraries/data-pipeline-core/tests/test_dataquality.py
+++ b/data-pipeline-libraries/data-pipeline-core/tests/test_dataquality.py
@@ -1,0 +1,439 @@
+"""Tests for the dataquality package — T18.2 / issue #118.
+
+Covers all five ported types: ViolationKind, NumericRange, FieldViolation,
+ValidationResult (ValidRow + InvalidRow), and DataQualityTransform.
+
+Mirrors Java semantics (cited inline).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Mapping, Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+from data_pipeline_core.dataquality import (
+    DataQualityTransform,
+    FieldViolation,
+    InvalidRow,
+    NumericRange,
+    ValidRow,
+    ValidationResult,
+    ViolationKind,
+)
+from data_pipeline_core.schema.entity import EntitySchema, SchemaField
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_context(pipeline_id: str = "pipe", run_id: str = "run-1") -> Any:
+    """Return a mock RuntimeContext that records StageMetrics calls."""
+    ctx = MagicMock()
+    ctx.pipeline_id = pipeline_id
+    ctx.run_id = run_id
+    ctx.stage_metrics = MagicMock()
+    return ctx
+
+
+def _make_schema(*fields: SchemaField) -> EntitySchema:
+    return EntitySchema(name="test_entity", fields=list(fields))
+
+
+Row = Dict[str, Any]
+_accessor: Any = lambda row: row  # identity accessor
+
+
+# ---------------------------------------------------------------------------
+# ViolationKind
+# ---------------------------------------------------------------------------
+
+class TestViolationKind:
+    def test_three_variants(self) -> None:
+        assert ViolationKind.MISSING_REQUIRED
+        assert ViolationKind.TYPE_MISMATCH
+        assert ViolationKind.OUT_OF_RANGE
+
+    def test_enum_values_match_names(self) -> None:
+        assert ViolationKind.MISSING_REQUIRED.value == "MISSING_REQUIRED"
+        assert ViolationKind.TYPE_MISMATCH.value == "TYPE_MISMATCH"
+        assert ViolationKind.OUT_OF_RANGE.value == "OUT_OF_RANGE"
+
+
+# ---------------------------------------------------------------------------
+# NumericRange
+# ---------------------------------------------------------------------------
+
+class TestNumericRange:
+    def test_of_factory(self) -> None:
+        nr = NumericRange.of(0.0, 100.0)
+        assert nr.min == 0.0
+        assert nr.max == 100.0
+
+    def test_contains_inclusive_bounds(self) -> None:
+        # Mirrors Java NumericRange.contains (Java lines 39-41): inclusive.
+        nr = NumericRange.of(1.0, 5.0)
+        assert nr.contains(1.0)
+        assert nr.contains(5.0)
+        assert nr.contains(3.0)
+
+    def test_contains_outside(self) -> None:
+        nr = NumericRange.of(1.0, 5.0)
+        assert not nr.contains(0.9)
+        assert not nr.contains(5.1)
+
+    def test_invalid_max_lt_min(self) -> None:
+        # Mirrors Java IllegalArgumentException (Java lines 23-26).
+        with pytest.raises(ValueError, match="max .* must be >= min"):
+            NumericRange.of(10.0, 5.0)
+
+    def test_equal_min_max_valid(self) -> None:
+        nr = NumericRange.of(3.0, 3.0)
+        assert nr.contains(3.0)
+        assert not nr.contains(3.1)
+
+
+# ---------------------------------------------------------------------------
+# FieldViolation
+# ---------------------------------------------------------------------------
+
+class TestFieldViolation:
+    def test_construction(self) -> None:
+        fv = FieldViolation(
+            field_name="amount",
+            violation_kind=ViolationKind.OUT_OF_RANGE,
+            detail="value 999 outside [0, 100]",
+        )
+        assert fv.field_name == "amount"
+        assert fv.violation_kind is ViolationKind.OUT_OF_RANGE
+        assert fv.detail == "value 999 outside [0, 100]"
+
+    def test_frozen(self) -> None:
+        fv = FieldViolation("x", ViolationKind.MISSING_REQUIRED, "msg")
+        with pytest.raises((AttributeError, TypeError)):
+            fv.field_name = "y"  # type: ignore[misc]
+
+    def test_none_field_name_raises(self) -> None:
+        with pytest.raises((ValueError, TypeError)):
+            FieldViolation(None, ViolationKind.MISSING_REQUIRED, "msg")  # type: ignore[arg-type]
+
+    def test_none_violation_kind_raises(self) -> None:
+        with pytest.raises((ValueError, TypeError)):
+            FieldViolation("f", None, "msg")  # type: ignore[arg-type]
+
+    def test_none_detail_raises(self) -> None:
+        with pytest.raises((ValueError, TypeError)):
+            FieldViolation("f", ViolationKind.TYPE_MISMATCH, None)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# ValidationResult — ValidRow / InvalidRow
+# ---------------------------------------------------------------------------
+
+class TestValidationResult:
+    def test_valid_row_is_valid(self) -> None:
+        vr: ValidationResult[Row] = ValidRow(row={"id": "1"})
+        assert vr.is_valid()
+
+    def test_invalid_row_not_valid(self) -> None:
+        fv = FieldViolation("id", ViolationKind.MISSING_REQUIRED, "required")
+        ir: ValidationResult[Row] = InvalidRow.of(row={"id": None}, violations=[fv])
+        assert not ir.is_valid()
+
+    def test_invalid_row_violations_immutable_tuple(self) -> None:
+        fv = FieldViolation("id", ViolationKind.MISSING_REQUIRED, "required")
+        ir = InvalidRow.of(row={"id": None}, violations=[fv])
+        assert isinstance(ir.violations, tuple)
+        assert len(ir.violations) == 1
+
+    def test_invalid_row_empty_violations_raises(self) -> None:
+        # Mirrors Java guard (Java lines 69-72).
+        with pytest.raises((ValueError, TypeError)):
+            InvalidRow(row={"id": "x"}, violations=())
+
+    def test_valid_row_none_row_raises(self) -> None:
+        with pytest.raises((ValueError, TypeError)):
+            ValidRow(row=None)
+
+    def test_invalid_row_none_violations_raises(self) -> None:
+        with pytest.raises((ValueError, TypeError)):
+            InvalidRow(row={"id": "x"}, violations=None)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# DataQualityTransform — validate()
+# ---------------------------------------------------------------------------
+
+class TestDataQualityTransformValidate:
+
+    def _dq(self, *fields: SchemaField) -> DataQualityTransform[Row]:
+        return DataQualityTransform(
+            schema=_make_schema(*fields),
+            row_accessor=_accessor,
+        )
+
+    # --- MISSING_REQUIRED ---
+
+    def test_missing_required_produces_violation(self) -> None:
+        dq = self._dq(SchemaField("id", "STRING", mode="REQUIRED"))
+        result = dq.validate({"id": None})
+        assert not result.is_valid()
+        assert isinstance(result, InvalidRow)
+        assert result.violations[0].violation_kind is ViolationKind.MISSING_REQUIRED
+
+    def test_missing_required_absent_key(self) -> None:
+        dq = self._dq(SchemaField("id", "STRING", mode="REQUIRED"))
+        result = dq.validate({})  # key absent
+        assert not result.is_valid()
+        assert result.violations[0].violation_kind is ViolationKind.MISSING_REQUIRED
+
+    def test_nullable_none_passes(self) -> None:
+        dq = self._dq(SchemaField("note", "STRING", mode="NULLABLE"))
+        result = dq.validate({"note": None})
+        assert result.is_valid()
+
+    # --- TYPE_MISMATCH ---
+
+    def test_type_mismatch_string_field_gets_int(self) -> None:
+        dq = self._dq(SchemaField("name", "STRING", mode="REQUIRED"))
+        result = dq.validate({"name": 42})
+        assert not result.is_valid()
+        assert isinstance(result, InvalidRow)
+        assert result.violations[0].violation_kind is ViolationKind.TYPE_MISMATCH
+
+    def test_type_mismatch_bool_field_gets_int(self) -> None:
+        # bool ≠ int in BOOL fields
+        dq = self._dq(SchemaField("active", "BOOL", mode="REQUIRED"))
+        result = dq.validate({"active": 1})  # int, not bool
+        assert not result.is_valid()
+        assert result.violations[0].violation_kind is ViolationKind.TYPE_MISMATCH
+
+    def test_bool_passes_bool_field(self) -> None:
+        dq = self._dq(SchemaField("active", "BOOL", mode="REQUIRED"))
+        assert dq.validate({"active": True}).is_valid()
+        assert dq.validate({"active": False}).is_valid()
+
+    def test_int64_with_int_passes(self) -> None:
+        # int is a numbers.Number and not bool → passes INT64
+        dq = self._dq(SchemaField("count", "INT64", mode="REQUIRED"))
+        assert dq.validate({"count": 42}).is_valid()
+
+    def test_int64_with_bool_is_type_mismatch(self) -> None:
+        # Python-specific: bool subclasses int but must not pass INT64
+        dq = self._dq(SchemaField("count", "INT64", mode="REQUIRED"))
+        result = dq.validate({"count": True})
+        assert not result.is_valid()
+        assert result.violations[0].violation_kind is ViolationKind.TYPE_MISMATCH
+
+    def test_float64_with_float_passes(self) -> None:
+        dq = self._dq(SchemaField("amount", "FLOAT64", mode="REQUIRED"))
+        assert dq.validate({"amount": 3.14}).is_valid()
+
+    def test_unknown_wire_type_passes_any_value(self) -> None:
+        # Mirrors Java: unknown wire types have no expected class → no check.
+        dq = self._dq(SchemaField("ts", "TIMESTAMP", mode="REQUIRED"))
+        assert dq.validate({"ts": "2024-01-01T00:00:00Z"}).is_valid()
+
+    # --- OUT_OF_RANGE ---
+
+    def test_out_of_range_produces_violation(self) -> None:
+        dq = self._dq(
+            SchemaField("amount", "FLOAT64", mode="REQUIRED",
+                        range=NumericRange.of(0.0, 100.0))
+        )
+        result = dq.validate({"amount": 200.0})
+        assert not result.is_valid()
+        assert isinstance(result, InvalidRow)
+        assert result.violations[0].violation_kind is ViolationKind.OUT_OF_RANGE
+
+    def test_in_range_passes(self) -> None:
+        dq = self._dq(
+            SchemaField("amount", "FLOAT64", mode="REQUIRED",
+                        range=NumericRange.of(0.0, 100.0))
+        )
+        assert dq.validate({"amount": 50.0}).is_valid()
+        assert dq.validate({"amount": 0.0}).is_valid()   # inclusive min
+        assert dq.validate({"amount": 100.0}).is_valid() # inclusive max
+
+    def test_range_check_skipped_on_type_mismatch(self) -> None:
+        # Mirrors Java lines 222-223: range skipped when typeMismatch=true
+        dq = self._dq(
+            SchemaField("amount", "FLOAT64", mode="REQUIRED",
+                        range=NumericRange.of(0.0, 100.0))
+        )
+        result = dq.validate({"amount": "not-a-number"})
+        assert not result.is_valid()
+        assert isinstance(result, InvalidRow)
+        # Only TYPE_MISMATCH — not OUT_OF_RANGE.
+        kinds = [v.violation_kind for v in result.violations]
+        assert ViolationKind.TYPE_MISMATCH in kinds
+        assert ViolationKind.OUT_OF_RANGE not in kinds
+
+    def test_range_check_skipped_for_bool_value(self) -> None:
+        # bool values that sneak through: no range check (not a numeric type for us).
+        dq = self._dq(
+            SchemaField("amount", "FLOAT64", mode="REQUIRED",
+                        range=NumericRange.of(0.0, 100.0))
+        )
+        result = dq.validate({"amount": True})
+        assert not result.is_valid()
+        kinds = [v.violation_kind for v in result.violations]
+        assert ViolationKind.TYPE_MISMATCH in kinds
+        assert ViolationKind.OUT_OF_RANGE not in kinds
+
+    # --- All violations accumulated ---
+
+    def test_multiple_fields_multiple_violations(self) -> None:
+        # Mirrors Java: all violations accumulated, no short-circuit (Java lines 48-50).
+        dq = self._dq(
+            SchemaField("id",     "STRING",  mode="REQUIRED"),
+            SchemaField("amount", "FLOAT64", mode="REQUIRED"),
+        )
+        result = dq.validate({"id": None, "amount": None})
+        assert not result.is_valid()
+        assert isinstance(result, InvalidRow)
+        assert len(result.violations) == 2
+
+    def test_valid_row_no_violations(self) -> None:
+        dq = self._dq(
+            SchemaField("id",     "STRING",  mode="REQUIRED"),
+            SchemaField("amount", "FLOAT64", mode="REQUIRED",
+                        range=NumericRange.of(0.0, 100.0)),
+            SchemaField("note",   "STRING"),
+        )
+        result = dq.validate({"id": "x1", "amount": 42.5, "note": None})
+        assert result.is_valid()
+
+    # --- None row ---
+
+    def test_none_row_raises(self) -> None:
+        dq = self._dq(SchemaField("id", "STRING"))
+        with pytest.raises((ValueError, TypeError)):
+            dq.validate(None)  # type: ignore[arg-type]
+
+    # --- Constructor guards ---
+
+    def test_none_schema_raises(self) -> None:
+        with pytest.raises((ValueError, TypeError)):
+            DataQualityTransform(schema=None, row_accessor=_accessor)  # type: ignore[arg-type]
+
+    def test_none_row_accessor_raises(self) -> None:
+        with pytest.raises((ValueError, TypeError)):
+            DataQualityTransform(
+                schema=_make_schema(SchemaField("id", "STRING")),
+                row_accessor=None,  # type: ignore[arg-type]
+            )
+
+
+# ---------------------------------------------------------------------------
+# DataQualityTransform — apply() / generator / metrics
+# ---------------------------------------------------------------------------
+
+class TestDataQualityTransformApply:
+
+    def _dq(self) -> DataQualityTransform[Row]:
+        return DataQualityTransform(
+            schema=_make_schema(
+                SchemaField("id",   "STRING",  mode="REQUIRED"),
+                SchemaField("val",  "FLOAT64", mode="REQUIRED",
+                            range=NumericRange.of(0.0, 100.0)),
+            ),
+            row_accessor=_accessor,
+        )
+
+    def test_apply_yields_results(self) -> None:
+        dq = self._dq()
+        ctx = _make_context()
+        rows: List[Row] = [
+            {"id": "a", "val": 50.0},
+            {"id": None, "val": 200.0},
+        ]
+        results = list(dq.apply(iter(rows), ctx))
+        assert len(results) == 2
+        assert results[0].is_valid()
+        assert not results[1].is_valid()
+
+    def test_apply_emits_stage_metrics_once(self) -> None:
+        dq = self._dq()
+        ctx = _make_context()
+        rows: List[Row] = [
+            {"id": "a", "val": 10.0},
+            {"id": "b", "val": 999.0},  # OUT_OF_RANGE → error
+        ]
+        list(dq.apply(iter(rows), ctx))
+        ctx.stage_metrics.record_stage_metrics.assert_called_once()
+        call_args = ctx.stage_metrics.record_stage_metrics.call_args[0][0]
+        assert call_args.rows_processed == 2
+        assert call_args.error_count == 1
+        assert call_args.stage_name == "DataQualityTransform"
+        assert call_args.pipeline_id == "pipe"
+        assert call_args.run_id == "run-1"
+
+    def test_apply_empty_input_emits_zero_metrics(self) -> None:
+        dq = self._dq()
+        ctx = _make_context()
+        list(dq.apply(iter([]), ctx))
+        ctx.stage_metrics.record_stage_metrics.assert_called_once()
+        call_args = ctx.stage_metrics.record_stage_metrics.call_args[0][0]
+        assert call_args.rows_processed == 0
+        assert call_args.error_count == 0
+        assert call_args.stage_latency_ms == 0.0
+
+    def test_apply_metrics_swallowed_on_exception(self) -> None:
+        """Metrics-emission exceptions must not surface to caller."""
+        dq = self._dq()
+        ctx = _make_context()
+        ctx.stage_metrics.record_stage_metrics.side_effect = RuntimeError("boom")
+        rows: List[Row] = [{"id": "x", "val": 1.0}]
+        # Should not raise despite metrics error.
+        results = list(dq.apply(iter(rows), ctx))
+        assert len(results) == 1
+
+    def test_apply_lazy_generator(self) -> None:
+        """apply() returns an iterator, not a materialised list."""
+        dq = self._dq()
+        ctx = _make_context()
+        gen = dq.apply(iter([{"id": "a", "val": 5.0}]), ctx)
+        # Must be an iterator, not a list.
+        assert hasattr(gen, "__iter__")
+        assert hasattr(gen, "__next__")
+
+    def test_apply_none_records_raises(self) -> None:
+        dq = self._dq()
+        ctx = _make_context()
+        with pytest.raises((ValueError, TypeError)):
+            dq.apply(None, ctx)  # type: ignore[arg-type]
+
+    def test_apply_none_context_raises(self) -> None:
+        dq = self._dq()
+        with pytest.raises((ValueError, TypeError)):
+            dq.apply(iter([]), None)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# GovernancePolicy masking — API parity flag
+# ---------------------------------------------------------------------------
+
+class TestMaskingApiParityFlag:
+    def test_masking_raises_not_implemented(self) -> None:
+        """governance_policy accepted but masking raises NotImplementedError (T18.2 flag)."""
+        mock_policy = MagicMock()
+        mock_policy.masking_for.return_value = MagicMock()  # non-None → triggers flag
+
+        dq: DataQualityTransform[Row] = DataQualityTransform(
+            schema=_make_schema(SchemaField("name", "STRING", mode="REQUIRED")),
+            row_accessor=_accessor,
+            governance_policy=mock_policy,
+        )
+        with pytest.raises(NotImplementedError, match="Masker"):
+            dq.validate({"name": "Alice"})
+
+    def test_no_masking_policy_no_error(self) -> None:
+        dq: DataQualityTransform[Row] = DataQualityTransform(
+            schema=_make_schema(SchemaField("name", "STRING", mode="REQUIRED")),
+            row_accessor=_accessor,
+        )
+        result = dq.validate({"name": "Alice"})
+        assert result.is_valid()

--- a/data-pipeline-libraries/data-pipeline-core/tests/test_governance_concretes.py
+++ b/data-pipeline-libraries/data-pipeline-core/tests/test_governance_concretes.py
@@ -1,0 +1,306 @@
+"""Tests for the governance_api concretes: Masker (mask()) + PiiMaskingGovernancePolicy.
+
+Mirrors behavioural coverage from Java:
+  - Masker.java (Sprint 14 / T14.4)
+  - PiiMaskingGovernancePolicy.java (Sprint 14 / T14.4 / issue #76)
+
+DoD requirement (T18.3): all new tests must pass within the full suite run.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from data_pipeline_core.contracts.governance import GovernancePolicy
+from data_pipeline_core.governance_api.classification import DataClassification
+from data_pipeline_core.governance_api.masker import _DEFAULT_SALT, mask
+from data_pipeline_core.governance_api.pii_masking_governance_policy import (
+    PiiMaskingGovernancePolicy,
+)
+from data_pipeline_core.governance_api.policies import MaskingPolicy, MaskingStrategy
+
+
+# ===========================================================================
+# Masker (mask()) — mirrors Masker.java strategy helpers
+# ===========================================================================
+
+class TestMaskNone:
+    """NONE strategy passes value through unchanged (Masker.java:59)."""
+
+    def test_none_strategy_string(self) -> None:
+        p = MaskingPolicy(strategy=MaskingStrategy.NONE)
+        assert mask("hello", p) == "hello"
+
+    def test_none_strategy_int(self) -> None:
+        p = MaskingPolicy(strategy=MaskingStrategy.NONE)
+        assert mask(42, p) == 42
+
+    def test_null_passthrough(self) -> None:
+        """None value is returned unchanged regardless of strategy."""
+        p = MaskingPolicy(strategy=MaskingStrategy.FULL)
+        assert mask(None, p) is None
+
+    def test_policy_none_raises(self) -> None:
+        with pytest.raises(TypeError):
+            mask("x", None)  # type: ignore[arg-type]
+
+
+class TestMaskFull:
+    """FULL strategy replaces value with policy.replacement (Masker.java:60)."""
+
+    def test_default_replacement(self) -> None:
+        p = MaskingPolicy(strategy=MaskingStrategy.FULL)
+        assert mask("secret", p) == "*"
+
+    def test_custom_replacement(self) -> None:
+        p = MaskingPolicy(strategy=MaskingStrategy.FULL, replacement="***")
+        assert mask("secret", p) == "***"
+
+    def test_non_string_value(self) -> None:
+        """FULL replaces the *replacement* string, not the original type."""
+        p = MaskingPolicy(strategy=MaskingStrategy.FULL, replacement="REDACTED")
+        assert mask(12345, p) == "REDACTED"
+
+
+class TestMaskRedacted:
+    """REDACTED behaves identically to FULL (Masker.java:60)."""
+
+    def test_redacted_equals_full(self) -> None:
+        p_full = MaskingPolicy(strategy=MaskingStrategy.FULL, replacement="***")
+        p_red = MaskingPolicy(strategy=MaskingStrategy.REDACTED, replacement="***")
+        assert mask("value", p_full) == mask("value", p_red)
+
+
+class TestMaskPartial:
+    """PARTIAL keeps last 4 characters (Masker.java:74-81)."""
+
+    def test_long_string_keeps_last_4(self) -> None:
+        p = MaskingPolicy(strategy=MaskingStrategy.PARTIAL)
+        result = mask("4111111111111234", p)
+        assert result == "************1234"
+
+    def test_exactly_4_chars_all_replaced(self) -> None:
+        p = MaskingPolicy(strategy=MaskingStrategy.PARTIAL)
+        assert mask("1234", p) == "****"
+
+    def test_fewer_than_4_chars_all_replaced(self) -> None:
+        p = MaskingPolicy(strategy=MaskingStrategy.PARTIAL)
+        assert mask("ab", p) == "**"
+
+    def test_custom_replacement_char(self) -> None:
+        p = MaskingPolicy(strategy=MaskingStrategy.PARTIAL, replacement="X")
+        result = mask("abcde12345", p)
+        # last 4 = "2345", rest = "XXXXXX"
+        assert result == "XXXXXX2345"
+
+    def test_empty_replacement_defaults_to_star(self) -> None:
+        """Empty replacement → '*' (mirrors Masker.java:75: replChar = '*')."""
+        p = MaskingPolicy(strategy=MaskingStrategy.PARTIAL, replacement="")
+        result = mask("abcde", p)
+        # "abcde" is 5 chars; last 4 kept → "bcde"; first char masked → "*bcde"
+        assert result == "*bcde"
+
+    def test_non_string_converted_via_str(self) -> None:
+        p = MaskingPolicy(strategy=MaskingStrategy.PARTIAL)
+        # int 123456 → str "123456" → last 4 kept
+        result = mask(123456, p)
+        assert result == "**3456"
+
+
+class TestMaskHash:
+    """HASH produces deterministic SHA-256 (Masker.java:87-101)."""
+
+    def test_hash_deterministic(self) -> None:
+        p = MaskingPolicy(strategy=MaskingStrategy.HASH, salt="mysalt")
+        assert mask("alice@example.com", p) == mask("alice@example.com", p)
+
+    def test_hash_default_salt(self) -> None:
+        """Empty salt uses DEFAULT_SALT = 'culvert-pii-salt' (Masker.java:41)."""
+        p = MaskingPolicy(strategy=MaskingStrategy.HASH, salt="")
+        value = "test-value"
+        expected = hashlib.sha256(
+            (_DEFAULT_SALT + value).encode("utf-8")
+        ).hexdigest()
+        assert mask(value, p) == expected
+
+    def test_hash_custom_salt(self) -> None:
+        p = MaskingPolicy(strategy=MaskingStrategy.HASH, salt="abc")
+        value = "test"
+        expected = hashlib.sha256(("abc" + value).encode("utf-8")).hexdigest()
+        assert mask(value, p) == expected
+
+    def test_different_values_produce_different_hashes(self) -> None:
+        p = MaskingPolicy(strategy=MaskingStrategy.HASH, salt="s")
+        assert mask("alice", p) != mask("bob", p)
+
+    def test_different_salts_produce_different_hashes(self) -> None:
+        p1 = MaskingPolicy(strategy=MaskingStrategy.HASH, salt="s1")
+        p2 = MaskingPolicy(strategy=MaskingStrategy.HASH, salt="s2")
+        assert mask("same-value", p1) != mask("same-value", p2)
+
+
+# ===========================================================================
+# PiiMaskingGovernancePolicy
+# ===========================================================================
+
+@pytest.fixture
+def default_policy() -> MaskingPolicy:
+    return MaskingPolicy(strategy=MaskingStrategy.FULL, replacement="***")
+
+
+@pytest.fixture
+def pii_policy(default_policy: MaskingPolicy) -> PiiMaskingGovernancePolicy:
+    return PiiMaskingGovernancePolicy(
+        pii_columns={"email", "ssn", "phone"},
+        pii_patterns=[".*_pii$", ".*_secret$"],
+        default_masking_policy=default_policy,
+    )
+
+
+class TestPiiMaskingGovernancePolicyConstruction:
+    def test_requires_default_masking_policy(self) -> None:
+        with pytest.raises(ValueError, match="default_masking_policy"):
+            PiiMaskingGovernancePolicy(
+                pii_columns={"email"},
+                default_masking_policy=None,  # type: ignore[arg-type]
+            )
+
+    def test_empty_columns_and_patterns_valid(self, default_policy: MaskingPolicy) -> None:
+        p = PiiMaskingGovernancePolicy(default_masking_policy=default_policy)
+        assert p.classify("any_field", "any_table") is DataClassification.INTERNAL
+
+    def test_invalid_regex_raises(self, default_policy: MaskingPolicy) -> None:
+        import re
+        with pytest.raises(re.error):
+            PiiMaskingGovernancePolicy(
+                pii_patterns=["[invalid"],
+                default_masking_policy=default_policy,
+            )
+
+
+class TestPiiMaskingGovernancePolicyClassify:
+    """classify() mirrors PiiMaskingGovernancePolicy.java:137-139."""
+
+    def test_exact_column_classified_restricted(self, pii_policy: PiiMaskingGovernancePolicy) -> None:
+        assert pii_policy.classify("email", "users") is DataClassification.RESTRICTED
+
+    def test_pattern_column_classified_restricted(self, pii_policy: PiiMaskingGovernancePolicy) -> None:
+        assert pii_policy.classify("national_id_pii", "users") is DataClassification.RESTRICTED
+
+    def test_non_pii_classified_internal(self, pii_policy: PiiMaskingGovernancePolicy) -> None:
+        assert pii_policy.classify("first_name", "users") is DataClassification.INTERNAL
+
+    def test_case_sensitive_match(self, pii_policy: PiiMaskingGovernancePolicy) -> None:
+        """Column matching is case-sensitive (mirrors Java Set.contains)."""
+        assert pii_policy.classify("Email", "users") is DataClassification.INTERNAL
+
+    def test_table_arg_ignored_for_structural_match(self, pii_policy: PiiMaskingGovernancePolicy) -> None:
+        """table is accepted but not used — both calls return the same result."""
+        assert pii_policy.classify("email", "table_a") == pii_policy.classify("email", "table_b")
+
+
+class TestPiiMaskingGovernancePolicyMaskingFor:
+    """masking_for() mirrors PiiMaskingGovernancePolicy.java:152-157."""
+
+    def test_pii_column_returns_default_policy(
+        self, pii_policy: PiiMaskingGovernancePolicy, default_policy: MaskingPolicy
+    ) -> None:
+        result = pii_policy.masking_for("email", "users")
+        assert result == default_policy
+
+    def test_non_pii_returns_none(self, pii_policy: PiiMaskingGovernancePolicy) -> None:
+        assert pii_policy.masking_for("first_name", "users") is None
+
+    def test_column_override_applied(self, default_policy: MaskingPolicy) -> None:
+        """Per-column override takes precedence (PiiMaskingGovernancePolicy.java:155-156)."""
+        phone_policy = MaskingPolicy(strategy=MaskingStrategy.PARTIAL, replacement="*")
+        p = PiiMaskingGovernancePolicy(
+            pii_columns={"email", "phone"},
+            default_masking_policy=default_policy,
+            column_overrides={"phone": phone_policy},
+        )
+        assert p.masking_for("phone", "users") == phone_policy
+        assert p.masking_for("email", "users") == default_policy
+
+    def test_override_key_not_in_column_set_does_not_match(self, default_policy: MaskingPolicy) -> None:
+        """Override map entry alone does not make a field match (Java doc, line ~43)."""
+        override_only_policy = MaskingPolicy(strategy=MaskingStrategy.PARTIAL)
+        p = PiiMaskingGovernancePolicy(
+            pii_columns={"email"},
+            default_masking_policy=default_policy,
+            column_overrides={"address": override_only_policy},  # not in pii_columns
+        )
+        # "address" is NOT matched — override key alone doesn't qualify the field
+        assert p.masking_for("address", "users") is None
+
+    def test_pattern_matched_field_returns_default_policy(
+        self, pii_policy: PiiMaskingGovernancePolicy, default_policy: MaskingPolicy
+    ) -> None:
+        result = pii_policy.masking_for("credit_card_secret", "payments")
+        assert result == default_policy
+
+
+class TestPiiMaskingGovernancePolicyRetentionFor:
+    """retention_for() always returns None (PiiMaskingGovernancePolicy.java:163-165)."""
+
+    def test_retention_for_always_none(self, pii_policy: PiiMaskingGovernancePolicy) -> None:
+        assert pii_policy.retention_for("users") is None
+        assert pii_policy.retention_for("payments") is None
+
+
+class TestPiiMaskingGovernancePolicyRegex:
+    """Regex matching uses re.fullmatch (mirrors Java Matcher.matches — anchored)."""
+
+    def test_pattern_full_match_required(self, default_policy: MaskingPolicy) -> None:
+        """'_pii' suffix pattern must match the full field name."""
+        p = PiiMaskingGovernancePolicy(
+            pii_patterns=[".*_pii$"],
+            default_masking_policy=default_policy,
+        )
+        assert p.classify("name_pii", "t") is DataClassification.RESTRICTED
+        # Partial match — pattern ".*_pii$" would match "name_pii_extra" only
+        # if fullmatch anchors; without anchoring "re.match" would pass partial
+        # We test a field that should NOT match fully.
+        assert p.classify("name_pii_extra_suffix", "t") is DataClassification.INTERNAL
+
+    def test_pattern_secret_suffix(self, default_policy: MaskingPolicy) -> None:
+        p = PiiMaskingGovernancePolicy(
+            pii_patterns=[".*_secret$"],
+            default_masking_policy=default_policy,
+        )
+        assert p.classify("api_secret", "t") is DataClassification.RESTRICTED
+        assert p.classify("api_secret_key", "t") is DataClassification.INTERNAL
+
+
+class TestPiiMaskingGovernancePolicyProtocol:
+    """PiiMaskingGovernancePolicy satisfies GovernancePolicy structurally."""
+
+    def test_isinstance_governance_policy(self, pii_policy: PiiMaskingGovernancePolicy) -> None:
+        """runtime_checkable Protocol: isinstance must pass (mirrors Java implements GovernancePolicy)."""
+        assert isinstance(pii_policy, GovernancePolicy)
+
+
+class TestPiiMaskingGovernancePolicyAccessors:
+    def test_pii_columns_accessor(self, pii_policy: PiiMaskingGovernancePolicy) -> None:
+        assert "email" in pii_policy.pii_columns
+        assert "ssn" in pii_policy.pii_columns
+
+    def test_default_masking_policy_accessor(
+        self, pii_policy: PiiMaskingGovernancePolicy, default_policy: MaskingPolicy
+    ) -> None:
+        assert pii_policy.default_masking_policy == default_policy
+
+    def test_column_overrides_returns_copy(self, default_policy: MaskingPolicy) -> None:
+        override = MaskingPolicy(strategy=MaskingStrategy.PARTIAL)
+        p = PiiMaskingGovernancePolicy(
+            pii_columns={"phone"},
+            default_masking_policy=default_policy,
+            column_overrides={"phone": override},
+        )
+        overrides = p.column_overrides
+        assert overrides["phone"] == override
+        # Mutating the returned dict must not affect the policy's internal state
+        overrides["phone"] = default_policy
+        assert p.column_overrides["phone"] == override

--- a/data-pipeline-libraries/data-pipeline-core/tests/test_runtime.py
+++ b/data-pipeline-libraries/data-pipeline-core/tests/test_runtime.py
@@ -1,0 +1,386 @@
+"""Tests for RuntimeContextImpl — the concrete RuntimeContext.
+
+Mandatory assertions (T18.1 DoD):
+1. ``isinstance(ctx, RuntimeContext) is True`` on a fully-populated instance.
+2. Negative-control: a stub missing exactly one required member does NOT pass.
+3. ``get`` / ``register`` round-trip.
+4. ``pipeline_id`` defaults to ``run_id``.
+5. Pickle round-trip: preserves the three identity/config fields; ``_registry``
+   is empty after deserialization (serialization boundary T10.6).
+
+Sprint-18 / T18.1 / issue #117.
+"""
+
+from __future__ import annotations
+
+import pickle
+from typing import Any, Mapping, Optional
+
+import pytest
+
+from data_pipeline_core.contracts.runtime import RuntimeContext
+from data_pipeline_core.contracts.secrets import SecretProvider
+from data_pipeline_core.contracts.observability import ObservabilityHook
+from data_pipeline_core.contracts.stage_metrics import StageMetricsHook
+from data_pipeline_core.contracts.lineage import LineageEmitter
+from data_pipeline_core.contracts.finops import FinOpsSink
+from data_pipeline_core.contracts.governance import GovernancePolicy
+from data_pipeline_core.runtime import DefaultRuntimeContext, RuntimeContextImpl
+
+
+# ---------------------------------------------------------------------------
+# Minimal fakes — used to populate the hard-dependency (secrets) slot.
+# Structural implementations: no Protocol inheritance needed.
+# ---------------------------------------------------------------------------
+
+
+class _FakeSecretProvider:
+    """Structural SecretProvider (secrets.py:19-31)."""
+
+    def __init__(self) -> None:
+        self._store = {"db-password": "hunter2"}
+
+    def get(self, name: str, version: str = "latest") -> str:
+        return self._store[name]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_ctx(**kwargs: Any) -> RuntimeContextImpl:
+    """Convenience factory: fully-populated context with a fake SecretProvider."""
+    ctx = RuntimeContextImpl(
+        run_id=kwargs.get("run_id", "run-test-001"),
+        environment=kwargs.get("environment", "test"),
+        config=kwargs.get("config", {"timeout": 30}),
+    )
+    # Register the hard-dependency so isinstance works and so advisory
+    # hook properties don't blow up during structural checks.
+    ctx.register(SecretProvider, _FakeSecretProvider())
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# 1. Mandatory: isinstance(ctx, RuntimeContext) is True
+# ---------------------------------------------------------------------------
+
+
+def test_isinstance_fully_populated() -> None:
+    """Fully-populated instance satisfies RuntimeContext Protocol.
+
+    This is the mandatory T18.1 guard.  On Python 3.12+ ``@runtime_checkable``
+    checks all DATA MEMBERS — a missing required attribute makes this False.
+
+    RuntimeContext members (contracts/runtime.py:53-65):
+        run_id, environment, config,
+        secrets, observability, stage_metrics, lineage, finops, governance
+    """
+    ctx = _make_ctx()
+    # Access all six hook properties so they are installed into the instance.
+    # Advisory hooks install a no-op on first access (they become data members).
+    _ = ctx.observability
+    _ = ctx.stage_metrics
+    _ = ctx.lineage
+    _ = ctx.finops
+    _ = ctx.governance
+    # secrets is already registered via _make_ctx().
+
+    assert isinstance(ctx, RuntimeContext) is True, (
+        "RuntimeContextImpl must satisfy the RuntimeContext Protocol. "
+        "Check that all required data members are present as instance attributes."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Negative control — a missing member breaks isinstance
+# ---------------------------------------------------------------------------
+
+
+class _StubMissingSecrets:
+    """Mimics RuntimeContextImpl but omits ``secrets`` attribute.
+
+    On Python 3.12+ this should fail isinstance against RuntimeContext
+    because ``secrets`` is a declared data member on the Protocol.
+
+    Mirrors ``test_partial_blob_store_does_not_satisfy_protocol``
+    (test_runtime_checkable.py:193-205).
+    """
+
+    run_id = "run-x"
+    environment = "test"
+    config: Mapping[str, Any] = {}
+    observability = None
+    stage_metrics = None
+    lineage = None
+    finops = None
+    governance = None
+    # ``secrets`` intentionally omitted.
+
+    @property
+    def pipeline_id(self) -> str:
+        return self.run_id
+
+    def get(self, protocol: type) -> Any:
+        raise KeyError(protocol)
+
+    def register(self, protocol: type, impl: Any) -> None:
+        pass
+
+
+def test_negative_control_missing_secrets_member() -> None:
+    """A stub missing ``secrets`` must not satisfy RuntimeContext.
+
+    This is the version-independent guard: if ``@runtime_checkable`` on
+    this Python version does NOT enforce data-member presence, this test
+    fails and the isinstance check is toothless — that finding must be
+    flagged in the report.
+    """
+    stub = _StubMissingSecrets()
+    result = isinstance(stub, RuntimeContext)
+    # We assert False, but if this assertion itself fails on a version where
+    # runtime_checkable is weak, we detect and surface it via the message.
+    assert result is False, (
+        "TOOTHLESS GUARD: isinstance() accepted a stub missing 'secrets'. "
+        "Python runtime_checkable on this version does not enforce data "
+        "member presence. The mandatory isinstance test in "
+        "test_isinstance_fully_populated is NOT a reliable guard on this "
+        "Python version. FLAG this in the T18.1 report."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. get / register round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_register_and_get_round_trip() -> None:
+    """register() followed by get() returns the same object."""
+    ctx = RuntimeContextImpl("run-1", "prod")
+    provider = _FakeSecretProvider()
+    ctx.register(SecretProvider, provider)
+    assert ctx.get(SecretProvider) is provider
+
+
+def test_get_unregistered_raises_key_error() -> None:
+    """get() raises KeyError when no impl is registered for the protocol."""
+    ctx = RuntimeContextImpl("run-1", "prod")
+
+    class _SomeProtocol:
+        pass
+
+    with pytest.raises(KeyError):
+        ctx.get(_SomeProtocol)
+
+
+def test_register_last_write_wins() -> None:
+    """A second register() call overrides the first (last-write-wins).
+
+    Mirrors Java ``DefaultRuntimeContext.register`` at :305-309 and
+    Builder.register at :339-344.
+    """
+    ctx = RuntimeContextImpl("run-1", "test")
+    first = _FakeSecretProvider()
+    second = _FakeSecretProvider()
+    ctx.register(SecretProvider, first)
+    ctx.register(SecretProvider, second)
+    assert ctx.get(SecretProvider) is second
+
+
+# ---------------------------------------------------------------------------
+# 4. pipeline_id default
+# ---------------------------------------------------------------------------
+
+
+def test_pipeline_id_defaults_to_run_id() -> None:
+    """pipeline_id defaults to run_id (contracts/runtime.py:81).
+
+    Mirrors Java ``RuntimeContext.pipelineId()`` default.
+    """
+    ctx = RuntimeContextImpl("run-abc", "staging")
+    assert ctx.pipeline_id == "run-abc"
+
+
+# ---------------------------------------------------------------------------
+# 5. Serialization boundary (T10.6)
+# ---------------------------------------------------------------------------
+
+
+def test_pickle_preserves_identity_and_config() -> None:
+    """Pickle round-trip preserves run_id, environment, and config.
+
+    The _registry is NOT serialized (transient by T10.6 design).
+    Mirrors Java ``transient volatile ConcurrentHashMap registry`` at :113
+    and the serialization contract at :55-80.
+    """
+    ctx = RuntimeContextImpl(
+        "run-99",
+        "prod",
+        {"key": "value", "nested": 42},
+    )
+    ctx.register(SecretProvider, _FakeSecretProvider())  # should not survive pickle
+
+    pickled = pickle.dumps(ctx)
+    restored: RuntimeContextImpl = pickle.loads(pickled)
+
+    assert restored.run_id == "run-99"
+    assert restored.environment == "prod"
+    assert restored.config["key"] == "value"
+    assert restored.config["nested"] == 42
+
+    # Registry must be empty after deserialization.
+    assert restored._registry == {}, (
+        "_registry must be empty after deserialization (T10.6 serialization boundary)."
+    )
+
+
+def test_pickle_registry_not_present_after_deserialization() -> None:
+    """get() raises KeyError on restored context (registry was not shipped)."""
+    ctx = RuntimeContextImpl("run-88", "prod")
+    ctx.register(SecretProvider, _FakeSecretProvider())
+
+    restored: RuntimeContextImpl = pickle.loads(pickle.dumps(ctx))
+
+    with pytest.raises(KeyError):
+        restored.get(SecretProvider)
+
+
+# ---------------------------------------------------------------------------
+# 6. Advisory hooks use no-op defaults
+# ---------------------------------------------------------------------------
+
+
+def test_observability_no_op_when_unregistered() -> None:
+    """observability returns a no-op (not None) when nothing is registered."""
+    ctx = RuntimeContextImpl("run-1", "test")
+    hook = ctx.observability
+    assert hook is not None
+    # No-op: these should not raise.
+    hook.counter("test.counter")
+    hook.gauge("test.gauge", 1.0)
+    hook.log("INFO", "hello")
+    with hook.span("test-span"):
+        pass
+
+
+def test_stage_metrics_no_op_when_unregistered() -> None:
+    """stage_metrics returns a no-op when nothing is registered (T12.4)."""
+    from data_pipeline_core.contracts.stage_metrics import StageMetrics
+
+    ctx = RuntimeContextImpl("run-1", "test")
+    hook = ctx.stage_metrics
+    assert hook is not None
+    hook.record_stage_metrics(StageMetrics("p", "r", "s", 0, 0.0, 0))
+
+
+def test_lineage_no_op_when_unregistered() -> None:
+    """lineage returns a no-op when nothing is registered."""
+    ctx = RuntimeContextImpl("run-1", "test")
+    emitter = ctx.lineage
+    assert emitter is not None
+    emitter.emit({})  # LineageEvent is a TypedDict (total=False)
+
+
+def test_finops_no_op_when_unregistered() -> None:
+    """finops returns a no-op when nothing is registered."""
+    from data_pipeline_core.finops_api.labels import FinOpsTag
+    from data_pipeline_core.finops_api.models import CostMetrics
+
+    ctx = RuntimeContextImpl("run-1", "test")
+    sink = ctx.finops
+    assert sink is not None
+    sink.record(
+        CostMetrics(run_id="run-1"),
+        FinOpsTag(
+            system="test",
+            environment="test",
+            cost_center="eng",
+            owner="test",
+            run_id="run-1",
+        ),
+    )
+
+
+def test_governance_no_op_classify_returns_internal() -> None:
+    """governance no-op classify() returns INTERNAL (governance.py:30-36)."""
+    from data_pipeline_core.governance_api.classification import DataClassification
+
+    ctx = RuntimeContextImpl("run-1", "test")
+    policy = ctx.governance
+    assert policy is not None
+    result = policy.classify("field_name", "table_name")
+    assert result is DataClassification.INTERNAL
+
+
+def test_governance_no_op_masking_returns_none() -> None:
+    """governance no-op masking_for() returns None (no policy)."""
+    ctx = RuntimeContextImpl("run-1", "test")
+    assert ctx.governance.masking_for("field_name", "table_name") is None
+
+
+def test_governance_no_op_retention_returns_none() -> None:
+    """governance no-op retention_for() returns None (no policy)."""
+    ctx = RuntimeContextImpl("run-1", "test")
+    assert ctx.governance.retention_for("table_name") is None
+
+
+# ---------------------------------------------------------------------------
+# 7. secrets raises when absent (hard dependency)
+# ---------------------------------------------------------------------------
+
+
+def test_secrets_raises_when_not_registered() -> None:
+    """Accessing secrets without registering raises RuntimeError.
+
+    Mirrors Java IllegalStateException for missing SecretProvider at
+    DefaultRuntimeContext.java:240-249.
+    """
+    ctx = RuntimeContextImpl("run-1", "prod")
+    with pytest.raises(RuntimeError, match="SecretProvider"):
+        _ = ctx.secrets
+
+
+def test_secrets_returns_registered_provider() -> None:
+    """Accessing secrets returns the registered provider."""
+    ctx = RuntimeContextImpl("run-1", "prod")
+    provider = _FakeSecretProvider()
+    ctx.register(SecretProvider, provider)
+    assert ctx.secrets is provider
+    assert ctx.secrets.get("db-password") == "hunter2"
+
+
+# ---------------------------------------------------------------------------
+# 8. Constructor validation
+# ---------------------------------------------------------------------------
+
+
+def test_blank_run_id_raises_value_error() -> None:
+    """Blank run_id raises ValueError (mirrors Java Builder :322-325)."""
+    with pytest.raises(ValueError, match="run_id"):
+        RuntimeContextImpl("", "prod")
+
+
+def test_blank_environment_raises_value_error() -> None:
+    """Blank environment raises ValueError (mirrors Java Builder :326-329)."""
+    with pytest.raises(ValueError, match="environment"):
+        RuntimeContextImpl("run-1", "")
+
+
+def test_config_is_immutable() -> None:
+    """config is read-only — mutation raises TypeError."""
+    ctx = RuntimeContextImpl("run-1", "prod", {"k": "v"})
+    with pytest.raises(TypeError):
+        ctx.config["k"] = "new_value"  # type: ignore[index]
+
+
+# ---------------------------------------------------------------------------
+# 9. DefaultRuntimeContext alias
+# ---------------------------------------------------------------------------
+
+
+def test_default_runtime_context_alias() -> None:
+    """DefaultRuntimeContext is an alias for RuntimeContextImpl."""
+    assert DefaultRuntimeContext is RuntimeContextImpl
+    ctx = DefaultRuntimeContext("run-alias", "test")
+    assert isinstance(ctx, RuntimeContextImpl)

--- a/docs/framework-evolution/13-python-parity-release.md
+++ b/docs/framework-evolution/13-python-parity-release.md
@@ -1,7 +1,8 @@
 # 13 — Python parity → coordinated polyglot release
 
-**Status:** scoped, not started. Successor to the 9–16 Java block (Sprints 11–16
-executed; Java reactor at `1.0.0` on `main`).
+**Status:** in progress. Wave A (S17, contract reconciliation) **merged to `main`**;
+Wave B (S18, core depth) **in PR #123**. Successor to the 9–16 Java block (Java
+reactor at `1.0.0` on `main`, frozen at tag `java-1.0.0`).
 
 **One-line:** Culvert is one polyglot, cloud-agnostic framework with GCP as its
 first implementation. Java is built to `1.0.0` but does **not** ship alone — the
@@ -18,7 +19,7 @@ shared seam; each runtime owns the layers it's best at.
 
 | Layer | Strategy | Why / repo evidence |
 |---|---|---|
-| **Contracts** | **Both** implement the same spec | `docs/CONTRACT.md` is language-neutral. Java: 17 interfaces in `data-pipeline-core-java`. Python: 15 Protocols already in `data-pipeline-core/contracts/`. |
+| **Contracts** | **Both** implement the same spec | `docs/CONTRACT.md` is language-neutral. Java: 16 contract interfaces + the `StageMetrics` record ("17 core contracts"). Python now matches after Wave A (`StageMetrics`/`StageMetricsHook` added). |
 | **dbt / transform** | **Reuse** (language-neutral) | It's SQL + macros, not "Java" or "Python". `data-pipeline-transform` is Python-packaged but the assets are dbt; there is deliberately **no** Java transform module. |
 | **Dataflow / execution** | **Java** (Beam) | `data-pipeline-gcp-dataflow-java` = `DataflowPipeline` + `StageTransform`. Legacy Python Beam is **not** being ported. |
 | **Orchestration** | **Reuse** — complementary, not duplicate | Python owns the runtime side (`operators/ sensors/ hooks/ routing/ factories/`); Java owns the cloud-neutral model + renderers (`DagSpec`/`TaskSpec`, `AirflowDagRenderer`/`ComposerDagRenderer`). |
@@ -46,13 +47,14 @@ Python parity (this epic)  ──┘                       └─►  legacy gcp
 - **Irreversible.** PyPI version numbers can't be reused; Maven Central is
   immutable. The publish itself stays a Joseph-gated manual trigger.
 
-## 3. Current state — Python vs Java 1.0.0 (content-verified 2026-06-14)
+## 3. Current state — Python vs Java 1.0.0 (baseline content-verified 2026-06-14)
 
 **Python already has more than a filename scan suggests.** Verified by grepping
-class definitions, not directory names.
+class definitions, not directory names. *This was the pre-Wave-A baseline; the
+gap table below is annotated with what Waves A/B since closed.*
 
 ### Present in Python today
-- **Contracts (15 of 17 Protocols)** in `data-pipeline-core/contracts/`:
+- **Contracts (all 17 since Wave A)** in `data-pipeline-core/contracts/`:
   BlobStore, AuditEventPublisher, LineageEmitter, PipelineStage, SecretProvider,
   GovernancePolicy, FinOpsSink, Warehouse, ObservabilityHook,
   JobControlRepository, RuntimeContext, Source, Pipeline, **Sink** (in
@@ -62,19 +64,19 @@ class definitions, not directory names.
 - **Adapters**: `data-pipeline-gcp-bigquery`, `-gcs`, `-pubsub`,
   `-orchestration` (runtime), `-transform` (dbt), `-tester`, `-contract-tests`.
 
-### Confirmed gaps vs Java 1.0.0
-| Gap | Kind | Note |
+### Gaps vs Java 1.0.0 (with Wave A/B status)
+| Gap | Kind | Status |
 |---|---|---|
-| `StageMetrics` / `StageMetricsHook` | **Contract** | The only genuine contract gap (added Java-side in S12). |
-| Contract drift on the 15 it has | **Reconcile** | Python Protocols predate the 9–16 Java evolution; verify each matches the final Java shape (esp. `RuntimeContext` T10.6 transient-registry semantics, `AuditEventPublisher`). |
-| `DefaultRuntimeContext` | **Core depth** | Absent in Python. The wiring kernel (S9). |
-| `dataquality` package | **Core depth** | `DataQualityTransform`, `ValidationResult`, quarantine — absent. |
-| Concrete governance policies | **Core depth** | `PiiMaskingGovernancePolicy`, `BudgetGovernancePolicy` — Python has `governance_api` models, not the policies. |
-| FinOps cost model + trackers | **Core/adapter depth** | `CostMetrics`/`FinOpsTag` + per-service `*CostTracker` (bigquery/gcs/pubsub) — absent. |
-| `gcp-secrets` Python package | **Adapter** | No Python `SecretManagerProvider` (Protocol exists, adapter doesn't). |
-| `gcp-observability` Python package | **Adapter** | No Python CloudTrace/DataCatalog/CloudMonitoring impls. |
-| `culvert`-named distribution | **Packaging** | Nothing ships as `culvert` yet; PyPI name is free. |
-| Python publish-from-git | **CI/release** | Actions PyPI job + trusted publishing not set up. |
+| `StageMetrics` / `StageMetricsHook` | **Contract** | ✅ **DONE** — Wave A (T17.1, #113). |
+| Contract drift on the 15 it has | **Reconcile** | ✅ **DONE** — Wave A (T17.2, #114): `BlobStore.open()` split, `RuntimeContext.pipeline_id`, T10.6 docstrings. |
+| `DefaultRuntimeContext` | **Core depth** | ✅ **DONE** — Wave B (T18.1, #117). Caveat: worker-side registry rebuild deferred (#122). |
+| `dataquality` package | **Core depth** | ✅ **DONE** — Wave B (T18.2, #118). Masker wire deferred (#121). |
+| Concrete governance policies | **Core depth** | ✅ **DONE** — Wave B: `PiiMaskingGovernancePolicy` (T18.3, #119), `BudgetGovernancePolicy` (T18.4, #120). |
+| FinOps cost model | **Core depth** | ✅ **DONE** — Wave B (T18.4): `BudgetViolationMode`/`BudgetExceededException`; `CostMetrics`/`FinOpsTag` reconciled. Per-service `*CostTracker` still open → **Wave C**. |
+| `gcp-secrets` Python package | **Adapter** | ⏳ **Wave C** — no Python `SecretManagerProvider` (Protocol exists, adapter doesn't). |
+| `gcp-observability` Python package | **Adapter** | ⏳ **Wave C** — no Python CloudTrace/DataCatalog/CloudMonitoring impls. |
+| `culvert`-named distribution | **Packaging** | ⏳ **Wave D** — nothing ships as `culvert` yet; PyPI name is free. |
+| Python publish-from-git | **CI/release** | ⏳ **Wave D** — Actions PyPI job + trusted publishing not set up. |
 
 ## 4. Epic scope — ticket groups
 


### PR DESCRIPTION
Sprint-18 integration → main (Joseph's merge trigger). Part of epic #112. Java frozen at `java-1.0.0`.

### Landed (4 parallel agents, disjoint ownership, all under the new dev-agent DoD)
- **T18.1 (#117)** — `DefaultRuntimeContext` concrete impl (`runtime.py`). Satisfies the Protocol incl. all six required hook attrs; T10.6 `__getstate__`/`__setstate__` ships only run_id/environment/config; no-op hook defaults. **Includes the mandated `isinstance(ctx, RuntimeContext)` test + a negative control.**
- **T18.2 (#118)** — `dataquality/` package (ValidationResult, DataQualityTransform, ViolationKind, NumericRange, FieldViolation). `bool` correctly excluded from INT64/FLOAT64 to match Java.
- **T18.3 (#119)** — governance: reconciled supporting types (enums **1:1 with Java**, no existing-file drift — verified) + `PiiMaskingGovernancePolicy` + `Masker`.
- **T18.4 (#120)** — finops: reconciled `CostMetrics`/`FinOpsTag` + `BudgetGovernancePolicy`/`BudgetViolationMode`/`BudgetExceededException`. Budget semantics verified (BLOCK raises, at-ceiling passes, WARN logs); `BudgetViolationMode` members `{BLOCK, WARN}` 1:1 with Java.

### Verification (independent, per DoD)
Full combined core suite: **172 passed, 0 failed** — reproduced from scratch, not per-agent counts. Advisor's two discriminators (governance enum 1:1; budget members + semantics) checked directly against `java-1.0.0`. Clean merges (disjoint ownership).

### Tracked follow-ups (not blocking)
- **#121 (T18.5)** — wire `DataQualityTransform` masking path to the new `Masker` (the two agents couldn't see each other).
- **#122 (T18.6)** — Python `DefaultRuntimeContext` has no worker-side registry rebuild across the T10.6 boundary (no Python distributed execution today, so latent).

closes #117, closes #118, closes #119, closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)