### PR TITLE
[sprint-19] Wave C — Python adapter parity (epic #112)

### DIFF
--- a/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/dataquality/data_quality_transform.py
+++ b/data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core/dataquality/data_quality_transform.py
@@ -4,7 +4,7 @@ Mirrors ``com.enrichmeai.culvert.dataquality.DataQualityTransform``
 (Java Sprint 14 / issue #73; masking T14.4 / issue #76;
 schema-grounded range validation T14.7 / issue #100).
 
-Port: T18.2 / issue #118.
+Port: T18.2 / issue #118.  Masking wired: T19.4 / issue #127.
 
 Design notes vs Java
 --------------------
@@ -14,10 +14,11 @@ Design notes vs Java
   ``numbers.Number``.  The Java ``WIRE_TYPE_MAP`` keeps ``Boolean`` and
   ``Number`` disjoint (Java lines 112-117), so INT64/FLOAT64 checks
   exclude ``bool`` explicitly here.
-* No Python ``Masker`` exists in this package yet (Java counterpart is
-  ``com.enrichmeai.culvert.governance.Masker``; Java lines 247-256).
-  The ``governance_policy`` parameter is accepted for API parity but
-  masking *application* is a FLAG — see class docstring.
+* PII masking is driven by ``governance_policy.masking_for(field, table)``
+  then ``governance_api.masker.mask(value, policy)``, mirroring Java
+  ``DataQualityTransform.java:247-256``.  Only valid rows are masked;
+  invalid rows go to the dead-letter path unchanged (mirrors Java comment
+  at lines 244-246).
 * ``SchemaField.range`` is an additive field added in T18.2 to
   ``data_pipeline_core.schema.entity.SchemaField`` (mirrors Java T14.7).
 """
@@ -47,6 +48,7 @@ from data_pipeline_core.dataquality.validation_result import (
     ValidationResult,
 )
 from data_pipeline_core.dataquality.violation_kind import ViolationKind
+from data_pipeline_core.governance_api.masker import mask as _masker_mask
 from data_pipeline_core.schema.entity import EntitySchema, SchemaField
 
 # TYPE_CHECKING import to avoid runtime circular dependency on GovernancePolicy.
@@ -111,14 +113,15 @@ class DataQualityTransform(Generic[R]):
     All violations are accumulated; validation does not short-circuit on
     the first failure (Java lines 48-50).
 
-    PII masking (FLAG):
-        The ``governance_policy`` constructor parameter is accepted to
-        mirror the Java API (``DataQualityTransform.java:161-168``).
-        However, no Python ``Masker`` exists in this package.  When a
-        policy is supplied the transform raises ``NotImplementedError``
-        on the first valid row that has a matching masking policy — do
-        not use in production until a ``Masker`` is ported.
-        Java masking path: lines 247-256.
+    PII masking (opt-in):
+        When ``governance_policy`` is supplied, each field of a valid row
+        is passed through ``governance_policy.masking_for(field, table)``
+        and, if a :class:`~data_pipeline_core.governance_api.policies.MaskingPolicy`
+        is returned, through ``data_pipeline_core.governance_api.masker.mask()``.
+        Masking mutates the fields mapping in place (mirrors Java
+        ``DataQualityTransform.java:247-256``).  Invalid rows are never
+        masked — they go to the dead-letter path with original values
+        intact (mirrors Java comment at lines 244-246).
 
     Usage — direct row validation::
 
@@ -166,8 +169,8 @@ class DataQualityTransform(Generic[R]):
             governance_policy: Optional GovernancePolicy for PII masking.
                                Pass ``None`` to disable masking (default).
                                Mirrors ``governancePolicy`` (Java line 125-127).
-                               FLAG: masking application is not yet implemented
-                               in Python (no Masker).
+                               When supplied, valid rows are masked via
+                               ``governance_api.masker.mask()`` (T19.4 / #127).
         """
         if schema is None:
             raise ValueError("schema must not be None")
@@ -259,21 +262,26 @@ class DataQualityTransform(Generic[R]):
         if violations:
             return InvalidRow.of(row=row, violations=violations)
 
-        # ---- Post-validation PII masking (opt-in) --------------------------
-        # FLAG: No Python Masker exists yet (Java: Masker.mask(), lines 247-256).
-        # The governance_policy param is stored for API parity.  If a policy
-        # is supplied we raise NotImplementedError to prevent silent no-ops.
-        # When a Masker is ported, replace this block with the real call.
+        # ---- Post-validation PII masking (opt-in, T19.4 / #127) ---------------
+        # Apply masking only when a GovernancePolicy is configured.
+        # Invalid rows are never masked — the dead-letter path receives the
+        # original values so violations can be diagnosed.
+        # Mirrors Java DataQualityTransform.java:247-256:
+        #   if (governancePolicy != null && fields != null) {
+        #       for (entry : fields.entrySet()) {
+        #           Optional<MaskingPolicy> mp =
+        #               governancePolicy.maskingFor(entry.getKey(), tableName);
+        #           if (mp.isPresent()) {
+        #               entry.setValue(Masker.mask(entry.getValue(), mp.get()));
+        #           }
+        #       }
+        #   }
         if self._governance_policy is not None and fields is not None:
-            for field_name, val in fields.items():
-                mp = self._governance_policy.masking_for(field_name, self._schema.name)
+            table_name = self._schema.name
+            for field_name in list(fields.keys()):  # snapshot keys; dict mutated below
+                mp = self._governance_policy.masking_for(field_name, table_name)
                 if mp is not None:
-                    raise NotImplementedError(
-                        "PII masking is accepted by the DataQualityTransform API "
-                        "(mirrors Java T14.4 / issue #76) but the Python Masker "
-                        "has not been ported yet (T18.2 flag).  Port "
-                        "data_pipeline_core.dataquality.masker.Masker first."
-                    )
+                    fields[field_name] = _masker_mask(fields[field_name], mp)  # type: ignore[index]
 
         return ValidRow(row=row)
 

--- a/data-pipeline-libraries/data-pipeline-core/tests/test_autoconfig.py
+++ b/data-pipeline-libraries/data-pipeline-core/tests/test_autoconfig.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 
 from data_pipeline_core.autoconfig import (
@@ -27,7 +29,13 @@ def test_discover_returns_autoconfig():
 
 
 def test_empty_registry_returns_empty_lists():
-    config = discover()
+    # Hermetic: simulate a bare classpath (no adapter entry-points) regardless
+    # of which adapter distributions are co-installed in the test env. Adapter
+    # packages now declare `data_pipeline_core.adapters` entry-points (Wave C),
+    # so a real `discover()` would find them — this test verifies the empty case.
+    with patch("data_pipeline_core.autoconfig.entry_points") as ep:
+        ep.return_value.select.return_value = []
+        config = discover()
     assert config.all("warehouse") == []
     assert config.first("warehouse") is None
 

--- a/data-pipeline-libraries/data-pipeline-core/tests/test_dataquality.py
+++ b/data-pipeline-libraries/data-pipeline-core/tests/test_dataquality.py
@@ -1,4 +1,4 @@
-"""Tests for the dataquality package — T18.2 / issue #118.
+"""Tests for the dataquality package — T18.2 / issue #118; masking T19.4 / issue #127.
 
 Covers all five ported types: ViolationKind, NumericRange, FieldViolation,
 ValidationResult (ValidRow + InvalidRow), and DataQualityTransform.
@@ -21,6 +21,11 @@ from data_pipeline_core.dataquality import (
     ValidRow,
     ValidationResult,
     ViolationKind,
+)
+from data_pipeline_core.governance_api import (
+    MaskingPolicy,
+    MaskingStrategy,
+    PiiMaskingGovernancePolicy,
 )
 from data_pipeline_core.schema.entity import EntitySchema, SchemaField
 
@@ -413,27 +418,145 @@ class TestDataQualityTransformApply:
 
 
 # ---------------------------------------------------------------------------
-# GovernancePolicy masking — API parity flag
+# GovernancePolicy masking — end-to-end (T19.4 / issue #127)
+# Mirrors Java DataQualityTransform.java:247-256:
+#   governancePolicy.maskingFor(field, table) → Masker.mask(value, policy)
 # ---------------------------------------------------------------------------
 
-class TestMaskingApiParityFlag:
-    def test_masking_raises_not_implemented(self) -> None:
-        """governance_policy accepted but masking raises NotImplementedError (T18.2 flag)."""
-        mock_policy = MagicMock()
-        mock_policy.masking_for.return_value = MagicMock()  # non-None → triggers flag
+class TestMaskingEndToEnd:
+    """PII field masked end-to-end through the transform (T19.4 / #127)."""
 
-        dq: DataQualityTransform[Row] = DataQualityTransform(
-            schema=_make_schema(SchemaField("name", "STRING", mode="REQUIRED")),
-            row_accessor=_accessor,
-            governance_policy=mock_policy,
+    def _policy(self) -> PiiMaskingGovernancePolicy:
+        return PiiMaskingGovernancePolicy(
+            pii_columns={"email", "ssn"},
+            default_masking_policy=MaskingPolicy(
+                strategy=MaskingStrategy.FULL, replacement="***"
+            ),
         )
-        with pytest.raises(NotImplementedError, match="Masker"):
-            dq.validate({"name": "Alice"})
 
-    def test_no_masking_policy_no_error(self) -> None:
+    def _schema(self) -> EntitySchema:
+        return EntitySchema(
+            name="users",
+            fields=[
+                SchemaField("user_id", "STRING", mode="REQUIRED"),
+                SchemaField("email",   "STRING", mode="REQUIRED"),
+                SchemaField("ssn",     "STRING", mode="REQUIRED"),
+                SchemaField("age",     "INT64",  mode="REQUIRED"),
+            ],
+        )
+
+    def test_pii_field_masked_non_pii_unchanged(self) -> None:
+        """A classified field is masked in the output; non-PII fields are unchanged.
+
+        Input row has email + ssn (PII) and user_id + age (non-PII).
+        After validate() the row dict should have email/ssn replaced with
+        the policy replacement ('***') and user_id/age left intact.
+        Mirrors Java DataQualityTransform.java:247-256.
+        """
+        row: Row = {
+            "user_id": "u-001",
+            "email":   "alice@example.com",
+            "ssn":     "123-45-6789",
+            "age":     30,
+        }
         dq: DataQualityTransform[Row] = DataQualityTransform(
-            schema=_make_schema(SchemaField("name", "STRING", mode="REQUIRED")),
+            schema=self._schema(),
+            row_accessor=_accessor,
+            governance_policy=self._policy(),
+        )
+
+        result = dq.validate(row)
+
+        assert result.is_valid(), "valid row should pass all checks"
+        assert isinstance(result, ValidRow)
+        masked_row = result.row
+        # PII fields must be replaced with the policy replacement.
+        assert masked_row["email"] == "***", "email must be masked"
+        assert masked_row["ssn"] == "***", "ssn must be masked"
+        # Non-PII fields must be unchanged.
+        assert masked_row["user_id"] == "u-001"
+        assert masked_row["age"] == 30
+
+    def test_invalid_row_not_masked(self) -> None:
+        """Invalid rows are never masked — original values preserved for diagnosis.
+
+        Mirrors Java comment at lines 244-246: masking block is only reached
+        after the violations list is confirmed empty.
+        """
+        row: Row = {
+            "user_id": None,          # REQUIRED → MISSING_REQUIRED
+            "email":   "alice@example.com",
+            "ssn":     "123-45-6789",
+            "age":     30,
+        }
+        dq: DataQualityTransform[Row] = DataQualityTransform(
+            schema=self._schema(),
+            row_accessor=_accessor,
+            governance_policy=self._policy(),
+        )
+
+        result = dq.validate(row)
+
+        assert not result.is_valid(), "row with missing required field should be invalid"
+        assert isinstance(result, InvalidRow)
+        # Original PII values must be unmasked in the dead-letter row.
+        assert result.row["email"] == "alice@example.com"
+        assert result.row["ssn"] == "123-45-6789"
+
+    def test_no_masking_policy_no_side_effect(self) -> None:
+        """Without a governance_policy, row values are never mutated."""
+        row: Row = {"user_id": "u-001", "email": "alice@example.com", "ssn": "x", "age": 30}
+        dq: DataQualityTransform[Row] = DataQualityTransform(
+            schema=self._schema(),
             row_accessor=_accessor,
         )
-        result = dq.validate({"name": "Alice"})
+        result = dq.validate(row)
         assert result.is_valid()
+        assert result.row["email"] == "alice@example.com"
+
+    def test_masking_with_partial_strategy(self) -> None:
+        """PARTIAL strategy keeps last 4 chars — wired through the transform."""
+        policy = PiiMaskingGovernancePolicy(
+            pii_columns={"card_number"},
+            default_masking_policy=MaskingPolicy(
+                strategy=MaskingStrategy.PARTIAL, replacement="*"
+            ),
+        )
+        schema = EntitySchema(
+            name="payments",
+            fields=[SchemaField("card_number", "STRING", mode="REQUIRED")],
+        )
+        row: Row = {"card_number": "4111111111111234"}
+        dq: DataQualityTransform[Row] = DataQualityTransform(
+            schema=schema, row_accessor=_accessor, governance_policy=policy
+        )
+        result = dq.validate(row)
+        assert result.is_valid()
+        assert result.row["card_number"] == "************1234"
+
+    def test_masking_through_apply_iterator(self) -> None:
+        """Masking applied when consuming via apply() (lazy generator path)."""
+        ctx = _make_context()
+        row1: Row = {
+            "user_id": "u-001",
+            "email":   "alice@example.com",
+            "ssn":     "123-45-6789",
+            "age":     30,
+        }
+        row2: Row = {
+            "user_id": "u-002",
+            "email":   "bob@example.com",
+            "ssn":     "987-65-4321",
+            "age":     25,
+        }
+        dq: DataQualityTransform[Row] = DataQualityTransform(
+            schema=self._schema(),
+            row_accessor=_accessor,
+            governance_policy=self._policy(),
+        )
+        results = list(dq.apply(iter([row1, row2]), ctx))
+        assert all(r.is_valid() for r in results)
+        assert results[0].row["email"] == "***"
+        assert results[1].row["email"] == "***"
+        assert results[0].row["user_id"] == "u-001"
+        assert results[1].row["user_id"] == "u-002"

--- a/data-pipeline-libraries/data-pipeline-core/tests/test_stage_metrics.py
+++ b/data-pipeline-libraries/data-pipeline-core/tests/test_stage_metrics.py
@@ -177,9 +177,19 @@ def test_autoconfig_has_stage_metrics_field() -> None:
 
 
 def test_autoconfig_discover_returns_empty_stage_metrics_on_bare_classpath() -> None:
-    """discover() returns empty stage_metrics when no entry-points are registered."""
+    """discover() returns empty stage_metrics when no entry-points are registered.
+
+    Hermetic: the GCP observability adapter (Wave C) now registers
+    CloudMonitoringMetricsHook under the `data_pipeline_core.adapters`
+    entry-point, so a real discover() finds it when that package is installed.
+    Mock the entry-point lookup to simulate the bare classpath this test covers.
+    """
+    from unittest.mock import patch
+
     from data_pipeline_core.autoconfig import discover
 
-    config = discover()
+    with patch("data_pipeline_core.autoconfig.entry_points") as ep:
+        ep.return_value.select.return_value = []
+        config = discover()
     assert config.all("stage_metrics") == []
     assert config.first("stage_metrics") is None

--- a/data-pipeline-libraries/data-pipeline-gcp-bigquery/pyproject.toml
+++ b/data-pipeline-libraries/data-pipeline-gcp-bigquery/pyproject.toml
@@ -41,9 +41,13 @@ Homepage = "https://github.com/enrichmeai/culvert"
 Repository = "https://github.com/enrichmeai/culvert"
 "Bug Tracker" = "https://github.com/enrichmeai/culvert/issues"
 
+[project.entry-points."data_pipeline_core.adapters"]
+warehouse = "data_pipeline_gcp_bigquery:BigQueryWarehouse"
+finops = "data_pipeline_gcp_bigquery:BigQueryFinOpsSink"
+
 [tool.setuptools.packages.find]
 where = ["src"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "-ra --strict-markers"
+addopts = "-ra --strict-markers --import-mode=importlib"

--- a/data-pipeline-libraries/data-pipeline-gcp-bigquery/src/data_pipeline_gcp_bigquery/__init__.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-bigquery/src/data_pipeline_gcp_bigquery/__init__.py
@@ -1,13 +1,18 @@
 """Google Cloud BigQuery adapter for the Culvert data pipeline framework.
 
-Implements the cloud-neutral ``Warehouse`` Protocol from
+Implements the cloud-neutral ``Warehouse`` and ``FinOpsSink`` Protocols from
 ``data-pipeline-core`` over ``google-cloud-bigquery``.
 """
 
 from __future__ import annotations
 
+from data_pipeline_gcp_bigquery.finops_sink import BigQueryFinOpsSink, FinOpsInsertException
 from data_pipeline_gcp_bigquery.warehouse import BigQueryWarehouse
 
 __version__ = "0.1.0"
 
-__all__ = ["BigQueryWarehouse"]
+__all__ = [
+    "BigQueryFinOpsSink",
+    "BigQueryWarehouse",
+    "FinOpsInsertException",
+]

--- a/data-pipeline-libraries/data-pipeline-gcp-bigquery/src/data_pipeline_gcp_bigquery/cost_tracker.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-bigquery/src/data_pipeline_gcp_bigquery/cost_tracker.py
@@ -1,0 +1,240 @@
+"""BigQueryCostTracker — builds CostMetrics from BigQuery job statistics.
+
+Java sibling: ``com.enrichmeai.culvert.gcp.bigquery.BigQueryCostTracker``
+(data-pipeline-libraries-java/data-pipeline-gcp-bigquery-java/src/main/java/
+com/enrichmeai/culvert/gcp/bigquery/BigQueryCostTracker.java)
+
+Mirrors the Java constants and formulas exactly:
+
+- ``BYTES_PER_TIB = 1_099_511_627_776``  (2^40, Java line 81)
+- ``QUERY_COST_USD_PER_TIB = 5.00``      (Java line 90)
+- ``LOAD_COST_USD_PER_TIB  = 0.01``      (Java line 103)
+- Formula: ``estimatedCostUsd = bytes / BYTES_PER_TIB * rate``
+  (Java ``bytesToUsd``, lines 321-326)
+
+Sprint-19 / T19.3 deliverable for issue #126.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from data_pipeline_core.contracts.finops import FinOpsSink
+from data_pipeline_core.finops_api.labels import FinOpsTag
+from data_pipeline_core.finops_api.models import CostMetrics
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Pricing constants — mirror Java BigQueryCostTracker exactly
+# ---------------------------------------------------------------------------
+
+#: Bytes in one tebibyte (2^40).
+#:
+#: BigQuery on-demand pricing uses the binary definition of terabyte.
+#: Use this constant — not 1e12 — to avoid an ~10% undercount in estimates.
+#:
+#: Java source: ``BigQueryCostTracker.BYTES_PER_TIB = 1_099_511_627_776L``
+#: (data-pipeline-gcp-bigquery-java/.../BigQueryCostTracker.java, line 81)
+BYTES_PER_TIB: int = 1_099_511_627_776  # 2^40
+
+#: BigQuery on-demand query cost in USD per TiB scanned.
+#:
+#: Rate as of 2025: $5.00/TiB for on-demand queries.
+#:
+#: Java source: ``BigQueryCostTracker.QUERY_COST_USD_PER_TIB = 5.00``
+#: (data-pipeline-gcp-bigquery-java/.../BigQueryCostTracker.java, line 90)
+QUERY_COST_USD_PER_TIB: float = 5.00
+
+#: Load cost constant in USD per TiB written — GCS-egress-equivalent
+#: accounting rate, not an actual BigQuery ingest charge.
+#:
+#: Java source: ``BigQueryCostTracker.LOAD_COST_USD_PER_TIB = 0.01``
+#: (data-pipeline-gcp-bigquery-java/.../BigQueryCostTracker.java, line 103)
+LOAD_COST_USD_PER_TIB: float = 0.01
+
+
+class BigQueryCostTracker:
+    """Reads job statistics from a completed BigQuery job, builds a
+    :class:`~data_pipeline_core.finops_api.models.CostMetrics` record, and
+    pushes it to the injected :class:`~data_pipeline_core.contracts.finops.FinOpsSink`.
+
+    Supported job types (mirrors Java Javadoc lines 22-30):
+    - **Query jobs**: ``totalBytesBilled`` → ``billed_bytes_scanned``;
+      ``totalSlotMs`` → ``slot_millis``.
+    - **Load jobs**: ``outputBytes`` → ``billed_bytes_written``.
+    - **Other jobs**: slot_millis only; zero cost.
+
+    Cost formula for query jobs (mirrors Java lines 243-248)::
+
+        estimated_cost_usd = billed_bytes_scanned / BYTES_PER_TIB * QUERY_COST_USD_PER_TIB
+
+    Cost formula for load jobs (mirrors Java lines 252-258)::
+
+        estimated_cost_usd = billed_bytes_written / BYTES_PER_TIB * LOAD_COST_USD_PER_TIB
+
+    This class does NOT hold its own client for dry-run support (that path
+    requires a real BigQuery client and is an optional method). Pass the
+    same ``client`` used to submit jobs.
+
+    :param client: Pre-built ``google.cloud.bigquery.Client``. Required.
+    :param sink:   FinOps sink that receives the built CostMetrics. Required.
+    :raises TypeError: if either argument is None.
+    """
+
+    def __init__(self, client: Any, sink: FinOpsSink) -> None:
+        if client is None:
+            raise TypeError("client must not be None")
+        if sink is None:
+            raise TypeError("sink must not be None")
+        self._client = client
+        self._sink = sink
+
+    # --- public API ---------------------------------------------------------
+
+    def track_job(self, job: Any, run_id: str, tag: FinOpsTag) -> None:
+        """Extract cost metrics from a completed BigQuery job and emit via sink.
+
+        Mirrors Java ``BigQueryCostTracker.trackJob`` (lines 138-165).
+
+        :param job:    Completed BigQuery job object. Required.
+        :param run_id: Pipeline run identifier. Required.
+        :param tag:    FinOps attribution tag. Required.
+        :raises TypeError: if job, run_id, or tag is None.
+        """
+        if job is None:
+            raise TypeError("job must not be None")
+        if run_id is None:
+            raise TypeError("run_id must not be None")
+        if tag is None:
+            raise TypeError("tag must not be None")
+
+        # Retrieve statistics from the job object.  The google-cloud-bigquery
+        # SDK exposes these on the Job object; we duck-type to avoid a hard
+        # import of the GCP types (mirrors Java's cast-based dispatch).
+        stats = self._get_stats(job, run_id)
+        if stats is None:
+            return
+
+        job_type = getattr(stats, "job_type", None) or _infer_job_type(stats)
+
+        if job_type == "QUERY":
+            metrics = self._build_from_query_stats(stats, run_id)
+        elif job_type == "LOAD":
+            metrics = self._build_from_load_stats(stats, run_id)
+        else:
+            # Copy / Extract / Script — zero-cost record with slot_millis.
+            slot_millis = _safe_slot_ms(stats, run_id)
+            metrics = CostMetrics(run_id=run_id, slot_millis=slot_millis)
+
+        self._sink.record(metrics, tag)
+
+    # --- private helpers ----------------------------------------------------
+
+    @staticmethod
+    def _get_stats(job: Any, run_id: str) -> Optional[Any]:
+        """Return job statistics object, logging WARN and returning None if absent."""
+        stats = None
+        # google-cloud-bigquery 3.x: job._properties["statistics"] or job.statistics()
+        if hasattr(job, "_job_statistics"):
+            stats = job._job_statistics()
+        elif hasattr(job, "statistics"):
+            stats = job.statistics
+        if stats is None:
+            logger.warning(
+                "BigQueryCostTracker: job has null statistics — cost metrics not emitted "
+                "(run_id=%s)", run_id,
+            )
+        return stats
+
+    @staticmethod
+    def _build_from_query_stats(stats: Any, run_id: str) -> CostMetrics:
+        """Build CostMetrics from QueryStatistics. Mirrors Java lines 238-249."""
+        bytes_scanned = _safe_bytes_scanned(stats, run_id)
+        slot_millis = _safe_slot_ms(stats, run_id)
+        cost_usd = _bytes_to_usd(bytes_scanned, QUERY_COST_USD_PER_TIB)
+        return CostMetrics(
+            run_id=run_id,
+            billed_bytes_scanned=bytes_scanned,
+            slot_millis=slot_millis,
+            estimated_cost_usd=cost_usd,
+        )
+
+    @staticmethod
+    def _build_from_load_stats(stats: Any, run_id: str) -> CostMetrics:
+        """Build CostMetrics from LoadStatistics. Mirrors Java lines 252-259."""
+        bytes_written = _safe_output_bytes(stats, run_id)
+        cost_usd = _bytes_to_usd(bytes_written, LOAD_COST_USD_PER_TIB)
+        return CostMetrics(
+            run_id=run_id,
+            billed_bytes_written=bytes_written,
+            estimated_cost_usd=cost_usd,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Module-level formula helpers (used by tests to verify the unit chain)
+# ---------------------------------------------------------------------------
+
+def bytes_to_usd(bytes_count: int, cost_per_tib: float) -> float:
+    """Convert bytes to USD at the given per-TiB rate.
+
+    Mirrors Java ``BigQueryCostTracker.bytesToUsd`` (lines 321-326)::
+
+        return (double) bytes / (double) BYTES_PER_TIB * costPerTib;
+
+    Zero or negative input returns 0.0 (mirrors Java guard on line 323).
+    """
+    if bytes_count <= 0:
+        return 0.0
+    return bytes_count / BYTES_PER_TIB * cost_per_tib
+
+
+# Internal alias used inside the class (avoids name collision with self).
+_bytes_to_usd = bytes_to_usd
+
+
+def _safe_bytes_scanned(stats: Any, run_id: str) -> int:
+    """Extract totalBytesBilled, treating None as 0 + WARN (mirrors Java lines 263-270)."""
+    v = getattr(stats, "total_bytes_billed", None)
+    if v is None:
+        logger.warning(
+            "BigQueryCostTracker: total_bytes_billed is None for run_id=%s — treating as 0",
+            run_id,
+        )
+        return 0
+    return int(v)
+
+
+def _safe_slot_ms(stats: Any, run_id: str) -> int:
+    """Extract totalSlotMs, treating None as 0 + WARN (mirrors Java lines 273-280)."""
+    v = getattr(stats, "total_slot_ms", None)
+    if v is None:
+        logger.warning(
+            "BigQueryCostTracker: total_slot_ms is None for run_id=%s — treating as 0",
+            run_id,
+        )
+        return 0
+    return int(v)
+
+
+def _safe_output_bytes(stats: Any, run_id: str) -> int:
+    """Extract outputBytes from LoadStatistics, treating None as 0 + WARN (mirrors Java lines 285-292)."""
+    v = getattr(stats, "output_bytes", None)
+    if v is None:
+        logger.warning(
+            "BigQueryCostTracker: output_bytes is None for run_id=%s — treating as 0",
+            run_id,
+        )
+        return 0
+    return int(v)
+
+
+def _infer_job_type(stats: Any) -> str:
+    """Infer job type from statistics attributes when job_type is not present."""
+    if hasattr(stats, "total_bytes_billed"):
+        return "QUERY"
+    if hasattr(stats, "output_bytes"):
+        return "LOAD"
+    return "OTHER"

--- a/data-pipeline-libraries/data-pipeline-gcp-bigquery/src/data_pipeline_gcp_bigquery/finops_sink.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-bigquery/src/data_pipeline_gcp_bigquery/finops_sink.py
@@ -1,0 +1,158 @@
+"""BigQueryFinOpsSink — FinOpsSink Protocol backed by BigQuery streaming inserts.
+
+Java sibling: ``com.enrichmeai.culvert.gcp.bigquery.BigQueryFinOpsSink``
+(data-pipeline-libraries-java/data-pipeline-gcp-bigquery-java/src/main/java/
+com/enrichmeai/culvert/gcp/bigquery/BigQueryFinOpsSink.java)
+
+Each call to :meth:`record` streams a single row into the configured
+``cost_metrics`` table via ``insert_rows_json``, BigQuery's Python-SDK
+equivalent of the Java ``insertAll`` API.
+
+Sprint-19 / T19.3 deliverable for issue #126.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Mapping, Optional
+
+from data_pipeline_core.contracts.finops import FinOpsSink
+from data_pipeline_core.finops_api.labels import FinOpsTag
+from data_pipeline_core.finops_api.models import CostMetrics
+
+logger = logging.getLogger(__name__)
+
+# Default table name — matches Java BigQueryFinOpsSink.DEFAULT_TABLE (line 60).
+DEFAULT_TABLE = "cost_metrics"
+
+
+class BigQueryFinOpsSink:
+    """FinOpsSink implementation backed by Google Cloud BigQuery streaming inserts.
+
+    Mirrors ``com.enrichmeai.culvert.gcp.bigquery.BigQueryFinOpsSink``.
+
+    Each :meth:`record` call streams a single row into the configured
+    ``cost_metrics`` table. The row carries every field from both
+    :class:`~data_pipeline_core.finops_api.models.CostMetrics` and
+    :class:`~data_pipeline_core.finops_api.labels.FinOpsTag`, flattened into
+    table columns. ``labels`` and ``extra`` are represented as
+    ``[{"key": k, "value": v}]`` lists (BigQuery's stable RECORD<key,value>
+    array pattern — no DDL change per new label key).
+
+    **Partial failures**: ``insert_rows_json`` can succeed at the request
+    level while reporting per-row errors. Any non-empty error list raises
+    :class:`FinOpsInsertException` — silently dropping cost rows would defeat
+    the FinOps audit trail (mirrors Java lines 101-103).
+
+    **Construction**: pass a pre-built ``google.cloud.bigquery.Client``,
+    project ID, dataset, and table name. The client is not closed by this
+    class (``google-cloud-bigquery`` 3.x clients are not context managers).
+    """
+
+    def __init__(
+        self,
+        client: Any,
+        project_id: str,
+        dataset: str,
+        table: str = DEFAULT_TABLE,
+    ) -> None:
+        """
+        :param client:     Pre-built ``google.cloud.bigquery.Client``. Required.
+        :param project_id: GCP project ID. Required.
+        :param dataset:    BigQuery dataset name. Required.
+        :param table:      BigQuery table name. Defaults to ``"cost_metrics"``.
+        :raises TypeError: if any required argument is None.
+        """
+        if client is None:
+            raise TypeError("client must not be None")
+        if project_id is None:
+            raise TypeError("project_id must not be None")
+        if dataset is None:
+            raise TypeError("dataset must not be None")
+        if table is None:
+            raise TypeError("table must not be None")
+
+        self._client = client
+        self._project_id = project_id
+        self._dataset = dataset
+        self._table = table
+
+    # --- FinOpsSink Protocol ------------------------------------------------
+
+    def record(self, metrics: CostMetrics, tags: FinOpsTag) -> None:
+        """Stream one cost-metrics row to BigQuery.
+
+        Mirrors Java ``BigQueryFinOpsSink.record`` (lines 92-104).
+
+        :raises TypeError: if metrics or tags is None.
+        :raises FinOpsInsertException: if BigQuery returns per-row errors.
+        """
+        if metrics is None:
+            raise TypeError("metrics must not be None")
+        if tags is None:
+            raise TypeError("tags must not be None")
+
+        table_ref = f"{self._project_id}.{self._dataset}.{self._table}"
+        row = self._to_row(metrics, tags)
+        errors = self._client.insert_rows_json(table_ref, [row])
+        if errors:
+            raise FinOpsInsertException(metrics.run_id, errors)
+
+    # --- internal helpers ---------------------------------------------------
+
+    def _to_row(self, metrics: CostMetrics, tags: FinOpsTag) -> Dict[str, Any]:
+        """Build the wire row dict.
+
+        Field ordering mirrors Java ``BigQueryFinOpsSink.toRow`` (lines 113-141):
+        FinOpsTag attribution columns first (cost-allocation key), then
+        CostMetrics columns.
+        """
+        row: Dict[str, Any] = {}
+        # FinOpsTag attribution columns — mirrors Java lines 116-123.
+        row["system"] = tags.system
+        row["environment"] = tags.environment
+        row["cost_center"] = tags.cost_center
+        row["owner"] = tags.owner
+        row["tag_run_id"] = tags.run_id
+        row["tag_extra"] = _flatten_map(tags.extra)
+
+        # CostMetrics columns — mirrors Java lines 126-139.
+        row["run_id"] = metrics.run_id
+        row["estimated_cost_usd"] = metrics.estimated_cost_usd
+        row["billed_bytes_scanned"] = metrics.billed_bytes_scanned
+        row["billed_bytes_written"] = metrics.billed_bytes_written
+        row["billed_bytes_stored"] = metrics.billed_bytes_stored
+        row["billed_messages_count"] = metrics.billed_messages_count
+        row["slot_millis"] = metrics.slot_millis
+        row["compute_units"] = metrics.compute_units
+        row["labels"] = _flatten_map(metrics.labels)
+        # ISO-8601 string — BigQuery TIMESTAMP accepts it (mirrors Java line 138).
+        row["timestamp"] = metrics.timestamp.isoformat()
+
+        return row
+
+
+def _flatten_map(mapping: Optional[Mapping[str, str]]) -> List[Dict[str, str]]:
+    """Flatten a str→str mapping into ``[{"key": k, "value": v}]`` records.
+
+    Mirrors Java ``BigQueryFinOpsSink.flattenMap`` (lines 149-161).
+    """
+    if not mapping:
+        return []
+    return [{"key": k, "value": v} for k, v in mapping.items()]
+
+
+class FinOpsInsertException(RuntimeError):
+    """Raised when BigQuery's streaming insert returns per-row errors.
+
+    Mirrors Java ``BigQueryFinOpsSink.FinOpsInsertException`` (lines 168-180).
+    """
+
+    def __init__(self, run_id: str, insert_errors: list) -> None:
+        n = len(insert_errors)
+        super().__init__(
+            f"BigQuery streaming insert returned errors for run_id={run_id!r} "
+            f"({n} row(s) failed)"
+        )
+        self.insert_errors = insert_errors
+        self.run_id = run_id

--- a/data-pipeline-libraries/data-pipeline-gcp-bigquery/tests/test_autoconfig_discovery.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-bigquery/tests/test_autoconfig_discovery.py
@@ -1,0 +1,29 @@
+"""Verify that AutoConfig.discover() finds BigQueryWarehouse and BigQueryFinOpsSink
+after the package is installed with its entry-points.
+
+These tests require the package to be installed (pip install -e .) so that
+setuptools entry-points are registered in the metadata.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from data_pipeline_core.autoconfig import discover
+from data_pipeline_gcp_bigquery import BigQueryFinOpsSink, BigQueryWarehouse
+
+
+def test_discover_finds_warehouse():
+    """BigQueryWarehouse must appear in discover().warehouse."""
+    cfg = discover()
+    assert BigQueryWarehouse in cfg.warehouse, (
+        f"BigQueryWarehouse not found in discover().warehouse; got: {cfg.warehouse}"
+    )
+
+
+def test_discover_finds_finops():
+    """BigQueryFinOpsSink must appear in discover().finops."""
+    cfg = discover()
+    assert BigQueryFinOpsSink in cfg.finops, (
+        f"BigQueryFinOpsSink not found in discover().finops; got: {cfg.finops}"
+    )

--- a/data-pipeline-libraries/data-pipeline-gcp-bigquery/tests/test_cost_tracker.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-bigquery/tests/test_cost_tracker.py
@@ -1,0 +1,231 @@
+"""Tests for BigQueryCostTracker — no real BigQuery client.
+
+End-to-end cost test re-derives one full cost:
+
+    Query: 1 TiB scanned (= BYTES_PER_TIB = 1_099_511_627_776 bytes)
+    Formula (mirrors Java BigQueryCostTracker.bytesToUsd, lines 321-326):
+        estimatedCostUsd = bytes / BYTES_PER_TIB * QUERY_COST_USD_PER_TIB
+                         = 1_099_511_627_776 / 1_099_511_627_776 * 5.00
+                         = 1.0 * 5.00
+                         = 5.00 USD
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from data_pipeline_gcp_bigquery.cost_tracker import (
+    BYTES_PER_TIB,
+    LOAD_COST_USD_PER_TIB,
+    QUERY_COST_USD_PER_TIB,
+    BigQueryCostTracker,
+    bytes_to_usd,
+)
+from data_pipeline_core.finops_api.labels import FinOpsTag
+from data_pipeline_core.finops_api.models import CostMetrics
+
+
+# --- pricing constants -------------------------------------------------------
+
+def test_bytes_per_tib_is_binary():
+    """BYTES_PER_TIB must be exactly 2^40, not 1e12 (10% difference matters)."""
+    assert BYTES_PER_TIB == 2 ** 40
+    assert BYTES_PER_TIB == 1_099_511_627_776
+
+
+def test_query_cost_per_tib():
+    assert QUERY_COST_USD_PER_TIB == 5.00
+
+
+def test_load_cost_per_tib():
+    assert LOAD_COST_USD_PER_TIB == 0.01
+
+
+# --- end-to-end cost formula -------------------------------------------------
+
+def test_bytes_to_usd_one_tib_query():
+    """Re-derive: 1 TiB query → $5.00.
+
+    Mirrors Java BigQueryCostTracker.bytesToUsd (lines 321-326):
+        return (double) bytes / (double) BYTES_PER_TIB * costPerTib;
+
+    Input:  bytes = BYTES_PER_TIB = 1_099_511_627_776
+    Rate:   QUERY_COST_USD_PER_TIB = 5.00
+    Output: 1_099_511_627_776 / 1_099_511_627_776 * 5.00 = 5.00 USD
+    """
+    result = bytes_to_usd(BYTES_PER_TIB, QUERY_COST_USD_PER_TIB)
+    assert result == pytest.approx(5.00)
+
+
+def test_bytes_to_usd_one_tib_load():
+    """Re-derive: 1 TiB load → $0.01.
+
+    Input:  bytes = BYTES_PER_TIB = 1_099_511_627_776
+    Rate:   LOAD_COST_USD_PER_TIB = 0.01
+    Output: 1_099_511_627_776 / 1_099_511_627_776 * 0.01 = 0.01 USD
+    """
+    result = bytes_to_usd(BYTES_PER_TIB, LOAD_COST_USD_PER_TIB)
+    assert result == pytest.approx(0.01)
+
+
+def test_bytes_to_usd_half_tib():
+    """Half TiB query → $2.50."""
+    result = bytes_to_usd(BYTES_PER_TIB // 2, QUERY_COST_USD_PER_TIB)
+    assert result == pytest.approx(2.50)
+
+
+def test_bytes_to_usd_zero():
+    assert bytes_to_usd(0, QUERY_COST_USD_PER_TIB) == 0.0
+
+
+def test_bytes_to_usd_negative():
+    assert bytes_to_usd(-1, QUERY_COST_USD_PER_TIB) == 0.0
+
+
+# --- fixtures ----------------------------------------------------------------
+
+@pytest.fixture
+def tag():
+    return FinOpsTag(
+        system="culvert", environment="test", cost_center="eng",
+        owner="team", run_id="run-42",
+    )
+
+
+@pytest.fixture
+def recording_sink():
+    """Captures the CostMetrics passed to record()."""
+    records = []
+
+    class _RecordingSink:
+        def record(self, metrics, tags):
+            records.append((metrics, tags))
+
+    sink = _RecordingSink()
+    sink.records = records
+    return sink
+
+
+@pytest.fixture
+def tracker(recording_sink):
+    return BigQueryCostTracker(MagicMock(), recording_sink)
+
+
+# --- constructor guards ------------------------------------------------------
+
+def test_rejects_none_client():
+    with pytest.raises(TypeError):
+        BigQueryCostTracker(None, MagicMock())
+
+
+def test_rejects_none_sink():
+    with pytest.raises(TypeError):
+        BigQueryCostTracker(MagicMock(), None)
+
+
+# --- track_job guards --------------------------------------------------------
+
+def test_track_job_rejects_none_job(tracker, tag):
+    with pytest.raises(TypeError):
+        tracker.track_job(None, "r1", tag)
+
+
+def test_track_job_rejects_none_run_id(tracker, tag):
+    job = MagicMock()
+    job._job_statistics.return_value = None
+    with pytest.raises(TypeError):
+        tracker.track_job(job, None, tag)
+
+
+def test_track_job_rejects_none_tag(tracker):
+    job = MagicMock()
+    with pytest.raises(TypeError):
+        tracker.track_job(job, "r1", None)
+
+
+# --- query job ---------------------------------------------------------------
+
+def test_track_job_query_populates_cost(recording_sink, tag):
+    """Full end-to-end: 1 TiB query → $5.00 in the emitted CostMetrics."""
+    stats = MagicMock()
+    stats.job_type = "QUERY"
+    stats.total_bytes_billed = BYTES_PER_TIB  # 1 TiB
+    stats.total_slot_ms = 1000
+
+    job = MagicMock()
+    job._job_statistics.return_value = stats
+
+    tracker = BigQueryCostTracker(MagicMock(), recording_sink)
+    tracker.track_job(job, "run-42", tag)
+
+    assert len(recording_sink.records) == 1
+    m, t = recording_sink.records[0]
+    assert m.billed_bytes_scanned == BYTES_PER_TIB
+    assert m.slot_millis == 1000
+    assert m.estimated_cost_usd == pytest.approx(5.00)
+
+
+def test_track_job_query_null_bytes_treated_as_zero(recording_sink, tag):
+    stats = MagicMock()
+    stats.job_type = "QUERY"
+    stats.total_bytes_billed = None
+    stats.total_slot_ms = 500
+
+    job = MagicMock()
+    job._job_statistics.return_value = stats
+
+    tracker = BigQueryCostTracker(MagicMock(), recording_sink)
+    tracker.track_job(job, "r1", tag)
+
+    m, _ = recording_sink.records[0]
+    assert m.billed_bytes_scanned == 0
+    assert m.estimated_cost_usd == pytest.approx(0.0)
+
+
+# --- load job ----------------------------------------------------------------
+
+def test_track_job_load_populates_cost(recording_sink, tag):
+    """Full end-to-end: 1 TiB load → $0.01 in emitted CostMetrics."""
+    stats = MagicMock()
+    stats.job_type = "LOAD"
+    stats.output_bytes = BYTES_PER_TIB  # 1 TiB
+
+    job = MagicMock()
+    job._job_statistics.return_value = stats
+
+    tracker = BigQueryCostTracker(MagicMock(), recording_sink)
+    tracker.track_job(job, "run-load", tag)
+
+    assert len(recording_sink.records) == 1
+    m, _ = recording_sink.records[0]
+    assert m.billed_bytes_written == BYTES_PER_TIB
+    assert m.estimated_cost_usd == pytest.approx(0.01)
+
+
+# --- null statistics ---------------------------------------------------------
+
+def test_track_job_null_stats_skips_emission(recording_sink, tag):
+    job = MagicMock()
+    job._job_statistics.return_value = None
+
+    tracker = BigQueryCostTracker(MagicMock(), recording_sink)
+    tracker.track_job(job, "r1", tag)
+    assert len(recording_sink.records) == 0
+
+
+# --- other job type (copy/export/script) ------------------------------------
+
+def test_track_job_other_type_zero_cost(recording_sink, tag):
+    stats = MagicMock(spec=[])  # no attributes like total_bytes_billed/output_bytes
+    stats.job_type = "COPY"
+
+    job = MagicMock()
+    job._job_statistics.return_value = stats
+
+    tracker = BigQueryCostTracker(MagicMock(), recording_sink)
+    tracker.track_job(job, "r1", tag)
+    assert len(recording_sink.records) == 1
+    m, _ = recording_sink.records[0]
+    assert m.estimated_cost_usd == pytest.approx(0.0)

--- a/data-pipeline-libraries/data-pipeline-gcp-bigquery/tests/test_finops_sink.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-bigquery/tests/test_finops_sink.py
@@ -1,0 +1,160 @@
+"""Tests for BigQueryFinOpsSink — no real BigQuery client."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from data_pipeline_gcp_bigquery import BigQueryFinOpsSink, FinOpsInsertException
+from data_pipeline_core.finops_api.models import CostMetrics
+from data_pipeline_core.finops_api.labels import FinOpsTag
+
+
+# --- fixtures ---------------------------------------------------------------
+
+@pytest.fixture
+def tag():
+    return FinOpsTag(
+        system="culvert",
+        environment="test",
+        cost_center="engineering",
+        owner="team-data",
+        run_id="run-001",
+        extra={"team": "data-platform"},
+    )
+
+
+@pytest.fixture
+def metrics():
+    return CostMetrics(
+        run_id="run-001",
+        estimated_cost_usd=1.23,
+        billed_bytes_scanned=1_099_511_627_776,  # 1 TiB
+        slot_millis=500,
+        labels={"env": "test"},
+    )
+
+
+@pytest.fixture
+def client():
+    c = MagicMock()
+    c.insert_rows_json.return_value = []  # success: empty error list
+    return c
+
+
+@pytest.fixture
+def sink(client):
+    return BigQueryFinOpsSink(client, "my-project", "finops_ds", "cost_metrics")
+
+
+# --- constructor guards ------------------------------------------------------
+
+def test_rejects_none_client():
+    with pytest.raises(TypeError):
+        BigQueryFinOpsSink(None, "p", "ds", "t")
+
+
+def test_rejects_none_project():
+    with pytest.raises(TypeError):
+        BigQueryFinOpsSink(MagicMock(), None, "ds", "t")
+
+
+def test_rejects_none_dataset():
+    with pytest.raises(TypeError):
+        BigQueryFinOpsSink(MagicMock(), "p", None, "t")
+
+
+def test_rejects_none_table():
+    with pytest.raises(TypeError):
+        BigQueryFinOpsSink(MagicMock(), "p", "ds", None)
+
+
+# --- record() guards --------------------------------------------------------
+
+def test_record_rejects_none_metrics(sink, tag):
+    with pytest.raises(TypeError):
+        sink.record(None, tag)
+
+
+def test_record_rejects_none_tags(sink, metrics):
+    with pytest.raises(TypeError):
+        sink.record(metrics, None)
+
+
+# --- happy path --------------------------------------------------------------
+
+def test_record_calls_insert_rows_json(sink, client, metrics, tag):
+    sink.record(metrics, tag)
+    client.insert_rows_json.assert_called_once()
+    table_ref, rows = client.insert_rows_json.call_args.args
+    assert table_ref == "my-project.finops_ds.cost_metrics"
+    assert len(rows) == 1
+
+
+def test_record_row_contains_finops_tag_fields(sink, client, metrics, tag):
+    sink.record(metrics, tag)
+    row = client.insert_rows_json.call_args.args[1][0]
+    assert row["system"] == "culvert"
+    assert row["environment"] == "test"
+    assert row["cost_center"] == "engineering"
+    assert row["owner"] == "team-data"
+    assert row["tag_run_id"] == "run-001"
+    # extra should be flattened to [{"key": "team", "value": "data-platform"}]
+    assert row["tag_extra"] == [{"key": "team", "value": "data-platform"}]
+
+
+def test_record_row_contains_cost_metrics_fields(sink, client, metrics, tag):
+    sink.record(metrics, tag)
+    row = client.insert_rows_json.call_args.args[1][0]
+    assert row["run_id"] == "run-001"
+    assert row["estimated_cost_usd"] == pytest.approx(1.23)
+    assert row["billed_bytes_scanned"] == 1_099_511_627_776
+    assert row["slot_millis"] == 500
+    # labels: {"env": "test"} → [{"key": "env", "value": "test"}]
+    assert row["labels"] == [{"key": "env", "value": "test"}]
+    assert "timestamp" in row
+
+
+def test_record_row_empty_labels_and_extra(client):
+    m = CostMetrics(run_id="r1")
+    t = FinOpsTag(
+        system="s", environment="e", cost_center="c", owner="o", run_id="r1"
+    )
+    sink = BigQueryFinOpsSink(client, "p", "ds", "t")
+    sink.record(m, t)
+    row = client.insert_rows_json.call_args.args[1][0]
+    assert row["labels"] == []
+    assert row["tag_extra"] == []
+
+
+# --- error path --------------------------------------------------------------
+
+def test_record_raises_on_insert_errors(client, metrics, tag):
+    client.insert_rows_json.return_value = [{"index": 0, "errors": [{"reason": "invalid"}]}]
+    sink = BigQueryFinOpsSink(client, "p", "ds", "t")
+    with pytest.raises(FinOpsInsertException) as exc_info:
+        sink.record(metrics, tag)
+    assert "run-001" in str(exc_info.value)
+
+
+def test_finops_insert_exception_carries_errors():
+    errors = [{"index": 0, "errors": [{"reason": "stopped"}]}]
+    exc = FinOpsInsertException("r42", errors)
+    assert exc.run_id == "r42"
+    assert exc.insert_errors is errors
+    assert "r42" in str(exc)
+
+
+# --- default table constant --------------------------------------------------
+
+def test_default_table_constant():
+    from data_pipeline_gcp_bigquery.finops_sink import DEFAULT_TABLE
+    assert DEFAULT_TABLE == "cost_metrics"
+
+
+def test_default_table_used_when_not_specified(client, metrics, tag):
+    sink = BigQueryFinOpsSink(client, "p", "ds")
+    sink.record(metrics, tag)
+    table_ref = client.insert_rows_json.call_args.args[0]
+    assert table_ref.endswith(".cost_metrics")

--- a/data-pipeline-libraries/data-pipeline-gcp-gcs/pyproject.toml
+++ b/data-pipeline-libraries/data-pipeline-gcp-gcs/pyproject.toml
@@ -33,9 +33,12 @@ test = ["pytest>=7.4", "pytest-cov>=4.1"]
 [project.urls]
 Homepage = "https://github.com/enrichmeai/culvert"
 
+[project.entry-points."data_pipeline_core.adapters"]
+blob_store = "data_pipeline_gcp_gcs:GcsBlobStore"
+
 [tool.setuptools.packages.find]
 where = ["src"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "-ra --strict-markers"
+addopts = "-ra --strict-markers --import-mode=importlib"

--- a/data-pipeline-libraries/data-pipeline-gcp-gcs/src/data_pipeline_gcp_gcs/__init__.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-gcs/src/data_pipeline_gcp_gcs/__init__.py
@@ -7,7 +7,11 @@ Implements the cloud-neutral ``BlobStore`` Protocol from
 from __future__ import annotations
 
 from data_pipeline_gcp_gcs.blob_store import GcsBlobStore
+from data_pipeline_gcp_gcs.cost_tracker import GcsCostTracker
 
 __version__ = "0.1.0"
 
-__all__ = ["GcsBlobStore"]
+__all__ = [
+    "GcsBlobStore",
+    "GcsCostTracker",
+]

--- a/data-pipeline-libraries/data-pipeline-gcp-gcs/src/data_pipeline_gcp_gcs/cost_tracker.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-gcs/src/data_pipeline_gcp_gcs/cost_tracker.py
@@ -1,0 +1,249 @@
+"""GcsCostTracker — builds CostMetrics from GCS operation byte counts.
+
+Java sibling: ``com.enrichmeai.culvert.gcp.gcs.GcsCostTracker``
+(data-pipeline-libraries-java/data-pipeline-gcp-gcs-java/src/main/java/
+com/enrichmeai/culvert/gcp/gcs/GcsCostTracker.java)
+
+Mirrors the Java constants and formulas exactly:
+
+- ``BYTES_PER_GIB = 1_073_741_824``         (2^30, Java line 77)
+- ``WRITE_COST_USD_PER_GIB = 0.01``          (Java line 90)
+- ``STANDARD_STORAGE_USD_PER_GIB = 0.020``   (Java line 99)
+- ``NEARLINE_STORAGE_USD_PER_GIB = 0.010``   (Java line 108)
+- ``COLDLINE_STORAGE_USD_PER_GIB = 0.004``   (Java line 117)
+- ``ARCHIVE_STORAGE_USD_PER_GIB  = 0.0012``  (Java line 126)
+
+Upload formula (Java lines 162-163)::
+
+    estimated_cost_usd = bytes_written / BYTES_PER_GIB * WRITE_COST_USD_PER_GIB
+
+Storage formula (Java lines 206-208)::
+
+    estimated_cost_usd = bytes_stored / BYTES_PER_GIB * rate_for_class
+
+Sprint-19 / T19.3 deliverable for issue #126.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from data_pipeline_core.contracts.finops import FinOpsSink
+from data_pipeline_core.finops_api.labels import FinOpsTag
+from data_pipeline_core.finops_api.models import CostMetrics
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Pricing constants — mirror Java GcsCostTracker exactly
+# ---------------------------------------------------------------------------
+
+#: Bytes in one gibibyte (2^30).
+#:
+#: GCS storage pricing is quoted in GiB-months (binary definition).
+#: Use this constant — not 1e9 — to avoid an ~7% undercount.
+#:
+#: Java source: ``GcsCostTracker.BYTES_PER_GIB = 1_073_741_824L``
+#: (data-pipeline-gcp-gcs-java/.../GcsCostTracker.java, line 77)
+BYTES_PER_GIB: int = 1_073_741_824  # 2^30
+
+#: GCS upload cost accounting placeholder in USD per GiB written.
+#:
+#: Note: GCS does not bill per-byte for write operations (Class A per-10k).
+#: This is an accounting placeholder.
+#:
+#: Java source: ``GcsCostTracker.WRITE_COST_USD_PER_GIB = 0.01``
+#: (data-pipeline-gcp-gcs-java/.../GcsCostTracker.java, line 90)
+WRITE_COST_USD_PER_GIB: float = 0.01
+
+#: GCS Standard storage rate in USD per GiB-month (US multi-region, 2025).
+#:
+#: Java source: ``GcsCostTracker.STANDARD_STORAGE_USD_PER_GIB = 0.020``
+#: (data-pipeline-gcp-gcs-java/.../GcsCostTracker.java, line 99)
+STANDARD_STORAGE_USD_PER_GIB: float = 0.020
+
+#: GCS Nearline storage rate in USD per GiB-month (US multi-region, 2025).
+#:
+#: Java source: ``GcsCostTracker.NEARLINE_STORAGE_USD_PER_GIB = 0.010``
+#: (data-pipeline-gcp-gcs-java/.../GcsCostTracker.java, line 108)
+NEARLINE_STORAGE_USD_PER_GIB: float = 0.010
+
+#: GCS Coldline storage rate in USD per GiB-month (US multi-region, 2025).
+#:
+#: Java source: ``GcsCostTracker.COLDLINE_STORAGE_USD_PER_GIB = 0.004``
+#: (data-pipeline-gcp-gcs-java/.../GcsCostTracker.java, line 117)
+COLDLINE_STORAGE_USD_PER_GIB: float = 0.004
+
+#: GCS Archive storage rate in USD per GiB-month (US multi-region, 2025).
+#:
+#: Java source: ``GcsCostTracker.ARCHIVE_STORAGE_USD_PER_GIB = 0.0012``
+#: (data-pipeline-gcp-gcs-java/.../GcsCostTracker.java, line 126)
+ARCHIVE_STORAGE_USD_PER_GIB: float = 0.0012
+
+
+class GcsCostTracker:
+    """Builds a :class:`~data_pipeline_core.finops_api.models.CostMetrics` record
+    from GCS operation sizes and pushes it to the injected
+    :class:`~data_pipeline_core.contracts.finops.FinOpsSink`.
+
+    Mirrors ``com.enrichmeai.culvert.gcp.gcs.GcsCostTracker``.
+
+    This class does NOT hold a GCS client — it operates on byte counts
+    already obtained by the caller (from a GCS API response).
+
+    Supported operations:
+
+    - :meth:`track_upload`: records ``billed_bytes_written``; estimates USD
+      using :data:`WRITE_COST_USD_PER_GIB`.
+    - :meth:`track_storage_class`: records ``billed_bytes_stored``; estimates
+      monthly storage USD at per-class rates.
+
+    :param sink: FinOps sink that receives the built CostMetrics. Required.
+    :raises TypeError: if sink is None.
+    """
+
+    def __init__(self, sink: FinOpsSink) -> None:
+        if sink is None:
+            raise TypeError("sink must not be None")
+        self._sink = sink
+
+    # --- public API ---------------------------------------------------------
+
+    def track_upload(self, bytes_written: int, run_id: str, tag: FinOpsTag) -> None:
+        """Record cost metrics for a GCS upload operation.
+
+        Mirrors Java ``GcsCostTracker.trackUpload`` (lines 153-171).
+
+        Formula (mirrors Java lines 162-163)::
+
+            estimated_cost_usd = bytes_written / BYTES_PER_GIB * WRITE_COST_USD_PER_GIB
+
+        Zero or negative ``bytes_written`` logs WARN and records zero cost;
+        :meth:`FinOpsSink.record` is called exactly once.
+
+        :param bytes_written: Number of bytes written in the upload.
+        :param run_id:        Pipeline run identifier.
+        :param tag:           FinOps attribution tag.
+        :raises TypeError: if run_id or tag is None.
+        """
+        if run_id is None:
+            raise TypeError("run_id must not be None")
+        if tag is None:
+            raise TypeError("tag must not be None")
+
+        if bytes_written <= 0:
+            logger.warning(
+                "GcsCostTracker.track_upload: bytes_written=%d for run_id=%s "
+                "— recording zero cost", bytes_written, run_id,
+            )
+
+        billed = max(0, bytes_written)
+        cost_usd = _bytes_to_usd(billed, WRITE_COST_USD_PER_GIB)
+
+        metrics = CostMetrics(
+            run_id=run_id,
+            billed_bytes_written=billed,
+            estimated_cost_usd=cost_usd,
+        )
+        self._sink.record(metrics, tag)
+
+    def track_storage_class(
+        self,
+        bytes_stored: int,
+        storage_class: str,
+        run_id: str,
+        tag: FinOpsTag,
+    ) -> None:
+        """Record cost metrics for bytes stored under a given GCS storage class.
+
+        Mirrors Java ``GcsCostTracker.trackStorageClass`` (lines 195-215).
+
+        Recognised storage class strings (case-insensitive):
+        ``STANDARD``, ``NEARLINE``, ``COLDLINE``, ``ARCHIVE``.
+        An unrecognised class falls back to Standard and logs WARN
+        (mirrors Java lines 235-239).
+
+        Formula (mirrors Java lines 206-208)::
+
+            estimated_cost_usd = bytes_stored / BYTES_PER_GIB * rate_for_class
+
+        :param bytes_stored:  Number of bytes stored.
+        :param storage_class: GCS storage class (e.g. ``"STANDARD"``).
+                              Case-insensitive. None treated as unknown.
+        :param run_id:        Pipeline run identifier.
+        :param tag:           FinOps attribution tag.
+        :raises TypeError: if run_id or tag is None.
+        """
+        if run_id is None:
+            raise TypeError("run_id must not be None")
+        if tag is None:
+            raise TypeError("tag must not be None")
+
+        if bytes_stored <= 0:
+            logger.warning(
+                "GcsCostTracker.track_storage_class: bytes_stored=%d for run_id=%s "
+                "— recording zero cost", bytes_stored, run_id,
+            )
+
+        rate = _resolve_storage_rate(storage_class, run_id)
+        billed = max(0, bytes_stored)
+        cost_usd = _bytes_to_usd(billed, rate)
+
+        metrics = CostMetrics(
+            run_id=run_id,
+            billed_bytes_stored=billed,
+            estimated_cost_usd=cost_usd,
+        )
+        self._sink.record(metrics, tag)
+
+
+# ---------------------------------------------------------------------------
+# Module-level formula helpers (used by tests to verify the unit chain)
+# ---------------------------------------------------------------------------
+
+def bytes_to_usd(bytes_count: int, rate_per_gib: float) -> float:
+    """Convert bytes to USD at the given per-GiB rate.
+
+    Mirrors Java ``GcsCostTracker.bytesToUsd`` (lines 244-248)::
+
+        return (double) bytes / (double) BYTES_PER_GIB * ratePerGib;
+
+    Zero or negative input returns 0.0 (mirrors Java guard on line 246).
+    """
+    if bytes_count <= 0:
+        return 0.0
+    return bytes_count / BYTES_PER_GIB * rate_per_gib
+
+
+# Internal alias used inside the class.
+_bytes_to_usd = bytes_to_usd
+
+
+def _resolve_storage_rate(storage_class: str, run_id: str) -> float:
+    """Resolve per-GiB-month rate for a given storage class string.
+
+    Mirrors Java ``GcsCostTracker.resolveStorageRate`` (lines 224-240).
+    Falls back to STANDARD and logs WARN on unknown/None input.
+    """
+    if storage_class is None:
+        logger.warning(
+            "GcsCostTracker.track_storage_class: None storage_class for run_id=%s "
+            "— defaulting to STANDARD rate", run_id,
+        )
+        return STANDARD_STORAGE_USD_PER_GIB
+
+    key = storage_class.upper()
+    rates = {
+        "STANDARD": STANDARD_STORAGE_USD_PER_GIB,
+        "NEARLINE":  NEARLINE_STORAGE_USD_PER_GIB,
+        "COLDLINE":  COLDLINE_STORAGE_USD_PER_GIB,
+        "ARCHIVE":   ARCHIVE_STORAGE_USD_PER_GIB,
+    }
+    rate = rates.get(key)
+    if rate is None:
+        logger.warning(
+            "GcsCostTracker.track_storage_class: unknown storage_class=%r for run_id=%s "
+            "— defaulting to STANDARD rate", storage_class, run_id,
+        )
+        return STANDARD_STORAGE_USD_PER_GIB
+    return rate

--- a/data-pipeline-libraries/data-pipeline-gcp-gcs/tests/test_autoconfig_discovery.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-gcs/tests/test_autoconfig_discovery.py
@@ -1,0 +1,14 @@
+"""Verify that AutoConfig.discover() finds GcsBlobStore after package install."""
+
+from __future__ import annotations
+
+from data_pipeline_core.autoconfig import discover
+from data_pipeline_gcp_gcs import GcsBlobStore
+
+
+def test_discover_finds_blob_store():
+    """GcsBlobStore must appear in discover().blob_store."""
+    cfg = discover()
+    assert GcsBlobStore in cfg.blob_store, (
+        f"GcsBlobStore not found in discover().blob_store; got: {cfg.blob_store}"
+    )

--- a/data-pipeline-libraries/data-pipeline-gcp-gcs/tests/test_cost_tracker.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-gcs/tests/test_cost_tracker.py
@@ -1,0 +1,253 @@
+"""Tests for GcsCostTracker — no real GCS client.
+
+End-to-end cost test re-derives one full cost:
+
+    Upload: 1 GiB written (= BYTES_PER_GIB = 1_073_741_824 bytes)
+    Formula (mirrors Java GcsCostTracker.bytesToUsd, lines 244-248):
+        estimatedCostUsd = bytes / BYTES_PER_GIB * WRITE_COST_USD_PER_GIB
+                         = 1_073_741_824 / 1_073_741_824 * 0.01
+                         = 1.0 * 0.01
+                         = 0.01 USD
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from data_pipeline_gcp_gcs.cost_tracker import (
+    ARCHIVE_STORAGE_USD_PER_GIB,
+    BYTES_PER_GIB,
+    COLDLINE_STORAGE_USD_PER_GIB,
+    NEARLINE_STORAGE_USD_PER_GIB,
+    STANDARD_STORAGE_USD_PER_GIB,
+    WRITE_COST_USD_PER_GIB,
+    GcsCostTracker,
+    bytes_to_usd,
+)
+from data_pipeline_core.finops_api.labels import FinOpsTag
+from data_pipeline_core.finops_api.models import CostMetrics
+
+
+# --- pricing constants -------------------------------------------------------
+
+def test_bytes_per_gib_is_binary():
+    """BYTES_PER_GIB must be exactly 2^30, not 1e9 (~7% difference matters)."""
+    assert BYTES_PER_GIB == 2 ** 30
+    assert BYTES_PER_GIB == 1_073_741_824
+
+
+def test_write_cost_per_gib():
+    assert WRITE_COST_USD_PER_GIB == 0.01
+
+
+def test_standard_storage_rate():
+    assert STANDARD_STORAGE_USD_PER_GIB == 0.020
+
+
+def test_nearline_storage_rate():
+    assert NEARLINE_STORAGE_USD_PER_GIB == 0.010
+
+
+def test_coldline_storage_rate():
+    assert COLDLINE_STORAGE_USD_PER_GIB == 0.004
+
+
+def test_archive_storage_rate():
+    assert ARCHIVE_STORAGE_USD_PER_GIB == 0.0012
+
+
+# --- end-to-end cost formula -------------------------------------------------
+
+def test_bytes_to_usd_one_gib_upload():
+    """Re-derive: 1 GiB upload → $0.01.
+
+    Mirrors Java GcsCostTracker.bytesToUsd (lines 244-248):
+        return (double) bytes / (double) BYTES_PER_GIB * ratePerGib;
+
+    Input:  bytes = BYTES_PER_GIB = 1_073_741_824
+    Rate:   WRITE_COST_USD_PER_GIB = 0.01
+    Output: 1_073_741_824 / 1_073_741_824 * 0.01 = 0.01 USD
+    """
+    result = bytes_to_usd(BYTES_PER_GIB, WRITE_COST_USD_PER_GIB)
+    assert result == pytest.approx(0.01)
+
+
+def test_bytes_to_usd_one_gib_standard_storage():
+    """1 GiB STANDARD → $0.020/GiB-month."""
+    result = bytes_to_usd(BYTES_PER_GIB, STANDARD_STORAGE_USD_PER_GIB)
+    assert result == pytest.approx(0.020)
+
+
+def test_bytes_to_usd_two_gib_coldline():
+    """2 GiB COLDLINE → 2 * $0.004 = $0.008/GiB-month."""
+    result = bytes_to_usd(2 * BYTES_PER_GIB, COLDLINE_STORAGE_USD_PER_GIB)
+    assert result == pytest.approx(0.008)
+
+
+def test_bytes_to_usd_zero():
+    assert bytes_to_usd(0, WRITE_COST_USD_PER_GIB) == 0.0
+
+
+def test_bytes_to_usd_negative():
+    assert bytes_to_usd(-1, WRITE_COST_USD_PER_GIB) == 0.0
+
+
+# --- fixtures ----------------------------------------------------------------
+
+@pytest.fixture
+def tag():
+    return FinOpsTag(
+        system="culvert", environment="test", cost_center="eng",
+        owner="team", run_id="run-gcs",
+    )
+
+
+@pytest.fixture
+def recording_sink():
+    records = []
+
+    class _RecordingSink:
+        def record(self, metrics, tags):
+            records.append((metrics, tags))
+
+    sink = _RecordingSink()
+    sink.records = records
+    return sink
+
+
+@pytest.fixture
+def tracker(recording_sink):
+    return GcsCostTracker(recording_sink)
+
+
+# --- constructor guard -------------------------------------------------------
+
+def test_rejects_none_sink():
+    with pytest.raises(TypeError):
+        GcsCostTracker(None)
+
+
+# --- track_upload ------------------------------------------------------------
+
+def test_track_upload_rejects_none_run_id(tracker, tag):
+    with pytest.raises(TypeError):
+        tracker.track_upload(1024, None, tag)
+
+
+def test_track_upload_rejects_none_tag(tracker):
+    with pytest.raises(TypeError):
+        tracker.track_upload(1024, "r1", None)
+
+
+def test_track_upload_one_gib(recording_sink, tag):
+    """End-to-end: 1 GiB upload → $0.01 emitted to sink."""
+    tracker = GcsCostTracker(recording_sink)
+    tracker.track_upload(BYTES_PER_GIB, "run-gcs", tag)
+
+    assert len(recording_sink.records) == 1
+    m, t = recording_sink.records[0]
+    assert m.billed_bytes_written == BYTES_PER_GIB
+    assert m.estimated_cost_usd == pytest.approx(0.01)
+    assert t is tag
+
+
+def test_track_upload_zero_bytes_emits_zero_cost(recording_sink, tag):
+    """Zero bytes: sink still called once; cost is 0."""
+    tracker = GcsCostTracker(recording_sink)
+    tracker.track_upload(0, "r1", tag)
+
+    assert len(recording_sink.records) == 1
+    m, _ = recording_sink.records[0]
+    assert m.billed_bytes_written == 0
+    assert m.estimated_cost_usd == pytest.approx(0.0)
+
+
+def test_track_upload_negative_bytes_treated_as_zero(recording_sink, tag):
+    tracker = GcsCostTracker(recording_sink)
+    tracker.track_upload(-100, "r1", tag)
+    m, _ = recording_sink.records[0]
+    assert m.billed_bytes_written == 0
+
+
+# --- track_storage_class -----------------------------------------------------
+
+def test_track_storage_class_rejects_none_run_id(tracker, tag):
+    with pytest.raises(TypeError):
+        tracker.track_storage_class(1024, "STANDARD", None, tag)
+
+
+def test_track_storage_class_rejects_none_tag(tracker):
+    with pytest.raises(TypeError):
+        tracker.track_storage_class(1024, "STANDARD", "r1", None)
+
+
+def test_track_storage_class_standard(recording_sink, tag):
+    """1 GiB STANDARD → $0.020."""
+    tracker = GcsCostTracker(recording_sink)
+    tracker.track_storage_class(BYTES_PER_GIB, "STANDARD", "run-gcs", tag)
+
+    m, _ = recording_sink.records[0]
+    assert m.billed_bytes_stored == BYTES_PER_GIB
+    assert m.estimated_cost_usd == pytest.approx(0.020)
+
+
+def test_track_storage_class_nearline(recording_sink, tag):
+    """1 GiB NEARLINE → $0.010."""
+    GcsCostTracker(recording_sink).track_storage_class(
+        BYTES_PER_GIB, "NEARLINE", "r1", tag
+    )
+    m, _ = recording_sink.records[0]
+    assert m.estimated_cost_usd == pytest.approx(0.010)
+
+
+def test_track_storage_class_coldline(recording_sink, tag):
+    """1 GiB COLDLINE → $0.004."""
+    GcsCostTracker(recording_sink).track_storage_class(
+        BYTES_PER_GIB, "COLDLINE", "r1", tag
+    )
+    m, _ = recording_sink.records[0]
+    assert m.estimated_cost_usd == pytest.approx(0.004)
+
+
+def test_track_storage_class_archive(recording_sink, tag):
+    """1 GiB ARCHIVE → $0.0012."""
+    GcsCostTracker(recording_sink).track_storage_class(
+        BYTES_PER_GIB, "ARCHIVE", "r1", tag
+    )
+    m, _ = recording_sink.records[0]
+    assert m.estimated_cost_usd == pytest.approx(0.0012)
+
+
+def test_track_storage_class_case_insensitive(recording_sink, tag):
+    """'standard' (lowercase) resolves to STANDARD rate."""
+    GcsCostTracker(recording_sink).track_storage_class(
+        BYTES_PER_GIB, "standard", "r1", tag
+    )
+    m, _ = recording_sink.records[0]
+    assert m.estimated_cost_usd == pytest.approx(0.020)
+
+
+def test_track_storage_class_unknown_falls_back_to_standard(recording_sink, tag):
+    """Unknown storage class falls back to Standard rate, logs WARN."""
+    GcsCostTracker(recording_sink).track_storage_class(
+        BYTES_PER_GIB, "GLACIER", "r1", tag
+    )
+    m, _ = recording_sink.records[0]
+    assert m.estimated_cost_usd == pytest.approx(0.020)
+
+
+def test_track_storage_class_none_falls_back_to_standard(recording_sink, tag):
+    GcsCostTracker(recording_sink).track_storage_class(
+        BYTES_PER_GIB, None, "r1", tag
+    )
+    m, _ = recording_sink.records[0]
+    assert m.estimated_cost_usd == pytest.approx(0.020)
+
+
+def test_track_storage_class_zero_bytes(recording_sink, tag):
+    """Zero bytes still calls sink once with zero cost."""
+    GcsCostTracker(recording_sink).track_storage_class(0, "STANDARD", "r1", tag)
+    assert len(recording_sink.records) == 1
+    m, _ = recording_sink.records[0]
+    assert m.billed_bytes_stored == 0
+    assert m.estimated_cost_usd == pytest.approx(0.0)

--- a/data-pipeline-libraries/data-pipeline-gcp-observability/pyproject.toml
+++ b/data-pipeline-libraries/data-pipeline-gcp-observability/pyproject.toml
@@ -1,0 +1,57 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "data-pipeline-gcp-observability"
+version = "0.1.0"
+description = "GCP observability adapter for the Culvert data pipeline framework. Implements ObservabilityHook (Cloud Trace/OTel), StageMetricsHook (Cloud Monitoring), LineageEmitter (Data Catalog), and CulvertMdcPopulator log-correlation helper."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [
+    { name = "Joseph Aruja", email = "joseph.a.aruja@googlemail.com" },
+]
+keywords = ["data", "pipeline", "framework", "culvert", "gcp", "observability", "tracing", "metrics", "lineage"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Typing :: Typed",
+]
+# GCP/OTel SDK deps are declared but mocked in tests so the suite runs offline.
+# In production these must be installed for real emission; lazy imports inside
+# each class mean import of this package never fails even when the SDK is absent.
+dependencies = [
+    "data-pipeline-core>=0.1.0",
+    "opentelemetry-api>=1.20.0",
+    "google-cloud-monitoring>=2.14.0",
+    "google-cloud-datacatalog>=3.14.0",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=7.4",
+    "pytest-cov>=4.1",
+    "data-pipeline-contract-tests>=0.1.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/enrichmeai/culvert"
+
+# Auto-registration: AutoConfig.discover() reads this group.
+# Key names must match AutoConfig dataclass field names.
+[project.entry-points."data_pipeline_core.adapters"]
+observability  = "data_pipeline_gcp_observability:CloudTraceObservabilityHook"
+stage_metrics  = "data_pipeline_gcp_observability:CloudMonitoringMetricsHook"
+lineage        = "data_pipeline_gcp_observability:DataCatalogLineageEmitter"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra --strict-markers"

--- a/data-pipeline-libraries/data-pipeline-gcp-observability/src/data_pipeline_gcp_observability/__init__.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-observability/src/data_pipeline_gcp_observability/__init__.py
@@ -1,0 +1,53 @@
+"""GCP observability adapter for the Culvert data pipeline framework.
+
+Implements:
+  - ``CloudTraceObservabilityHook``  — ObservabilityHook over OTel / Cloud Trace
+  - ``CloudMonitoringMetricsHook``   — StageMetricsHook over Cloud Monitoring
+  - ``DataCatalogLineageEmitter``    — LineageEmitter over Data Catalog tags
+  - ``CulvertMdcPopulator``          — structured-log correlation (MDC bridge)
+
+Java siblings live in
+``data-pipeline-libraries-java/data-pipeline-gcp-observability-java/``.
+
+Auto-registration
+-----------------
+Entry-points in ``pyproject.toml`` under
+``[project.entry-points."data_pipeline_core.adapters"]`` expose three keys:
+
+  observability = "data_pipeline_gcp_observability:CloudTraceObservabilityHook"
+  stage_metrics = "data_pipeline_gcp_observability:CloudMonitoringMetricsHook"
+  lineage       = "data_pipeline_gcp_observability:DataCatalogLineageEmitter"
+
+``AutoConfig.discover()`` from ``data-pipeline-core`` will find them after
+``pip install -e data-pipeline-gcp-observability``.
+
+Sprint-19 / T19.2 — issue #125.
+"""
+
+from __future__ import annotations
+
+from data_pipeline_gcp_observability.cloud_monitoring_metrics_hook import (
+    CloudMonitoringMetricsHook,
+)
+from data_pipeline_gcp_observability.cloud_trace_observability_hook import (
+    CloudTraceObservabilityHook,
+)
+from data_pipeline_gcp_observability.culvert_mdc_populator import (
+    CulvertLoggerAdapter,
+    CulvertMdcPopulator,
+    stage_context,
+)
+from data_pipeline_gcp_observability.data_catalog_lineage_emitter import (
+    DataCatalogLineageEmitter,
+)
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "CloudTraceObservabilityHook",
+    "CloudMonitoringMetricsHook",
+    "DataCatalogLineageEmitter",
+    "CulvertMdcPopulator",
+    "CulvertLoggerAdapter",
+    "stage_context",
+]

--- a/data-pipeline-libraries/data-pipeline-gcp-observability/src/data_pipeline_gcp_observability/cloud_monitoring_metrics_hook.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-observability/src/data_pipeline_gcp_observability/cloud_monitoring_metrics_hook.py
@@ -1,0 +1,287 @@
+"""CloudMonitoringMetricsHook — StageMetricsHook backed by Cloud Monitoring.
+
+Java sibling:
+  data-pipeline-libraries-java/data-pipeline-gcp-observability-java/src/main/java/
+  com/enrichmeai/culvert/gcp/observability/CloudMonitoringMetricsHook.java
+
+Imports ``google.cloud.monitoring_v3`` lazily so that the module can be
+imported even when the SDK is not installed (offline / unit-test environments).
+Mock the ``MetricServiceClient`` in tests; never call the real API.
+
+Sprint-19 / T19.2 — issue #125.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+from data_pipeline_core.contracts.stage_metrics import StageMetrics
+
+logger = logging.getLogger(__name__)
+
+# Metric type constants — mirrors Java static constants (lines 97–106).
+METRIC_PREFIX = "custom.googleapis.com/culvert/"
+METRIC_ROWS_PROCESSED = METRIC_PREFIX + "rows_processed"
+METRIC_STAGE_LATENCY_MS = METRIC_PREFIX + "stage_latency_ms"
+METRIC_ERROR_COUNT = METRIC_PREFIX + "error_count"
+
+# Config key names — mirrors Java constants (lines 113–116).
+SYSPROP_GCP_PROJECT = "culvert.gcp.project"   # not applicable in Python (Java-ism)
+ENVVAR_GCP_PROJECT = "CULVERT_GCP_PROJECT"
+
+
+class CloudMonitoringMetricsHook:
+    """StageMetricsHook implementation that emits Culvert pipeline metrics to
+    Google Cloud Monitoring via the Monitoring v3 API.
+
+    Mirrors Java ``CloudMonitoringMetricsHook`` (line 92).
+
+    Metric schema (same as Java table, lines 38–53):
+      custom.googleapis.com/culvert/rows_processed   CUMULATIVE  INT64
+      custom.googleapis.com/culvert/stage_latency_ms GAUGE       DOUBLE
+      custom.googleapis.com/culvert/error_count      CUMULATIVE  INT64
+
+    Monitoring failures are swallowed (line 250–254 in Java) and the failure
+    count incremented; the pipeline is never interrupted.
+
+    Construction
+    ------------
+    - ``CloudMonitoringMetricsHook(client, project_id)`` — primary; inject a
+      pre-built ``MetricServiceClient`` (or mock) and an explicit project-id.
+      Mirrors Java (client, projectId) constructor (line 152).
+    - ``CloudMonitoringMetricsHook.default()`` — no-arg factory; resolves the
+      project-id from the precedence chain (env var → ADC) and builds the
+      client from ADC.  Mirrors Java no-arg constructor (line 140).
+
+    Lifecycle
+    ---------
+    Implements context-manager protocol (``__enter__``/``__exit__``) and
+    ``close()``.  Closing this hook closes the underlying client, mirroring
+    Java ``AutoCloseable.close()`` (line 272).
+    """
+
+    def __init__(self, client: Any, project_id: str) -> None:
+        """Inject a pre-built MetricServiceClient and GCP project-id.
+
+        Args:
+            client:     MetricServiceClient (real or mock).  Required.
+            project_id: GCP project ID metrics are written to.  Required.
+
+        Raises:
+            TypeError: if either argument is None.
+        """
+        if client is None:
+            raise TypeError("client must not be None")
+        if project_id is None:
+            raise TypeError("project_id must not be None")
+        self._client = client
+        self._project_id = project_id
+        self._monitoring_failures = 0
+
+    @classmethod
+    def default(cls) -> "CloudMonitoringMetricsHook":
+        """Build from ADC and environment — mirrors Java no-arg ctor (line 140).
+
+        Project-id resolution (mirrors Java resolveProjectId, line 167):
+          1. Environment variable ``CULVERT_GCP_PROJECT``
+          2. ADC default via ``google.cloud.ServiceOptions`` — not available in
+             Python; instead reads ``GCLOUD_PROJECT`` / ``GOOGLE_CLOUD_PROJECT``
+             environment variables that the GCP Python SDK uses.
+          3. Raises ``RuntimeError`` if no project-id is resolvable.
+
+        Raises:
+            RuntimeError: if no GCP project-id can be resolved.
+            ImportError:  if ``google-cloud-monitoring`` is not installed.
+        """
+        project_id = cls._resolve_project_id()
+        try:
+            from google.cloud import monitoring_v3  # type: ignore[import]
+        except ImportError as exc:  # pragma: no cover
+            raise ImportError(
+                "google-cloud-monitoring is required for CloudMonitoringMetricsHook.default(). "
+                "Install it with: pip install google-cloud-monitoring"
+            ) from exc
+        client = monitoring_v3.MetricServiceClient()
+        return cls(client, project_id)
+
+    @classmethod
+    def _resolve_project_id(cls) -> str:
+        """Resolve the GCP project-id — mirrors Java resolveProjectId (line 167)."""
+        from_env = os.environ.get(ENVVAR_GCP_PROJECT, "").strip()
+        if from_env:
+            return from_env
+        # Python GCP SDK reads these env vars for the default project.
+        for key in ("GCLOUD_PROJECT", "GOOGLE_CLOUD_PROJECT"):
+            val = os.environ.get(key, "").strip()
+            if val:
+                return val
+        raise RuntimeError(
+            f"Cannot resolve GCP project-id for CloudMonitoringMetricsHook. "
+            f"Set one of: env var '{ENVVAR_GCP_PROJECT}', 'GCLOUD_PROJECT', "
+            f"or 'GOOGLE_CLOUD_PROJECT'."
+        )
+
+    # ------------------------------------------------------------------
+    # StageMetricsHook Protocol
+    # ------------------------------------------------------------------
+
+    def record_stage_metrics(self, metrics: StageMetrics) -> None:
+        """Emit all three Culvert metrics for a completed stage.
+
+        Mirrors Java ``recordStageMetrics`` (line 222).
+
+        Monitoring failures are swallowed — the pipeline continues
+        uninterrupted (Java lines 250–255).
+
+        Args:
+            metrics: Stage metrics snapshot.  Must not be None.
+
+        Raises:
+            TypeError: if ``metrics`` is None.
+        """
+        if metrics is None:
+            raise TypeError("metrics must not be None")
+
+        try:
+            self._emit(metrics)
+        except Exception:  # noqa: BLE001
+            self._monitoring_failures += 1
+            logger.warning(
+                "CloudMonitoringMetricsHook: failed to write metrics for "
+                "pipeline=%s run=%s stage=%s; monitoring error swallowed",
+                metrics.pipeline_id,
+                metrics.run_id,
+                metrics.stage_name,
+                exc_info=True,
+            )
+
+    def _emit(self, metrics: StageMetrics) -> None:
+        """Build and send a CreateTimeSeries request.
+
+        Lazily imports the Cloud Monitoring proto types so the class can be
+        instantiated with a mock client even when the SDK is not installed.
+        """
+        try:
+            from google.cloud import monitoring_v3  # type: ignore[import]
+            import datetime
+        except ImportError as exc:  # pragma: no cover
+            raise RuntimeError(
+                "google-cloud-monitoring is required for real metric emission."
+            ) from exc
+
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
+        start = now - datetime.timedelta(milliseconds=metrics.stage_latency_ms)
+
+        end_ts = monitoring_v3.TimeInterval(
+            end_time=now
+        )
+        start_end_ts = monitoring_v3.TimeInterval(
+            start_time=start,
+            end_time=now,
+        )
+
+        labels = {
+            "pipeline_id": metrics.pipeline_id,
+            "run_id": metrics.run_id,
+            "stage_name": metrics.stage_name,
+        }
+
+        series = [
+            self._cumulative_int64_series(
+                METRIC_ROWS_PROCESSED, labels, start_end_ts, metrics.rows_processed
+            ),
+            self._gauge_double_series(
+                METRIC_STAGE_LATENCY_MS, labels, end_ts, metrics.stage_latency_ms
+            ),
+            self._cumulative_int64_series(
+                METRIC_ERROR_COUNT, labels, start_end_ts, metrics.error_count
+            ),
+        ]
+
+        project_name = f"projects/{self._project_id}"
+        self._client.create_time_series(
+            request={
+                "name": project_name,
+                "time_series": series,
+            }
+        )
+
+    @staticmethod
+    def _cumulative_int64_series(
+        metric_type: str,
+        labels: dict,
+        interval: Any,
+        value: int,
+    ) -> Any:
+        """Build a CUMULATIVE INT64 TimeSeries — mirrors Java buildCumulativeInt64 (line 278)."""
+        from google.api import metric_pb2, monitored_resource_pb2  # type: ignore[import]
+        from google.cloud import monitoring_v3  # type: ignore[import]
+        from google.api import metric_pb2 as ga_metric  # type: ignore[import]
+
+        series = monitoring_v3.TimeSeries()
+        series.metric.type = metric_type
+        for k, v in labels.items():
+            series.metric.labels[k] = v
+        series.resource.type = "global"
+        series.metric_kind = monitoring_v3.MetricDescriptor.MetricKind.CUMULATIVE
+        series.value_type = monitoring_v3.MetricDescriptor.ValueType.INT64
+
+        point = monitoring_v3.Point(
+            interval=interval,
+            value=monitoring_v3.TypedValue(int64_value=value),
+        )
+        series.points = [point]
+        return series
+
+    @staticmethod
+    def _gauge_double_series(
+        metric_type: str,
+        labels: dict,
+        interval: Any,
+        value: float,
+    ) -> Any:
+        """Build a GAUGE DOUBLE TimeSeries — mirrors Java buildGaugeDouble (line 305)."""
+        from google.cloud import monitoring_v3  # type: ignore[import]
+
+        series = monitoring_v3.TimeSeries()
+        series.metric.type = metric_type
+        for k, v in labels.items():
+            series.metric.labels[k] = v
+        series.resource.type = "global"
+        series.metric_kind = monitoring_v3.MetricDescriptor.MetricKind.GAUGE
+        series.value_type = monitoring_v3.MetricDescriptor.ValueType.DOUBLE
+
+        point = monitoring_v3.Point(
+            interval=interval,
+            value=monitoring_v3.TypedValue(double_value=value),
+        )
+        series.points = [point]
+        return series
+
+    # ------------------------------------------------------------------
+    # Accessors / lifecycle
+    # ------------------------------------------------------------------
+
+    @property
+    def project_id(self) -> str:
+        """GCP project ID metrics are written to — mirrors Java projectId() (line 268)."""
+        return self._project_id
+
+    def monitoring_failure_count(self) -> int:
+        """Cumulative monitoring write failures — mirrors Java monitoringFailureCount() (line 262)."""
+        return self._monitoring_failures
+
+    def close(self) -> None:
+        """Close the underlying MetricServiceClient — mirrors Java close() (line 272)."""
+        try:
+            self._client.close()
+        except Exception:  # noqa: BLE001
+            pass
+
+    def __enter__(self) -> "CloudMonitoringMetricsHook":
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        self.close()

--- a/data-pipeline-libraries/data-pipeline-gcp-observability/src/data_pipeline_gcp_observability/cloud_trace_observability_hook.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-observability/src/data_pipeline_gcp_observability/cloud_trace_observability_hook.py
@@ -1,0 +1,236 @@
+"""CloudTraceObservabilityHook — ObservabilityHook backed by OpenTelemetry.
+
+Java sibling:
+  data-pipeline-libraries-java/data-pipeline-gcp-observability-java/src/main/java/
+  com/enrichmeai/culvert/gcp/observability/CloudTraceObservabilityHook.java
+
+The OTel SDK and exporter are injected by the caller; this class only wraps
+them as the Culvert ObservabilityHook Protocol surface.  All SDK imports are
+performed lazily so the module can be imported even when the OTel SDK is not
+installed (e.g. in unit test environments that only install mocks).
+
+Sprint-19 / T19.2 — issue #125.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from typing import Any, Generator, Mapping
+
+logger = logging.getLogger(__name__)
+
+# Sentinel for empty tag mappings — avoids dict construction on every call.
+_NO_TAGS: Mapping[str, str] = {}
+
+
+class CloudTraceObservabilityHook:
+    """ObservabilityHook implementation backed by OpenTelemetry.
+
+    Mirrors Java ``CloudTraceObservabilityHook`` (file line 71).
+
+    Callers construct an OpenTelemetry instance whose tracer / meter providers
+    export to Google Cloud Trace / Cloud Monitoring and pass it here.  This
+    class only wraps the resulting tracer and meter and bridges them to the
+    Culvert ``ObservabilityHook`` Protocol.
+
+    Construction
+    ------------
+    - ``CloudTraceObservabilityHook(tracer, meter)`` — primary; inject
+      already-resolved tracer and meter (OTel SDK objects or mocks).
+    - ``CloudTraceObservabilityHook.from_otel(otel, scope)`` — convenience
+      class-method; mirrors Java ``(OpenTelemetry, String)`` constructor
+      (line 127).  Requires the OTel SDK to be installed.
+    - ``CloudTraceObservabilityHook()`` — no-arg; wraps the OTel global SDK
+      (mirrors Java no-arg ctor, line 113).  Requires the OTel SDK.
+
+    The no-arg and ``from_otel`` paths perform lazy SDK imports so that the
+    class can be imported even when the SDK is absent.
+
+    Instrument caches (counters, histograms) are ``dict``-backed; OTel
+    instruments are keyed by name so re-registration is avoided, mirroring
+    Java ``ConcurrentHashMap`` caches (line 91–93).
+    """
+
+    DEFAULT_INSTRUMENTATION_SCOPE = "com.enrichmeai.culvert"
+
+    def __init__(self, tracer: Any, meter: Any) -> None:
+        """Inject an already-resolved OTel tracer and meter.
+
+        Both are required.  Pass ``MagicMock()`` instances in tests.
+
+        Args:
+            tracer: OTel Tracer (or mock).
+            meter:  OTel Meter (or mock).
+
+        Raises:
+            TypeError: if either argument is None.
+        """
+        if tracer is None:
+            raise TypeError("tracer must not be None")
+        if meter is None:
+            raise TypeError("meter must not be None")
+        self._tracer = tracer
+        self._meter = meter
+        self._counters: dict[str, Any] = {}
+        self._histograms: dict[str, Any] = {}
+        self._gauges: dict[str, Any] = {}
+
+    @classmethod
+    def from_otel(cls, otel: Any, scope: str) -> "CloudTraceObservabilityHook":
+        """Build from an ``OpenTelemetry`` instance and an instrumentation scope.
+
+        Mirrors Java primary constructor (line 127).
+
+        Args:
+            otel:  Configured OpenTelemetry instance.
+            scope: Instrumentation scope name (typically the pipeline name).
+
+        Raises:
+            TypeError:     if either argument is None.
+            ImportError:   if ``opentelemetry-api`` is not installed.
+        """
+        if otel is None:
+            raise TypeError("otel must not be None")
+        if scope is None:
+            raise TypeError("scope must not be None")
+        return cls(otel.get_tracer(scope), otel.get_meter(scope))
+
+    @classmethod
+    def default(cls) -> "CloudTraceObservabilityHook":
+        """Build from the OTel global SDK.
+
+        Mirrors Java no-arg constructor (line 113).
+
+        Raises:
+            ImportError: if ``opentelemetry-api`` is not installed.
+        """
+        try:
+            from opentelemetry import trace, metrics  # type: ignore[import]
+        except ImportError as exc:  # pragma: no cover
+            raise ImportError(
+                "opentelemetry-api is required for CloudTraceObservabilityHook.default(). "
+                "Install it with: pip install opentelemetry-api"
+            ) from exc
+        tracer = trace.get_tracer(cls.DEFAULT_INSTRUMENTATION_SCOPE)
+        meter = metrics.get_meter(cls.DEFAULT_INSTRUMENTATION_SCOPE)
+        return cls(tracer, meter)
+
+    # ------------------------------------------------------------------
+    # ObservabilityHook Protocol
+    # ------------------------------------------------------------------
+
+    def counter(
+        self,
+        name: str,
+        value: int = 1,
+        tags: Mapping[str, str] = _NO_TAGS,
+    ) -> None:
+        """Increment a monotonic counter — mirrors Java counter() (line 146)."""
+        if name is None:
+            raise TypeError("name must not be None")
+        instrument = self._counters.get(name)
+        if instrument is None:
+            instrument = self._meter.create_counter(name)
+            self._counters[name] = instrument
+        instrument.add(value, self._to_attributes(tags))
+
+    def gauge(
+        self,
+        name: str,
+        value: float,
+        tags: Mapping[str, str] = _NO_TAGS,
+    ) -> None:
+        """Record a gauge value — mirrors Java gauge() (line 153)."""
+        if name is None:
+            raise TypeError("name must not be None")
+        instrument = self._gauges.get(name)
+        if instrument is None:
+            # Use histogram as a gauge proxy (mirrors Java comment, line 158).
+            instrument = self._meter.create_histogram(name)
+            self._gauges[name] = instrument
+        instrument.record(value, self._to_attributes(tags))
+
+    def histogram(
+        self,
+        name: str,
+        value: float,
+        tags: Mapping[str, str] = _NO_TAGS,
+    ) -> None:
+        """Record a histogram observation — mirrors Java histogram() (line 166)."""
+        if name is None:
+            raise TypeError("name must not be None")
+        instrument = self._histograms.get(name)
+        if instrument is None:
+            instrument = self._meter.create_histogram(name)
+            self._histograms[name] = instrument
+        instrument.record(value, self._to_attributes(tags))
+
+    def log(self, level: str, message: str, **fields: Any) -> None:
+        """Structured log — mirrors Java log() (line 174).
+
+        ``level`` is mapped to the stdlib logging level (DEBUG/INFO/WARNING/ERROR).
+        ``**fields`` are appended as ``key=value`` pairs on the log message,
+        mirroring the Java ``renderFields`` helper (line 211).
+        """
+        if level is None:
+            raise TypeError("level must not be None")
+        if message is None:
+            raise TypeError("message must not be None")
+        rendered = self._render_fields(message, fields)
+        upper = level.upper()
+        if upper == "DEBUG":
+            logger.debug(rendered)
+        elif upper in ("WARNING", "WARN"):
+            logger.warning(rendered)
+        elif upper == "ERROR":
+            logger.error(rendered)
+        elif upper == "CRITICAL":
+            logger.critical(rendered)
+        else:
+            logger.info(rendered)
+
+    @contextmanager
+    def span(self, name: str) -> Generator[Any, None, None]:
+        """Open a tracing span — mirrors Java span() + OtelSpanAdapter (line 189, 234).
+
+        Uses the injected tracer.  If the tracer is a mock the context manager
+        still works because we guard every OTel call.
+
+        Yields the underlying span object (or mock).
+        """
+        if name is None:
+            raise TypeError("name must not be None")
+        otel_span = self._tracer.start_span(name)
+        try:
+            yield otel_span
+        except Exception as exc:
+            try:
+                otel_span.record_exception(exc)
+            except Exception:  # noqa: BLE001
+                pass
+            raise
+        finally:
+            try:
+                otel_span.end()
+            except Exception:  # noqa: BLE001
+                pass
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _to_attributes(tags: Mapping[str, str]) -> dict[str, str]:
+        """Convert a tags mapping to a plain dict (OTel attribute map)."""
+        if not tags:
+            return {}
+        return {k: v for k, v in tags.items() if k is not None and v is not None}
+
+    @staticmethod
+    def _render_fields(message: str, fields: dict[str, Any]) -> str:
+        """Append ``key=value`` pairs to ``message`` — mirrors Java renderFields (line 211)."""
+        if not fields:
+            return message
+        parts = " ".join(f"{k}={v}" for k, v in fields.items())
+        return f"{message} {parts}"

--- a/data-pipeline-libraries/data-pipeline-gcp-observability/src/data_pipeline_gcp_observability/culvert_mdc_populator.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-observability/src/data_pipeline_gcp_observability/culvert_mdc_populator.py
@@ -1,0 +1,186 @@
+"""CulvertMdcPopulator — structured-logging context helper.
+
+Java sibling:
+  data-pipeline-libraries-java/data-pipeline-gcp-observability-java/src/main/java/
+  com/enrichmeai/culvert/gcp/observability/CulvertMdcPopulator.java
+
+Python has no SLF4J MDC, but the ``logging`` module supports ``LoggerAdapter``
+and thread-local ``extra`` dicts.  This module provides a context manager
+that temporarily injects Culvert pipeline context into a
+``threading.local``-backed store so that log formatters, ``LogRecordFactory``
+overrides, or ``LoggerAdapter``-based code can read them.
+
+The three MDC keys are identical to the Java constants (lines 47–53).
+
+Sprint-19 / T19.2 — issue #125.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import threading
+from typing import Any, Callable, Generator, TypeVar
+
+logger = logging.getLogger(__name__)
+
+# ------------------------------------------------------------------
+# MDC key constants — mirrors Java (lines 47–53).
+# ------------------------------------------------------------------
+
+RUN_ID_KEY = "run_id"
+STAGE_NAME_KEY = "stage_name"
+PIPELINE_ID_KEY = "pipeline_id"
+
+# Thread-local MDC store.
+_local = threading.local()
+
+T = TypeVar("T")
+
+
+def _get_mdc() -> dict[str, str]:
+    """Return (or lazily create) the thread-local MDC dict."""
+    if not hasattr(_local, "mdc"):
+        _local.mdc = {}
+    return _local.mdc  # type: ignore[return-value]
+
+
+def put(key: str, value: str) -> None:
+    """Write ``key`` → ``value`` into the current thread's MDC."""
+    _get_mdc()[key] = value
+
+
+def remove(key: str) -> None:
+    """Remove ``key`` from the current thread's MDC (no-op if absent)."""
+    _get_mdc().pop(key, None)
+
+
+def get(key: str) -> str | None:
+    """Read ``key`` from the current thread's MDC (None if absent)."""
+    return _get_mdc().get(key)
+
+
+def clear() -> None:
+    """Clear the entire MDC for the current thread."""
+    _get_mdc().clear()
+
+
+@contextlib.contextmanager
+def stage_context(
+    run_id: str,
+    stage_name: str,
+    pipeline_id: str,
+) -> Generator[None, None, None]:
+    """Context manager that populates the three Culvert MDC keys.
+
+    Mirrors Java ``CulvertMdcPopulator.withStageContext`` (line 77 and line 112).
+
+    The MDC keys are always cleared in the ``finally`` block so a raising body
+    leaves no stale context on the thread.
+
+    Usage::
+
+        with stage_context(run_id, stage_name, pipeline_id):
+            logger.info("reading records")   # MDC fields are populated here
+
+    Args:
+        run_id:      Pipeline run identifier.  Must not be None.
+        stage_name:  Name of the executing stage.  Must not be None.
+        pipeline_id: Pipeline identifier.  Must not be None.
+
+    Raises:
+        TypeError: if any argument is None.
+    """
+    if run_id is None:
+        raise TypeError("run_id must not be None")
+    if stage_name is None:
+        raise TypeError("stage_name must not be None")
+    if pipeline_id is None:
+        raise TypeError("pipeline_id must not be None")
+
+    put(RUN_ID_KEY, run_id)
+    put(STAGE_NAME_KEY, stage_name)
+    put(PIPELINE_ID_KEY, pipeline_id)
+    try:
+        yield
+    finally:
+        remove(RUN_ID_KEY)
+        remove(STAGE_NAME_KEY)
+        remove(PIPELINE_ID_KEY)
+
+
+class CulvertMdcPopulator:
+    """Utility class providing static/class methods for MDC population.
+
+    Mirrors the Java utility class ``CulvertMdcPopulator`` (line 44).
+    Python convention: prefer the module-level ``stage_context`` context
+    manager; this class exists for API symmetry with the Java sibling.
+
+    All instances are disallowed (mirrors Java UnsupportedOperationException
+    in the private constructor, line 57).
+    """
+
+    def __init__(self) -> None:
+        raise TypeError("CulvertMdcPopulator is a utility class — do not instantiate it")
+
+    # MDC key constants as class attributes (mirrors Java, lines 47–53).
+    RUN_ID_KEY = RUN_ID_KEY
+    STAGE_NAME_KEY = STAGE_NAME_KEY
+    PIPELINE_ID_KEY = PIPELINE_ID_KEY
+
+    @staticmethod
+    def with_stage_context(
+        run_id: str,
+        stage_name: str,
+        pipeline_id: str,
+        body: Callable[[], T],
+    ) -> T:
+        """Execute ``body`` with the three Culvert MDC keys populated.
+
+        Mirrors Java ``withStageContext(String, String, String, Supplier<T>)``
+        (line 77).
+
+        Args:
+            run_id:      Pipeline run identifier.  Must not be None.
+            stage_name:  Name of the executing stage.  Must not be None.
+            pipeline_id: Pipeline identifier.  Must not be None.
+            body:        Zero-argument callable whose return value is returned.
+
+        Returns:
+            The value returned by ``body``.
+
+        Raises:
+            TypeError: if any argument is None.
+        """
+        if body is None:
+            raise TypeError("body must not be None")
+        with stage_context(run_id, stage_name, pipeline_id):
+            return body()
+
+    # Expose the module-level context manager as a class-level convenience.
+    stage_context = staticmethod(stage_context)
+
+
+# ------------------------------------------------------------------
+# LoggerAdapter integration — optional helper
+# ------------------------------------------------------------------
+
+class CulvertLoggerAdapter(logging.LoggerAdapter):
+    """LoggerAdapter that injects the current thread's MDC into every log record.
+
+    Usage::
+
+        log = CulvertLoggerAdapter(logging.getLogger(__name__), {})
+        with stage_context(run_id, stage_name, pipeline_id):
+            log.info("processing")   # record.extra includes MDC keys
+
+    The ``extra`` dict supplied at construction is merged with the live MDC
+    on every call, so log records carry ``run_id``, ``stage_name``, and
+    ``pipeline_id`` as first-class ``LogRecord`` attributes.
+    """
+
+    def process(self, msg: Any, kwargs: Any) -> tuple[Any, Any]:
+        extra = dict(self.extra or {})
+        extra.update(_get_mdc())
+        kwargs["extra"] = extra
+        return msg, kwargs

--- a/data-pipeline-libraries/data-pipeline-gcp-observability/src/data_pipeline_gcp_observability/data_catalog_lineage_emitter.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-observability/src/data_pipeline_gcp_observability/data_catalog_lineage_emitter.py
@@ -1,0 +1,189 @@
+"""DataCatalogLineageEmitter — LineageEmitter backed by Google Data Catalog.
+
+Java sibling:
+  data-pipeline-libraries-java/data-pipeline-gcp-observability-java/src/main/java/
+  com/enrichmeai/culvert/gcp/observability/DataCatalogLineageEmitter.java
+
+Imports ``google.cloud.datacatalog_v1`` lazily so the module can be imported
+offline / in unit-test environments.  Pass a mock ``DataCatalogClient`` in
+tests; never call the real API.
+
+Sprint-19 / T19.2 — issue #125.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from data_pipeline_core.lineage.events import LineageEvent
+
+logger = logging.getLogger(__name__)
+
+
+class DataCatalogLineageEmitter:
+    """LineageEmitter that writes lineage events as Data Catalog tags.
+
+    Mirrors Java ``DataCatalogLineageEmitter`` (line 55).
+
+    Each ``LineageEvent`` becomes one tag attached to the configured Data
+    Catalog entry.  The tag's fields mirror the four sub-dicts of
+    ``LineageEvent`` (source, pipeline, destination, audit), flattened to
+    scalar string values — mirrors Java ``flatten()`` helper (line 137).
+
+    Construction
+    ------------
+    - ``DataCatalogLineageEmitter(client, entry_name, tag_template)``
+      Primary.  Mirrors Java constructor (line 77).  Caller owns the
+      credential lifecycle; pass a ``MagicMock()`` for the client in tests.
+
+    Lifecycle
+    ---------
+    Implements context-manager protocol and ``close()``.  Mirrors Java
+    ``AutoCloseable.close()`` (line 128).
+    """
+
+    def __init__(self, client: Any, entry_name: str, tag_template: str) -> None:
+        """Inject a pre-built DataCatalogClient and entry / template identifiers.
+
+        Args:
+            client:       DataCatalogClient (real or mock).  Required.
+            entry_name:   Fully-qualified Data Catalog entry name
+                          (``projects/{p}/locations/{l}/entryGroups/{g}/entries/{e}``).
+                          Required.
+            tag_template: Fully-qualified tag template name
+                          (``projects/{p}/locations/{l}/tagTemplates/{t}``).
+                          Required.
+
+        Raises:
+            TypeError: if any argument is None.
+        """
+        if client is None:
+            raise TypeError("client must not be None")
+        if entry_name is None:
+            raise TypeError("entry_name must not be None")
+        if tag_template is None:
+            raise TypeError("tag_template must not be None")
+        self._client = client
+        self._entry_name = entry_name
+        self._tag_template = tag_template
+
+    # ------------------------------------------------------------------
+    # LineageEmitter Protocol
+    # ------------------------------------------------------------------
+
+    def emit(self, event: LineageEvent) -> None:
+        """Emit one lineage event as a Data Catalog tag — mirrors Java emit() (line 95).
+
+        The event's sub-dicts are flattened to scalar string fields and written
+        as a Data Catalog tag on ``entry_name`` using ``tag_template``.
+
+        If the underlying Data Catalog call raises, the exception propagates to
+        the caller (mirrors Java — exceptions are not swallowed here, unlike
+        ``StageMetricsHook``).
+
+        Args:
+            event: The lineage event to emit.  Must not be None.
+
+        Raises:
+            TypeError: if ``event`` is None.
+        """
+        if event is None:
+            raise TypeError("event must not be None")
+
+        fields = self._flatten(event)
+
+        # Lazy import — avoids hard dependency at module import time.
+        try:
+            from google.cloud import datacatalog_v1  # type: ignore[import]
+        except ImportError as exc:  # pragma: no cover
+            raise ImportError(
+                "google-cloud-datacatalog is required for DataCatalogLineageEmitter.emit(). "
+                "Install it with: pip install google-cloud-datacatalog"
+            ) from exc
+
+        tag = datacatalog_v1.Tag(template=self._tag_template)
+        for field_name, str_value in fields.items():
+            tag.fields[field_name] = datacatalog_v1.TagField(
+                string_value=str_value
+            )
+
+        request = datacatalog_v1.CreateTagRequest(
+            parent=self._entry_name,
+            tag=tag,
+        )
+        self._client.create_tag(request=request)
+        logger.debug("emitted lineage tag for entry %s", self._entry_name)
+
+    # ------------------------------------------------------------------
+    # Accessors / lifecycle
+    # ------------------------------------------------------------------
+
+    @property
+    def entry_name(self) -> str:
+        """Data Catalog entry name lineage tags are attached to — mirrors Java entryName() (line 117)."""
+        return self._entry_name
+
+    @property
+    def tag_template(self) -> str:
+        """Tag template the emitted tags reference — mirrors Java tagTemplate() (line 122)."""
+        return self._tag_template
+
+    def close(self) -> None:
+        """Close the underlying DataCatalogClient — mirrors Java close() (line 128)."""
+        try:
+            self._client.close()
+        except Exception:  # noqa: BLE001
+            pass
+
+    def __enter__(self) -> "DataCatalogLineageEmitter":
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        self.close()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _flatten(event: LineageEvent) -> dict[str, str]:
+        """Flatten a LineageEvent into scalar string fields.
+
+        Mirrors Java ``flatten()`` helper (line 137).  ``total=False``
+        TypedDicts mean sub-dicts may be absent; absent keys are skipped.
+        """
+        out: dict[str, str] = {}
+
+        source = event.get("source")
+        if source:
+            if "type" in source:
+                out["source_type"] = str(source["type"])
+            if "uri" in source:
+                out["source_uri"] = str(source["uri"])
+
+        pipeline = event.get("pipeline")
+        if pipeline:
+            if "run_id" in pipeline:
+                out["run_id"] = str(pipeline["run_id"])
+            if "pipeline_name" in pipeline:
+                out["pipeline_name"] = str(pipeline["pipeline_name"])
+            if "stage" in pipeline:
+                out["stage"] = str(pipeline["stage"])
+            if "started_at" in pipeline:
+                out["started_at"] = str(pipeline["started_at"])
+            if "completed_at" in pipeline:
+                out["completed_at"] = str(pipeline["completed_at"])
+
+        destination = event.get("destination")
+        if destination:
+            if "type" in destination:
+                out["destination_type"] = str(destination["type"])
+            if "uri" in destination:
+                out["destination_uri"] = str(destination["uri"])
+
+        audit = event.get("audit")
+        if audit:
+            out["audit"] = str(audit)
+
+        return out

--- a/data-pipeline-libraries/data-pipeline-gcp-observability/tests/test_autoconfig_discovery.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-observability/tests/test_autoconfig_discovery.py
@@ -1,0 +1,56 @@
+"""AutoConfig.discover() integration tests.
+
+Verifies that the three entry-points declared in pyproject.toml are loaded
+by ``AutoConfig.discover()`` when the package is installed (editable mode).
+
+These tests exercise the actual entry-point machinery via
+``importlib.metadata.entry_points``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from data_pipeline_core.autoconfig import discover
+from data_pipeline_gcp_observability import (
+    CloudTraceObservabilityHook,
+    CloudMonitoringMetricsHook,
+    DataCatalogLineageEmitter,
+)
+
+
+class TestAutoconfigDiscovery:
+    """AutoConfig.discover() must find all three adapters."""
+
+    def test_observability_adapter_registered(self):
+        config = discover()
+        assert CloudTraceObservabilityHook in config.observability, (
+            f"CloudTraceObservabilityHook not found in AutoConfig.observability; "
+            f"found: {config.observability}"
+        )
+
+    def test_stage_metrics_adapter_registered(self):
+        config = discover()
+        assert CloudMonitoringMetricsHook in config.stage_metrics, (
+            f"CloudMonitoringMetricsHook not found in AutoConfig.stage_metrics; "
+            f"found: {config.stage_metrics}"
+        )
+
+    def test_lineage_adapter_registered(self):
+        config = discover()
+        assert DataCatalogLineageEmitter in config.lineage, (
+            f"DataCatalogLineageEmitter not found in AutoConfig.lineage; "
+            f"found: {config.lineage}"
+        )
+
+    def test_all_three_adapters_in_single_discover_call(self):
+        config = discover()
+        assert CloudTraceObservabilityHook in config.observability
+        assert CloudMonitoringMetricsHook in config.stage_metrics
+        assert DataCatalogLineageEmitter in config.lineage
+
+    def test_discover_returns_autoconfig_with_first_method(self):
+        config = discover()
+        assert config.first("observability") is CloudTraceObservabilityHook
+        assert config.first("stage_metrics") is CloudMonitoringMetricsHook
+        assert config.first("lineage") is DataCatalogLineageEmitter

--- a/data-pipeline-libraries/data-pipeline-gcp-observability/tests/test_cloud_monitoring_metrics_hook.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-observability/tests/test_cloud_monitoring_metrics_hook.py
@@ -1,0 +1,205 @@
+"""Tests for CloudMonitoringMetricsHook — Cloud Monitoring client is mocked.
+
+Binds StageMetricsHookContract to CloudMonitoringMetricsHook.
+"""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from data_pipeline_contract_tests import StageMetricsHookContract
+from data_pipeline_core.contracts.stage_metrics import StageMetrics
+from data_pipeline_gcp_observability import CloudMonitoringMetricsHook
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_hook(project_id: str = "test-project", side_effect=None):
+    """Return a CloudMonitoringMetricsHook with a mocked client."""
+    client = MagicMock()
+    if side_effect is not None:
+        client.create_time_series.side_effect = side_effect
+    return CloudMonitoringMetricsHook(client, project_id)
+
+
+def _valid_metrics(**overrides) -> StageMetrics:
+    defaults = dict(
+        pipeline_id="pipe-1",
+        run_id="run-abc",
+        stage_name="stage-x",
+        rows_processed=100,
+        stage_latency_ms=42.5,
+        error_count=0,
+    )
+    defaults.update(overrides)
+    return StageMetrics(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Contract tests — bind StageMetricsHookContract to CloudMonitoringMetricsHook
+# ---------------------------------------------------------------------------
+
+class TestCloudMonitoringMetricsHookContract(StageMetricsHookContract):
+    """Exercise every StageMetricsHookContract guarantee against a mocked client.
+
+    The mixin requires two fixtures: ``hook`` (happy-path) and
+    ``failing_hook`` (backend raises on every call).
+    """
+
+    @pytest.fixture
+    def hook(self):
+        """Happy-path hook — client.create_time_series is a no-op mock."""
+        # We mock out the _emit method entirely since it requires
+        # google-cloud-monitoring proto types to be installed.
+        h = _make_hook()
+        # Patch _emit to be a no-op so the test doesn't need the real SDK.
+        h._emit = MagicMock()
+        return h
+
+    @pytest.fixture
+    def failing_hook(self):
+        """Hook whose backend raises on every record_stage_metrics call."""
+        h = _make_hook()
+        h._emit = MagicMock(side_effect=RuntimeError("backend down"))
+        return h
+
+
+# ---------------------------------------------------------------------------
+# Constructor
+# ---------------------------------------------------------------------------
+
+class TestConstructor:
+    def test_rejects_none_client(self):
+        with pytest.raises(TypeError):
+            CloudMonitoringMetricsHook(None, "proj")
+
+    def test_rejects_none_project_id(self):
+        with pytest.raises(TypeError):
+            CloudMonitoringMetricsHook(MagicMock(), None)
+
+    def test_accepts_valid_args(self):
+        h = _make_hook()
+        assert h.project_id == "test-project"
+
+    def test_monitoring_failure_count_starts_at_zero(self):
+        h = _make_hook()
+        assert h.monitoring_failure_count() == 0
+
+
+# ---------------------------------------------------------------------------
+# record_stage_metrics()
+# ---------------------------------------------------------------------------
+
+class TestRecordStageMetrics:
+    def test_rejects_none_metrics(self):
+        h = _make_hook()
+        with pytest.raises(TypeError):
+            h.record_stage_metrics(None)
+
+    def test_happy_path_no_raise(self):
+        h = _make_hook()
+        h._emit = MagicMock()
+        h.record_stage_metrics(_valid_metrics())
+        h._emit.assert_called_once()
+
+    def test_backend_failure_swallowed_and_counted(self):
+        h = _make_hook()
+        h._emit = MagicMock(side_effect=RuntimeError("oops"))
+        # Must not raise
+        h.record_stage_metrics(_valid_metrics())
+        assert h.monitoring_failure_count() == 1
+
+    def test_multiple_failures_accumulate(self):
+        h = _make_hook()
+        h._emit = MagicMock(side_effect=RuntimeError("down"))
+        h.record_stage_metrics(_valid_metrics())
+        h.record_stage_metrics(_valid_metrics())
+        assert h.monitoring_failure_count() == 2
+
+    def test_emit_called_with_correct_metrics(self):
+        h = _make_hook()
+        h._emit = MagicMock()
+        m = _valid_metrics(pipeline_id="p1", run_id="r1", stage_name="s1")
+        h.record_stage_metrics(m)
+        h._emit.assert_called_once_with(m)
+
+
+# ---------------------------------------------------------------------------
+# Metric constants
+# ---------------------------------------------------------------------------
+
+class TestMetricConstants:
+    def test_metric_prefix(self):
+        from data_pipeline_gcp_observability.cloud_monitoring_metrics_hook import (
+            METRIC_PREFIX,
+            METRIC_ROWS_PROCESSED,
+            METRIC_STAGE_LATENCY_MS,
+            METRIC_ERROR_COUNT,
+        )
+        assert METRIC_PREFIX == "custom.googleapis.com/culvert/"
+        assert METRIC_ROWS_PROCESSED == "custom.googleapis.com/culvert/rows_processed"
+        assert METRIC_STAGE_LATENCY_MS == "custom.googleapis.com/culvert/stage_latency_ms"
+        assert METRIC_ERROR_COUNT == "custom.googleapis.com/culvert/error_count"
+
+
+# ---------------------------------------------------------------------------
+# Project-id resolution
+# ---------------------------------------------------------------------------
+
+class TestResolveProjectId:
+    def test_reads_culvert_env_var(self, monkeypatch):
+        monkeypatch.setenv("CULVERT_GCP_PROJECT", "my-proj")
+        assert CloudMonitoringMetricsHook._resolve_project_id() == "my-proj"
+
+    def test_reads_gcloud_project_env_var(self, monkeypatch):
+        monkeypatch.delenv("CULVERT_GCP_PROJECT", raising=False)
+        monkeypatch.setenv("GCLOUD_PROJECT", "gcloud-proj")
+        monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+        assert CloudMonitoringMetricsHook._resolve_project_id() == "gcloud-proj"
+
+    def test_reads_google_cloud_project_env_var(self, monkeypatch):
+        monkeypatch.delenv("CULVERT_GCP_PROJECT", raising=False)
+        monkeypatch.delenv("GCLOUD_PROJECT", raising=False)
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "gcp-proj")
+        assert CloudMonitoringMetricsHook._resolve_project_id() == "gcp-proj"
+
+    def test_raises_when_no_project_set(self, monkeypatch):
+        monkeypatch.delenv("CULVERT_GCP_PROJECT", raising=False)
+        monkeypatch.delenv("GCLOUD_PROJECT", raising=False)
+        monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+        with pytest.raises(RuntimeError, match="Cannot resolve GCP project-id"):
+            CloudMonitoringMetricsHook._resolve_project_id()
+
+    def test_culvert_env_takes_precedence(self, monkeypatch):
+        monkeypatch.setenv("CULVERT_GCP_PROJECT", "winner")
+        monkeypatch.setenv("GCLOUD_PROJECT", "loser")
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "also-loser")
+        assert CloudMonitoringMetricsHook._resolve_project_id() == "winner"
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle (close / context manager)
+# ---------------------------------------------------------------------------
+
+class TestLifecycle:
+    def test_close_closes_client(self):
+        client = MagicMock()
+        h = CloudMonitoringMetricsHook(client, "proj")
+        h.close()
+        client.close.assert_called_once()
+
+    def test_context_manager(self):
+        client = MagicMock()
+        with CloudMonitoringMetricsHook(client, "proj") as h:
+            assert h.project_id == "proj"
+        client.close.assert_called_once()
+
+    def test_close_tolerates_client_error(self):
+        client = MagicMock()
+        client.close.side_effect = RuntimeError("gone")
+        h = CloudMonitoringMetricsHook(client, "proj")
+        # Should not raise
+        h.close()

--- a/data-pipeline-libraries/data-pipeline-gcp-observability/tests/test_cloud_trace_observability_hook.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-observability/tests/test_cloud_trace_observability_hook.py
@@ -1,0 +1,240 @@
+"""Tests for CloudTraceObservabilityHook — GCP/OTel clients are mocked.
+
+All SDK imports are avoided; the hook is exercised with MagicMock tracer/meter.
+"""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from data_pipeline_gcp_observability import CloudTraceObservabilityHook
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_tracer():
+    tracer = MagicMock()
+    # start_span returns an object with .end() and .record_exception()
+    span = MagicMock()
+    tracer.start_span.return_value = span
+    return tracer
+
+
+@pytest.fixture
+def mock_meter():
+    meter = MagicMock()
+    counter = MagicMock()
+    histogram = MagicMock()
+    meter.create_counter.return_value = counter
+    meter.create_histogram.return_value = histogram
+    return meter
+
+
+@pytest.fixture
+def hook(mock_tracer, mock_meter):
+    return CloudTraceObservabilityHook(mock_tracer, mock_meter)
+
+
+# ---------------------------------------------------------------------------
+# Constructor
+# ---------------------------------------------------------------------------
+
+class TestConstructor:
+    def test_rejects_none_tracer(self, mock_meter):
+        with pytest.raises(TypeError):
+            CloudTraceObservabilityHook(None, mock_meter)
+
+    def test_rejects_none_meter(self, mock_tracer):
+        with pytest.raises(TypeError):
+            CloudTraceObservabilityHook(mock_tracer, None)
+
+    def test_accepts_valid_args(self, mock_tracer, mock_meter):
+        h = CloudTraceObservabilityHook(mock_tracer, mock_meter)
+        assert h is not None
+
+    def test_from_otel_rejects_none_otel(self):
+        with pytest.raises(TypeError):
+            CloudTraceObservabilityHook.from_otel(None, "scope")
+
+    def test_from_otel_rejects_none_scope(self):
+        otel = MagicMock()
+        with pytest.raises(TypeError):
+            CloudTraceObservabilityHook.from_otel(otel, None)
+
+    def test_from_otel_builds_hook(self):
+        otel = MagicMock()
+        h = CloudTraceObservabilityHook.from_otel(otel, "my-pipeline")
+        assert h is not None
+        otel.get_tracer.assert_called_once_with("my-pipeline")
+        otel.get_meter.assert_called_once_with("my-pipeline")
+
+    def test_default_scope_constant(self):
+        assert CloudTraceObservabilityHook.DEFAULT_INSTRUMENTATION_SCOPE == "com.enrichmeai.culvert"
+
+
+# ---------------------------------------------------------------------------
+# counter()
+# ---------------------------------------------------------------------------
+
+class TestCounter:
+    def test_counter_creates_instrument_and_adds(self, hook, mock_meter):
+        hook.counter("my.counter", 3, {"env": "test"})
+        mock_meter.create_counter.assert_called_once_with("my.counter")
+        counter_inst = mock_meter.create_counter.return_value
+        counter_inst.add.assert_called_once()
+        args = counter_inst.add.call_args
+        assert args[0][0] == 3
+
+    def test_counter_default_value(self, hook, mock_meter):
+        hook.counter("c")
+        counter_inst = mock_meter.create_counter.return_value
+        args = counter_inst.add.call_args
+        assert args[0][0] == 1
+
+    def test_counter_caches_instrument(self, hook, mock_meter):
+        hook.counter("c")
+        hook.counter("c")
+        mock_meter.create_counter.assert_called_once()
+
+    def test_counter_rejects_none_name(self, hook):
+        with pytest.raises(TypeError):
+            hook.counter(None)
+
+    def test_counter_empty_tags(self, hook, mock_meter):
+        hook.counter("c", tags={})
+        counter_inst = mock_meter.create_counter.return_value
+        _, kwargs = counter_inst.add.call_args
+        # tags kwarg may be positional; just check it was called
+        assert counter_inst.add.called
+
+
+# ---------------------------------------------------------------------------
+# gauge()
+# ---------------------------------------------------------------------------
+
+class TestGauge:
+    def test_gauge_records_via_histogram(self, hook, mock_meter):
+        hook.gauge("my.gauge", 42.5)
+        mock_meter.create_histogram.assert_called_with("my.gauge")
+        hist = mock_meter.create_histogram.return_value
+        hist.record.assert_called_once()
+        args = hist.record.call_args
+        assert args[0][0] == 42.5
+
+    def test_gauge_rejects_none_name(self, hook):
+        with pytest.raises(TypeError):
+            hook.gauge(None, 1.0)
+
+
+# ---------------------------------------------------------------------------
+# histogram()
+# ---------------------------------------------------------------------------
+
+class TestHistogram:
+    def test_histogram_records_value(self, hook, mock_meter):
+        hook.histogram("latency_ms", 99.0)
+        hist = mock_meter.create_histogram.return_value
+        hist.record.assert_called_once()
+
+    def test_histogram_caches_instrument(self, hook, mock_meter):
+        hook.histogram("h", 1.0)
+        hook.histogram("h", 2.0)
+        mock_meter.create_histogram.assert_called_once()
+
+    def test_histogram_rejects_none_name(self, hook):
+        with pytest.raises(TypeError):
+            hook.histogram(None, 1.0)
+
+
+# ---------------------------------------------------------------------------
+# log()
+# ---------------------------------------------------------------------------
+
+class TestLog:
+    def test_log_info(self, hook, caplog):
+        import logging
+        with caplog.at_level(logging.INFO):
+            hook.log("INFO", "hello")
+        assert "hello" in caplog.text
+
+    def test_log_debug(self, hook, caplog):
+        import logging
+        with caplog.at_level(logging.DEBUG):
+            hook.log("DEBUG", "dbg msg")
+        assert "dbg msg" in caplog.text
+
+    def test_log_warning(self, hook, caplog):
+        import logging
+        with caplog.at_level(logging.WARNING):
+            hook.log("WARNING", "warn msg")
+        assert "warn msg" in caplog.text
+
+    def test_log_error(self, hook, caplog):
+        import logging
+        with caplog.at_level(logging.ERROR):
+            hook.log("ERROR", "err msg")
+        assert "err msg" in caplog.text
+
+    def test_log_renders_fields(self, hook, caplog):
+        import logging
+        with caplog.at_level(logging.INFO):
+            hook.log("INFO", "base", run_id="r1", stage="s1")
+        assert "run_id=r1" in caplog.text
+        assert "stage=s1" in caplog.text
+
+    def test_log_rejects_none_level(self, hook):
+        with pytest.raises(TypeError):
+            hook.log(None, "msg")
+
+    def test_log_rejects_none_message(self, hook):
+        with pytest.raises(TypeError):
+            hook.log("INFO", None)
+
+    def test_log_unknown_level_falls_back_to_info(self, hook, caplog):
+        import logging
+        with caplog.at_level(logging.INFO):
+            hook.log("VERBOSE", "verbose msg")
+        assert "verbose msg" in caplog.text
+
+    def test_log_warn_alias(self, hook, caplog):
+        import logging
+        with caplog.at_level(logging.WARNING):
+            hook.log("WARN", "warn-alias")
+        assert "warn-alias" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# span()
+# ---------------------------------------------------------------------------
+
+class TestSpan:
+    def test_span_context_manager_calls_start_and_end(self, hook, mock_tracer):
+        span_mock = mock_tracer.start_span.return_value
+        with hook.span("my-span"):
+            mock_tracer.start_span.assert_called_with("my-span")
+        span_mock.end.assert_called_once()
+
+    def test_span_records_exception_on_error(self, hook, mock_tracer):
+        span_mock = mock_tracer.start_span.return_value
+        with pytest.raises(ValueError):
+            with hook.span("bad-span"):
+                raise ValueError("oops")
+        span_mock.record_exception.assert_called_once()
+        span_mock.end.assert_called_once()
+
+    def test_span_rejects_none_name(self, hook):
+        with pytest.raises(TypeError):
+            with hook.span(None):
+                pass
+
+    def test_span_end_called_even_if_record_exception_fails(self, hook, mock_tracer):
+        span_mock = mock_tracer.start_span.return_value
+        span_mock.record_exception.side_effect = RuntimeError("internal")
+        with pytest.raises(ValueError):
+            with hook.span("s"):
+                raise ValueError("orig")
+        span_mock.end.assert_called_once()

--- a/data-pipeline-libraries/data-pipeline-gcp-observability/tests/test_culvert_mdc_populator.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-observability/tests/test_culvert_mdc_populator.py
@@ -1,0 +1,197 @@
+"""Tests for CulvertMdcPopulator and stage_context."""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from data_pipeline_gcp_observability.culvert_mdc_populator import (
+    CulvertMdcPopulator,
+    CulvertLoggerAdapter,
+    RUN_ID_KEY,
+    STAGE_NAME_KEY,
+    PIPELINE_ID_KEY,
+    clear,
+    get,
+    put,
+    remove,
+    stage_context,
+)
+
+
+# ---------------------------------------------------------------------------
+# MDC key constants
+# ---------------------------------------------------------------------------
+
+class TestMdcKeyConstants:
+    def test_key_values(self):
+        assert RUN_ID_KEY == "run_id"
+        assert STAGE_NAME_KEY == "stage_name"
+        assert PIPELINE_ID_KEY == "pipeline_id"
+
+    def test_class_constants_match_module_constants(self):
+        assert CulvertMdcPopulator.RUN_ID_KEY == RUN_ID_KEY
+        assert CulvertMdcPopulator.STAGE_NAME_KEY == STAGE_NAME_KEY
+        assert CulvertMdcPopulator.PIPELINE_ID_KEY == PIPELINE_ID_KEY
+
+
+# ---------------------------------------------------------------------------
+# stage_context context manager
+# ---------------------------------------------------------------------------
+
+class TestStageContext:
+    def setup_method(self):
+        clear()
+
+    def test_populates_mdc_keys_inside_block(self):
+        with stage_context("run-1", "stage-1", "pipe-1"):
+            assert get(RUN_ID_KEY) == "run-1"
+            assert get(STAGE_NAME_KEY) == "stage-1"
+            assert get(PIPELINE_ID_KEY) == "pipe-1"
+
+    def test_clears_keys_after_block(self):
+        with stage_context("run-1", "stage-1", "pipe-1"):
+            pass
+        assert get(RUN_ID_KEY) is None
+        assert get(STAGE_NAME_KEY) is None
+        assert get(PIPELINE_ID_KEY) is None
+
+    def test_clears_keys_even_when_body_raises(self):
+        with pytest.raises(ValueError):
+            with stage_context("run-1", "stage-1", "pipe-1"):
+                raise ValueError("boom")
+        assert get(RUN_ID_KEY) is None
+
+    def test_rejects_none_run_id(self):
+        with pytest.raises(TypeError):
+            with stage_context(None, "stage", "pipe"):
+                pass
+
+    def test_rejects_none_stage_name(self):
+        with pytest.raises(TypeError):
+            with stage_context("run", None, "pipe"):
+                pass
+
+    def test_rejects_none_pipeline_id(self):
+        with pytest.raises(TypeError):
+            with stage_context("run", "stage", None):
+                pass
+
+    def test_nested_context_restores_outer_context(self):
+        with stage_context("outer-run", "outer-stage", "outer-pipe"):
+            with stage_context("inner-run", "inner-stage", "inner-pipe"):
+                assert get(RUN_ID_KEY) == "inner-run"
+            # After inner exits, outer keys are GONE (last one to set wins,
+            # then all cleared; this is documented behaviour — don't nest).
+            # The outer context's own keys were overwritten then cleared.
+            # The important thing is no stale data remains after the inner.
+            assert get(STAGE_NAME_KEY) is None
+
+    def test_thread_isolation(self):
+        """Each thread has its own MDC."""
+        results = {}
+
+        def worker(thread_id):
+            clear()
+            with stage_context(f"run-{thread_id}", f"stage-{thread_id}", "pipe"):
+                results[thread_id] = get(RUN_ID_KEY)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(3)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        for i in range(3):
+            assert results[i] == f"run-{i}"
+
+
+# ---------------------------------------------------------------------------
+# CulvertMdcPopulator.with_stage_context
+# ---------------------------------------------------------------------------
+
+class TestWithStageContext:
+    def setup_method(self):
+        clear()
+
+    def test_returns_body_value(self):
+        result = CulvertMdcPopulator.with_stage_context("r", "s", "p", lambda: 42)
+        assert result == 42
+
+    def test_mdc_populated_during_body(self):
+        captured = {}
+
+        def body():
+            captured["run"] = get(RUN_ID_KEY)
+            return None
+
+        CulvertMdcPopulator.with_stage_context("run-x", "stage-x", "pipe-x", body)
+        assert captured["run"] == "run-x"
+
+    def test_mdc_cleared_after_body(self):
+        CulvertMdcPopulator.with_stage_context("r", "s", "p", lambda: None)
+        assert get(RUN_ID_KEY) is None
+
+    def test_mdc_cleared_when_body_raises(self):
+        def raiser():
+            raise RuntimeError("fail")
+
+        with pytest.raises(RuntimeError):
+            CulvertMdcPopulator.with_stage_context("r", "s", "p", raiser)
+        assert get(RUN_ID_KEY) is None
+
+    def test_rejects_none_body(self):
+        with pytest.raises(TypeError):
+            CulvertMdcPopulator.with_stage_context("r", "s", "p", None)
+
+
+# ---------------------------------------------------------------------------
+# CulvertMdcPopulator — instantiation guard
+# ---------------------------------------------------------------------------
+
+class TestInstantiationGuard:
+    def test_cannot_instantiate(self):
+        with pytest.raises(TypeError):
+            CulvertMdcPopulator()
+
+
+# ---------------------------------------------------------------------------
+# CulvertLoggerAdapter
+# ---------------------------------------------------------------------------
+
+class TestCulvertLoggerAdapter:
+    def setup_method(self):
+        clear()
+
+    def test_process_injects_mdc_into_extra(self):
+        import logging
+        base_logger = logging.getLogger("test")
+        adapter = CulvertLoggerAdapter(base_logger, {})
+
+        with stage_context("run-a", "stage-a", "pipe-a"):
+            _, kwargs = adapter.process("msg", {})
+            extra = kwargs.get("extra", {})
+            assert extra.get(RUN_ID_KEY) == "run-a"
+            assert extra.get(STAGE_NAME_KEY) == "stage-a"
+            assert extra.get(PIPELINE_ID_KEY) == "pipe-a"
+
+    def test_process_merges_base_extra(self):
+        import logging
+        base_logger = logging.getLogger("test")
+        adapter = CulvertLoggerAdapter(base_logger, {"custom": "value"})
+
+        with stage_context("r", "s", "p"):
+            _, kwargs = adapter.process("msg", {})
+            extra = kwargs.get("extra", {})
+            assert extra.get("custom") == "value"
+            assert extra.get(RUN_ID_KEY) == "r"
+
+    def test_process_empty_mdc(self):
+        import logging
+        base_logger = logging.getLogger("test")
+        adapter = CulvertLoggerAdapter(base_logger, {})
+        clear()
+        _, kwargs = adapter.process("msg", {})
+        extra = kwargs.get("extra", {})
+        assert extra.get(RUN_ID_KEY) is None

--- a/data-pipeline-libraries/data-pipeline-gcp-observability/tests/test_data_catalog_lineage_emitter.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-observability/tests/test_data_catalog_lineage_emitter.py
@@ -1,0 +1,180 @@
+"""Tests for DataCatalogLineageEmitter — Data Catalog client is mocked."""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from data_pipeline_gcp_observability import DataCatalogLineageEmitter
+from data_pipeline_core.lineage.events import LineageEvent
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_client():
+    return MagicMock()
+
+
+@pytest.fixture
+def emitter(mock_client):
+    return DataCatalogLineageEmitter(
+        mock_client,
+        entry_name="projects/p/locations/l/entryGroups/g/entries/e",
+        tag_template="projects/p/locations/l/tagTemplates/t",
+    )
+
+
+def _event(**kwargs) -> LineageEvent:
+    base: LineageEvent = {}
+    base.update(kwargs)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Constructor
+# ---------------------------------------------------------------------------
+
+class TestConstructor:
+    def test_rejects_none_client(self):
+        with pytest.raises(TypeError):
+            DataCatalogLineageEmitter(None, "entry", "template")
+
+    def test_rejects_none_entry_name(self, mock_client):
+        with pytest.raises(TypeError):
+            DataCatalogLineageEmitter(mock_client, None, "template")
+
+    def test_rejects_none_tag_template(self, mock_client):
+        with pytest.raises(TypeError):
+            DataCatalogLineageEmitter(mock_client, "entry", None)
+
+    def test_accessors(self, emitter):
+        assert emitter.entry_name == "projects/p/locations/l/entryGroups/g/entries/e"
+        assert emitter.tag_template == "projects/p/locations/l/tagTemplates/t"
+
+
+# ---------------------------------------------------------------------------
+# _flatten()
+# ---------------------------------------------------------------------------
+
+class TestFlatten:
+    def test_source_fields(self):
+        event = _event(source={"type": "file", "uri": "gs://b/f"})
+        out = DataCatalogLineageEmitter._flatten(event)
+        assert out["source_type"] == "file"
+        assert out["source_uri"] == "gs://b/f"
+
+    def test_pipeline_fields(self):
+        event = _event(pipeline={
+            "run_id": "r1", "pipeline_name": "pipe", "stage": "load",
+            "started_at": "2026-01-01T00:00:00Z", "completed_at": "2026-01-01T01:00:00Z",
+        })
+        out = DataCatalogLineageEmitter._flatten(event)
+        assert out["run_id"] == "r1"
+        assert out["pipeline_name"] == "pipe"
+        assert out["stage"] == "load"
+        assert "started_at" in out
+        assert "completed_at" in out
+
+    def test_destination_fields(self):
+        event = _event(destination={"type": "table", "uri": "bq://proj/ds/t"})
+        out = DataCatalogLineageEmitter._flatten(event)
+        assert out["destination_type"] == "table"
+        assert out["destination_uri"] == "bq://proj/ds/t"
+
+    def test_audit_field(self):
+        event = _event(audit={"record_count_source": 10, "error_count": 0})
+        out = DataCatalogLineageEmitter._flatten(event)
+        assert "audit" in out
+
+    def test_empty_event_produces_empty_dict(self):
+        assert DataCatalogLineageEmitter._flatten({}) == {}
+
+    def test_partial_source_only_uri(self):
+        event = _event(source={"uri": "gs://bucket/file"})
+        out = DataCatalogLineageEmitter._flatten(event)
+        assert "source_uri" in out
+        assert "source_type" not in out
+
+
+# ---------------------------------------------------------------------------
+# emit() — with mocked Data Catalog SDK
+# ---------------------------------------------------------------------------
+
+class TestEmit:
+    def test_rejects_none_event(self, emitter):
+        with pytest.raises(TypeError):
+            emitter.emit(None)
+
+    def test_emit_calls_create_tag(self, emitter, mock_client):
+        """Verify create_tag is called with a request bearing the right parent.
+
+        We mock the entire google.cloud.datacatalog_v1 module so the test
+        runs without the SDK installed.
+        """
+        dc_mock = MagicMock()
+        tag_instance = MagicMock()
+        dc_mock.Tag.return_value = tag_instance
+        dc_mock.TagField.side_effect = lambda string_value: MagicMock(string_value=string_value)
+        dc_mock.CreateTagRequest.return_value = MagicMock()
+        tag_instance.fields = {}
+
+        with patch.dict("sys.modules", {"google.cloud": MagicMock(),
+                                         "google.cloud.datacatalog_v1": dc_mock}):
+            event = _event(
+                source={"type": "file", "uri": "gs://b/f"},
+                pipeline={"run_id": "r1", "pipeline_name": "p"},
+            )
+            emitter.emit(event)
+
+        mock_client.create_tag.assert_called_once()
+
+    def test_emit_empty_event(self, emitter, mock_client):
+        dc_mock = MagicMock()
+        tag_instance = MagicMock()
+        tag_instance.fields = {}
+        dc_mock.Tag.return_value = tag_instance
+        dc_mock.TagField.side_effect = lambda string_value: MagicMock()
+        dc_mock.CreateTagRequest.return_value = MagicMock()
+
+        with patch.dict("sys.modules", {"google.cloud": MagicMock(),
+                                         "google.cloud.datacatalog_v1": dc_mock}):
+            emitter.emit({})
+
+        mock_client.create_tag.assert_called_once()
+
+    def test_emit_propagates_client_exception(self, emitter, mock_client):
+        mock_client.create_tag.side_effect = RuntimeError("network error")
+        dc_mock = MagicMock()
+        tag_instance = MagicMock()
+        tag_instance.fields = {}
+        dc_mock.Tag.return_value = tag_instance
+        dc_mock.TagField.side_effect = lambda string_value: MagicMock()
+        dc_mock.CreateTagRequest.return_value = MagicMock()
+
+        with patch.dict("sys.modules", {"google.cloud": MagicMock(),
+                                         "google.cloud.datacatalog_v1": dc_mock}):
+            with pytest.raises(RuntimeError, match="network error"):
+                emitter.emit(_event(source={"type": "f", "uri": "gs://b/o"}))
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle (close / context manager)
+# ---------------------------------------------------------------------------
+
+class TestLifecycle:
+    def test_close_closes_client(self, emitter, mock_client):
+        emitter.close()
+        mock_client.close.assert_called_once()
+
+    def test_context_manager(self, mock_client):
+        with DataCatalogLineageEmitter(mock_client, "e", "t") as em:
+            assert em.entry_name == "e"
+        mock_client.close.assert_called_once()
+
+    def test_close_tolerates_client_error(self, mock_client):
+        mock_client.close.side_effect = RuntimeError("gone")
+        em = DataCatalogLineageEmitter(mock_client, "e", "t")
+        em.close()  # Should not raise

--- a/data-pipeline-libraries/data-pipeline-gcp-pubsub/pyproject.toml
+++ b/data-pipeline-libraries/data-pipeline-gcp-pubsub/pyproject.toml
@@ -33,9 +33,13 @@ test = ["pytest>=7.4", "pytest-cov>=4.1"]
 [project.urls]
 Homepage = "https://github.com/enrichmeai/culvert"
 
+[project.entry-points."data_pipeline_core.adapters"]
+source = "data_pipeline_gcp_pubsub:PubSubSource"
+sink = "data_pipeline_gcp_pubsub:PubSubSink"
+
 [tool.setuptools.packages.find]
 where = ["src"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "-ra --strict-markers"
+addopts = "-ra --strict-markers --import-mode=importlib"

--- a/data-pipeline-libraries/data-pipeline-gcp-pubsub/src/data_pipeline_gcp_pubsub/__init__.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-pubsub/src/data_pipeline_gcp_pubsub/__init__.py
@@ -6,8 +6,13 @@ Implements the cloud-neutral ``Source`` and ``Sink`` Protocols from
 
 from __future__ import annotations
 
+from data_pipeline_gcp_pubsub.cost_tracker import PubSubCostTracker
 from data_pipeline_gcp_pubsub.io import PubSubSink, PubSubSource
 
 __version__ = "0.1.0"
 
-__all__ = ["PubSubSource", "PubSubSink"]
+__all__ = [
+    "PubSubSource",
+    "PubSubSink",
+    "PubSubCostTracker",
+]

--- a/data-pipeline-libraries/data-pipeline-gcp-pubsub/src/data_pipeline_gcp_pubsub/cost_tracker.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-pubsub/src/data_pipeline_gcp_pubsub/cost_tracker.py
@@ -1,0 +1,205 @@
+"""PubSubCostTracker — builds CostMetrics from Pub/Sub message counts and bytes.
+
+Java sibling: ``com.enrichmeai.culvert.gcp.pubsub.PubSubCostTracker``
+(data-pipeline-libraries-java/data-pipeline-gcp-pubsub-java/src/main/java/
+com/enrichmeai/culvert/gcp/pubsub/PubSubCostTracker.java)
+
+Mirrors the Java constants and formula exactly:
+
+- ``BYTES_PER_TIB = 1_099_511_627_776``    (2^40, Java line 65)
+- ``THROUGHPUT_COST_USD_PER_TIB = 40.00``  (Java line 81)
+
+Formula for publish and subscribe (Java lines 125, 186)::
+
+    estimated_cost_usd = total_bytes / BYTES_PER_TIB * THROUGHPUT_COST_USD_PER_TIB
+
+``message_count`` maps to ``billed_messages_count`` for attribution;
+it does NOT drive the USD estimate because Pub/Sub bills on throughput bytes
+(mirrors Java Javadoc lines 35-37).
+
+Sprint-19 / T19.3 deliverable for issue #126.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from data_pipeline_core.contracts.finops import FinOpsSink
+from data_pipeline_core.finops_api.labels import FinOpsTag
+from data_pipeline_core.finops_api.models import CostMetrics
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Pricing constants — mirror Java PubSubCostTracker exactly
+# ---------------------------------------------------------------------------
+
+#: Bytes in one tebibyte (2^40).
+#:
+#: Pub/Sub pricing uses binary TiB. Mirrors BigQueryCostTracker.BYTES_PER_TIB.
+#: Use this constant — not 1e12 — to avoid an ~10% undercount.
+#:
+#: Java source: ``PubSubCostTracker.BYTES_PER_TIB = 1_099_511_627_776L``
+#: (data-pipeline-gcp-pubsub-java/.../PubSubCostTracker.java, line 65)
+BYTES_PER_TIB: int = 1_099_511_627_776  # 2^40
+
+#: Pub/Sub message throughput cost in USD per TiB.
+#:
+#: Rate as of 2025: $40.00/TiB of message data throughput.
+#: The first 10 GiB/month is free; this constant is the on-demand rate
+#: above the free tier (no free-tier deduction applied here).
+#:
+#: Java source: ``PubSubCostTracker.THROUGHPUT_COST_USD_PER_TIB = 40.00``
+#: (data-pipeline-gcp-pubsub-java/.../PubSubCostTracker.java, line 81)
+THROUGHPUT_COST_USD_PER_TIB: float = 40.00
+
+
+class PubSubCostTracker:
+    """Builds a :class:`~data_pipeline_core.finops_api.models.CostMetrics` record
+    from Pub/Sub message-count and throughput-bytes, and pushes it to the
+    injected :class:`~data_pipeline_core.contracts.finops.FinOpsSink`.
+
+    Mirrors ``com.enrichmeai.culvert.gcp.pubsub.PubSubCostTracker``.
+
+    This class does NOT hold a Pub/Sub client — it operates on message counts
+    and byte counts already obtained by the caller.
+
+    Supported operations:
+
+    - :meth:`track_publish`:   publish batch cost (mirrors Java lines 110-134).
+    - :meth:`track_subscribe`: subscribe batch cost (mirrors Java lines 153-177).
+
+    :param sink: FinOps sink that receives the built CostMetrics. Required.
+    :raises TypeError: if sink is None.
+    """
+
+    def __init__(self, sink: FinOpsSink) -> None:
+        if sink is None:
+            raise TypeError("sink must not be None")
+        self._sink = sink
+
+    # --- public API ---------------------------------------------------------
+
+    def track_publish(
+        self,
+        message_count: int,
+        total_bytes: int,
+        run_id: str,
+        tag: FinOpsTag,
+    ) -> None:
+        """Record cost metrics for a Pub/Sub publish batch.
+
+        Mirrors Java ``PubSubCostTracker.trackPublish`` (lines 110-134).
+
+        Maps ``message_count`` → ``billed_messages_count`` and
+        ``total_bytes`` → ``billed_bytes_written``. USD estimated from
+        ``total_bytes`` (throughput drives the bill, not message count).
+
+        Formula (mirrors Java ``bytesToUsd``, lines 182-186)::
+
+            estimated_cost_usd = total_bytes / BYTES_PER_TIB * THROUGHPUT_COST_USD_PER_TIB
+
+        Zero or negative inputs log WARN and record zero; sink called once.
+
+        :param message_count: Number of messages published.
+        :param total_bytes:   Total payload bytes published.
+        :param run_id:        Pipeline run identifier.
+        :param tag:           FinOps attribution tag.
+        :raises TypeError: if run_id or tag is None.
+        """
+        if run_id is None:
+            raise TypeError("run_id must not be None")
+        if tag is None:
+            raise TypeError("tag must not be None")
+
+        if message_count <= 0:
+            logger.warning(
+                "PubSubCostTracker.track_publish: message_count=%d for run_id=%s "
+                "— recording zero messages", message_count, run_id,
+            )
+        if total_bytes <= 0:
+            logger.warning(
+                "PubSubCostTracker.track_publish: total_bytes=%d for run_id=%s "
+                "— recording zero cost", total_bytes, run_id,
+            )
+
+        messages = max(0, message_count)
+        billed_bytes = max(0, total_bytes)
+        cost_usd = _bytes_to_usd(billed_bytes)
+
+        metrics = CostMetrics(
+            run_id=run_id,
+            billed_messages_count=messages,
+            billed_bytes_written=billed_bytes,
+            estimated_cost_usd=cost_usd,
+        )
+        self._sink.record(metrics, tag)
+
+    def track_subscribe(
+        self,
+        message_count: int,
+        total_bytes: int,
+        run_id: str,
+        tag: FinOpsTag,
+    ) -> None:
+        """Record cost metrics for a Pub/Sub subscription pull/push batch.
+
+        Mirrors Java ``PubSubCostTracker.trackSubscribe`` (lines 153-177).
+        Pub/Sub charges both publisher and subscriber throughput, so the
+        same formula and rate apply.
+
+        :param message_count: Number of messages received.
+        :param total_bytes:   Total payload bytes received.
+        :param run_id:        Pipeline run identifier.
+        :param tag:           FinOps attribution tag.
+        :raises TypeError: if run_id or tag is None.
+        """
+        if run_id is None:
+            raise TypeError("run_id must not be None")
+        if tag is None:
+            raise TypeError("tag must not be None")
+
+        if message_count <= 0:
+            logger.warning(
+                "PubSubCostTracker.track_subscribe: message_count=%d for run_id=%s "
+                "— recording zero messages", message_count, run_id,
+            )
+        if total_bytes <= 0:
+            logger.warning(
+                "PubSubCostTracker.track_subscribe: total_bytes=%d for run_id=%s "
+                "— recording zero cost", total_bytes, run_id,
+            )
+
+        messages = max(0, message_count)
+        billed_bytes = max(0, total_bytes)
+        cost_usd = _bytes_to_usd(billed_bytes)
+
+        metrics = CostMetrics(
+            run_id=run_id,
+            billed_messages_count=messages,
+            billed_bytes_written=billed_bytes,
+            estimated_cost_usd=cost_usd,
+        )
+        self._sink.record(metrics, tag)
+
+
+# ---------------------------------------------------------------------------
+# Module-level formula helper (used by tests to verify the unit chain)
+# ---------------------------------------------------------------------------
+
+def bytes_to_usd(bytes_count: int) -> float:
+    """Convert bytes to USD using THROUGHPUT_COST_USD_PER_TIB.
+
+    Mirrors Java ``PubSubCostTracker.bytesToUsd`` (lines 182-186)::
+
+        return (double) bytes / (double) BYTES_PER_TIB * THROUGHPUT_COST_USD_PER_TIB;
+
+    Zero or negative input returns 0.0 (mirrors Java guard on line 183).
+    """
+    if bytes_count <= 0:
+        return 0.0
+    return bytes_count / BYTES_PER_TIB * THROUGHPUT_COST_USD_PER_TIB
+
+
+# Internal alias.
+_bytes_to_usd = bytes_to_usd

--- a/data-pipeline-libraries/data-pipeline-gcp-pubsub/tests/test_autoconfig_discovery.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-pubsub/tests/test_autoconfig_discovery.py
@@ -1,0 +1,22 @@
+"""Verify that AutoConfig.discover() finds PubSubSource and PubSubSink after install."""
+
+from __future__ import annotations
+
+from data_pipeline_core.autoconfig import discover
+from data_pipeline_gcp_pubsub import PubSubSink, PubSubSource
+
+
+def test_discover_finds_source():
+    """PubSubSource must appear in discover().source."""
+    cfg = discover()
+    assert PubSubSource in cfg.source, (
+        f"PubSubSource not found in discover().source; got: {cfg.source}"
+    )
+
+
+def test_discover_finds_sink():
+    """PubSubSink must appear in discover().sink."""
+    cfg = discover()
+    assert PubSubSink in cfg.sink, (
+        f"PubSubSink not found in discover().sink; got: {cfg.sink}"
+    )

--- a/data-pipeline-libraries/data-pipeline-gcp-pubsub/tests/test_cost_tracker.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-pubsub/tests/test_cost_tracker.py
@@ -1,0 +1,181 @@
+"""Tests for PubSubCostTracker — no real Pub/Sub client.
+
+End-to-end cost test re-derives one full cost:
+
+    Publish: 1 TiB total_bytes (= BYTES_PER_TIB = 1_099_511_627_776 bytes)
+    Formula (mirrors Java PubSubCostTracker.bytesToUsd, lines 182-186):
+        estimatedCostUsd = total_bytes / BYTES_PER_TIB * THROUGHPUT_COST_USD_PER_TIB
+                         = 1_099_511_627_776 / 1_099_511_627_776 * 40.00
+                         = 1.0 * 40.00
+                         = 40.00 USD
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from data_pipeline_gcp_pubsub.cost_tracker import (
+    BYTES_PER_TIB,
+    THROUGHPUT_COST_USD_PER_TIB,
+    PubSubCostTracker,
+    bytes_to_usd,
+)
+from data_pipeline_core.finops_api.labels import FinOpsTag
+from data_pipeline_core.finops_api.models import CostMetrics
+
+
+# --- pricing constants -------------------------------------------------------
+
+def test_bytes_per_tib_is_binary():
+    """BYTES_PER_TIB must be exactly 2^40, not 1e12 (~10% difference matters)."""
+    assert BYTES_PER_TIB == 2 ** 40
+    assert BYTES_PER_TIB == 1_099_511_627_776
+
+
+def test_throughput_cost_per_tib():
+    assert THROUGHPUT_COST_USD_PER_TIB == 40.00
+
+
+# --- end-to-end cost formula -------------------------------------------------
+
+def test_bytes_to_usd_one_tib():
+    """Re-derive: 1 TiB publish → $40.00.
+
+    Mirrors Java PubSubCostTracker.bytesToUsd (lines 182-186):
+        return (double) bytes / (double) BYTES_PER_TIB * THROUGHPUT_COST_USD_PER_TIB;
+
+    Input:  bytes = BYTES_PER_TIB = 1_099_511_627_776
+    Rate:   THROUGHPUT_COST_USD_PER_TIB = 40.00
+    Output: 1_099_511_627_776 / 1_099_511_627_776 * 40.00 = 40.00 USD
+    """
+    result = bytes_to_usd(BYTES_PER_TIB)
+    assert result == pytest.approx(40.00)
+
+
+def test_bytes_to_usd_half_tib():
+    """0.5 TiB → $20.00."""
+    result = bytes_to_usd(BYTES_PER_TIB // 2)
+    assert result == pytest.approx(20.00)
+
+
+def test_bytes_to_usd_zero():
+    assert bytes_to_usd(0) == 0.0
+
+
+def test_bytes_to_usd_negative():
+    assert bytes_to_usd(-1) == 0.0
+
+
+# --- fixtures ----------------------------------------------------------------
+
+@pytest.fixture
+def tag():
+    return FinOpsTag(
+        system="culvert", environment="test", cost_center="eng",
+        owner="team", run_id="run-pubsub",
+    )
+
+
+@pytest.fixture
+def recording_sink():
+    records = []
+
+    class _RecordingSink:
+        def record(self, metrics, tags):
+            records.append((metrics, tags))
+
+    sink = _RecordingSink()
+    sink.records = records
+    return sink
+
+
+@pytest.fixture
+def tracker(recording_sink):
+    return PubSubCostTracker(recording_sink)
+
+
+# --- constructor guard -------------------------------------------------------
+
+def test_rejects_none_sink():
+    with pytest.raises(TypeError):
+        PubSubCostTracker(None)
+
+
+# --- track_publish -----------------------------------------------------------
+
+def test_track_publish_rejects_none_run_id(tracker, tag):
+    with pytest.raises(TypeError):
+        tracker.track_publish(100, 1024, None, tag)
+
+
+def test_track_publish_rejects_none_tag(tracker):
+    with pytest.raises(TypeError):
+        tracker.track_publish(100, 1024, "r1", None)
+
+
+def test_track_publish_one_tib(recording_sink, tag):
+    """End-to-end: 1 TiB publish → $40.00 emitted to sink."""
+    tracker = PubSubCostTracker(recording_sink)
+    tracker.track_publish(1_000_000, BYTES_PER_TIB, "run-pubsub", tag)
+
+    assert len(recording_sink.records) == 1
+    m, t = recording_sink.records[0]
+    assert m.billed_messages_count == 1_000_000
+    assert m.billed_bytes_written == BYTES_PER_TIB
+    assert m.estimated_cost_usd == pytest.approx(40.00)
+    assert t is tag
+
+
+def test_track_publish_zero_bytes_emits_zero_cost(recording_sink, tag):
+    tracker = PubSubCostTracker(recording_sink)
+    tracker.track_publish(100, 0, "r1", tag)
+    m, _ = recording_sink.records[0]
+    assert m.billed_bytes_written == 0
+    assert m.estimated_cost_usd == pytest.approx(0.0)
+
+
+def test_track_publish_zero_messages_still_calls_sink(recording_sink, tag):
+    tracker = PubSubCostTracker(recording_sink)
+    tracker.track_publish(0, 1024, "r1", tag)
+    assert len(recording_sink.records) == 1
+    m, _ = recording_sink.records[0]
+    assert m.billed_messages_count == 0
+
+
+def test_track_publish_negative_bytes_treated_as_zero(recording_sink, tag):
+    tracker = PubSubCostTracker(recording_sink)
+    tracker.track_publish(10, -500, "r1", tag)
+    m, _ = recording_sink.records[0]
+    assert m.billed_bytes_written == 0
+    assert m.estimated_cost_usd == pytest.approx(0.0)
+
+
+# --- track_subscribe ---------------------------------------------------------
+
+def test_track_subscribe_rejects_none_run_id(tracker, tag):
+    with pytest.raises(TypeError):
+        tracker.track_subscribe(100, 1024, None, tag)
+
+
+def test_track_subscribe_rejects_none_tag(tracker):
+    with pytest.raises(TypeError):
+        tracker.track_subscribe(100, 1024, "r1", None)
+
+
+def test_track_subscribe_one_tib(recording_sink, tag):
+    """End-to-end: 1 TiB subscribe → $40.00 emitted to sink."""
+    tracker = PubSubCostTracker(recording_sink)
+    tracker.track_subscribe(500_000, BYTES_PER_TIB, "run-sub", tag)
+
+    assert len(recording_sink.records) == 1
+    m, _ = recording_sink.records[0]
+    assert m.billed_messages_count == 500_000
+    assert m.billed_bytes_written == BYTES_PER_TIB
+    assert m.estimated_cost_usd == pytest.approx(40.00)
+
+
+def test_track_subscribe_zero_bytes(recording_sink, tag):
+    tracker = PubSubCostTracker(recording_sink)
+    tracker.track_subscribe(10, 0, "r1", tag)
+    m, _ = recording_sink.records[0]
+    assert m.estimated_cost_usd == pytest.approx(0.0)

--- a/data-pipeline-libraries/data-pipeline-gcp-secrets/README.md
+++ b/data-pipeline-libraries/data-pipeline-gcp-secrets/README.md
@@ -1,0 +1,65 @@
+# data-pipeline-gcp-secrets (Python)
+
+Google Cloud Secret Manager adapter for the Culvert data pipeline framework. Implements the cloud-neutral [`SecretProvider`](../data-pipeline-core/src/data_pipeline_core/contracts/secrets.py) Protocol.
+
+**Java sibling:** `com.enrichmeai.culvert.gcp.secrets.SecretManagerProvider`
+(`data-pipeline-libraries-java/data-pipeline-gcp-secrets-java/src/main/java/com/enrichmeai/culvert/gcp/secrets/SecretManagerProvider.java`).
+
+## Install
+
+```bash
+pip install data-pipeline-gcp-secrets
+```
+
+## Usage
+
+```python
+from data_pipeline_gcp_secrets import SecretManagerProvider
+
+# Production: reads GCP_PROJECT_ID from env, uses Application Default Credentials
+provider = SecretManagerProvider()
+
+# Explicit project:
+provider = SecretManagerProvider("my-project-id")
+
+value = provider.get("my-secret")           # latest version
+value = provider.get("my-secret", "42")     # pinned version
+```
+
+## Environment variables
+
+| Variable | Used by |
+|---|---|
+| `GCP_PROJECT_ID` | No-arg constructor (required for entry-point / AutoConfig discovery) |
+
+## Errors
+
+| Cause | Raised |
+|---|---|
+| Secret or version not found | `KeyError` |
+| `name` is `None` | `TypeError` |
+| Empty `project_id` | `ValueError` |
+| `GCP_PROJECT_ID` unset (no-arg constructor) | `EnvironmentError` |
+| Other Secret Manager errors | propagated |
+
+## AutoConfig registration
+
+This package registers itself under the `data_pipeline_core.adapters` entry-point group:
+
+```toml
+[project.entry-points."data_pipeline_core.adapters"]
+secrets = "data_pipeline_gcp_secrets:SecretManagerProvider"
+```
+
+After `pip install -e .`, `AutoConfig.discover().secrets` will contain `SecretManagerProvider`.
+
+## Testing
+
+```bash
+pip install -e ".[test]"
+pytest
+```
+
+All tests run against a `unittest.mock.MagicMock` client — no real Secret Manager calls.
+
+Sprint-19 deliverable (issue #124, T19.1 Wave C adapter parity).

--- a/data-pipeline-libraries/data-pipeline-gcp-secrets/pyproject.toml
+++ b/data-pipeline-libraries/data-pipeline-gcp-secrets/pyproject.toml
@@ -1,0 +1,44 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "data-pipeline-gcp-secrets"
+version = "0.1.0"
+description = "Google Cloud Secret Manager adapter for the Culvert data pipeline framework. Implements the cloud-neutral SecretProvider contract from data-pipeline-core."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [
+    { name = "Joseph Aruja", email = "joseph.a.aruja@googlemail.com" },
+]
+keywords = ["data", "pipeline", "framework", "culvert", "secret-manager", "gcp"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Typing :: Typed",
+]
+dependencies = [
+    "data-pipeline-core>=0.1.0",
+    "google-cloud-secret-manager>=2.16.0",
+]
+
+[project.optional-dependencies]
+test = ["pytest>=7.4", "pytest-cov>=4.1"]
+
+[project.urls]
+Homepage = "https://github.com/enrichmeai/culvert"
+
+[project.entry-points."data_pipeline_core.adapters"]
+secrets = "data_pipeline_gcp_secrets:SecretManagerProvider"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra --strict-markers"

--- a/data-pipeline-libraries/data-pipeline-gcp-secrets/src/data_pipeline_gcp_secrets/__init__.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-secrets/src/data_pipeline_gcp_secrets/__init__.py
@@ -1,0 +1,13 @@
+"""Google Cloud Secret Manager adapter for the Culvert data pipeline framework.
+
+Implements the cloud-neutral ``SecretProvider`` Protocol from
+``data-pipeline-core`` over ``google-cloud-secret-manager``.
+"""
+
+from __future__ import annotations
+
+from data_pipeline_gcp_secrets.secret_manager_provider import SecretManagerProvider
+
+__version__ = "0.1.0"
+
+__all__ = ["SecretManagerProvider"]

--- a/data-pipeline-libraries/data-pipeline-gcp-secrets/src/data_pipeline_gcp_secrets/secret_manager_provider.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-secrets/src/data_pipeline_gcp_secrets/secret_manager_provider.py
@@ -87,6 +87,8 @@ class SecretManagerProvider:
         """
         if name is None:
             raise TypeError("name must not be None")
+        if version is None:
+            raise TypeError("version must not be None")
 
         secret_version_path = (
             f"projects/{self.project_id}/secrets/{name}/versions/{version}"

--- a/data-pipeline-libraries/data-pipeline-gcp-secrets/src/data_pipeline_gcp_secrets/secret_manager_provider.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-secrets/src/data_pipeline_gcp_secrets/secret_manager_provider.py
@@ -1,0 +1,162 @@
+"""SecretManagerProvider — SecretProvider Protocol over Google Cloud Secret Manager.
+
+Java sibling:
+``com.enrichmeai.culvert.gcp.secrets.SecretManagerProvider``
+(data-pipeline-libraries-java/data-pipeline-gcp-secrets-java/src/main/java/
+com/enrichmeai/culvert/gcp/secrets/SecretManagerProvider.java).
+
+Key shapes mirrored from Java (file:line references):
+- ENV_PROJECT_ID = "GCP_PROJECT_ID"           (line 47)
+- No-arg constructor reads GCP_PROJECT_ID env  (lines 61-63)
+- (str, client) constructor for test injection  (lines 86-89)
+- get(name, version="latest") resolves          (lines 92-108)
+  projects/{projectId}/secrets/{name}/versions/{version}
+- NotFoundException → KeyError (Python) / NoSuchElementException (Java line 106)
+- close() delegates to underlying client        (lines 112-113)
+- Never log the secret payload (documented invariant)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+ENV_PROJECT_ID = "GCP_PROJECT_ID"
+
+_SENTINEL = object()  # distinguish "not provided" from explicit None
+
+
+class SecretManagerProvider:
+    """SecretProvider implementation backed by Google Cloud Secret Manager.
+
+    Resolves secrets at::
+
+        projects/{project_id}/secrets/{name}/versions/{version}
+
+    Construction mirrors the Java sibling exactly:
+
+    * **No-arg** — reads ``GCP_PROJECT_ID`` from the environment and builds a
+      default ``SecretManagerServiceClient``.  Required for entry-point /
+      ``AutoConfig.discover()`` instantiation.
+    * **Two-arg (project_id, client)** — inject a mock client in unit tests.
+      Mirrors Java ``SecretManagerProvider(String, SecretManagerServiceClient)``
+      (lines 86-89). ``client`` must not be ``None``.
+
+    Raises:
+        KeyError: if the secret does not exist (mirrors Java ``NoSuchElementException``).
+        TypeError: if ``name`` or ``client`` is ``None``.
+        ValueError: if ``project_id`` is empty.
+    """
+
+    def __init__(self, project_id: str | None = None, client: Any = _SENTINEL) -> None:
+        """
+        Args:
+            project_id: GCP project ID.  If *None*, reads ``GCP_PROJECT_ID``
+                from the environment (mirrors Java no-arg constructor, line 61).
+            client: Pre-built ``SecretManagerServiceClient``.  If omitted, a
+                default client is created via Application Default Credentials.
+                Passing ``None`` explicitly raises ``TypeError`` — mirrors Java
+                ``Objects.requireNonNull(client)`` (line 88).
+        """
+        if project_id is None:
+            project_id = self._require_env_project_id()
+        if not project_id:
+            raise ValueError("project_id must not be empty")
+        self.project_id = project_id
+
+        if client is _SENTINEL:
+            # No client supplied — build a default one.
+            client = self._create_default_client()
+        if client is None:
+            raise TypeError("client must not be None")
+        self.client = client
+
+    # --- SecretProvider Protocol ------------------------------------------
+
+    def get(self, name: str, version: str = "latest") -> str:
+        """Return the secret value at *name* (and optional *version*).
+
+        Mirrors Java ``get(String name, String version)`` (lines 92-108).
+
+        Raises:
+            TypeError: if ``name`` is ``None``.
+            KeyError: if the secret or version does not exist.
+        """
+        if name is None:
+            raise TypeError("name must not be None")
+
+        secret_version_path = (
+            f"projects/{self.project_id}/secrets/{name}/versions/{version}"
+        )
+        try:
+            response = self.client.access_secret_version(
+                request={"name": secret_version_path}
+            )
+            # Never log the returned payload — documented invariant.
+            return response.payload.data.decode("utf-8")
+        except Exception as exc:
+            if self._is_not_found(exc):
+                raise KeyError(
+                    f"Secret not found: projects/{self.project_id}"
+                    f"/secrets/{name}/versions/{version}"
+                ) from exc
+            raise
+
+    def close(self) -> None:
+        """Close the underlying client. Mirrors Java ``close()`` (line 112)."""
+        if hasattr(self.client, "close"):
+            self.client.close()
+
+    # --- helpers ----------------------------------------------------------
+
+    @staticmethod
+    def _require_env_project_id() -> str:
+        """Read GCP_PROJECT_ID from the environment.
+
+        Mirrors Java ``requireEnvProjectId()`` (lines 116-126).
+        """
+        value = os.environ.get(ENV_PROJECT_ID, "")
+        if not value:
+            raise EnvironmentError(
+                f"Environment variable {ENV_PROJECT_ID} is not set; "
+                "required for the no-arg constructor (entry-point discovery). "
+                f"Either set {ENV_PROJECT_ID} or pass project_id explicitly."
+            )
+        return value
+
+    @staticmethod
+    def _create_default_client() -> Any:
+        """Build a default SecretManagerServiceClient.
+
+        Mirrors Java ``createDefaultClient()`` (lines 129-135).
+        Wraps the import so tests that mock the client bypass the SDK entirely.
+        """
+        try:
+            from google.cloud import secretmanager  # type: ignore[import]
+
+            return secretmanager.SecretManagerServiceClient()
+        except Exception as exc:
+            raise RuntimeError(
+                "Failed to create SecretManagerServiceClient; "
+                "ensure google-cloud-secret-manager is installed and "
+                "Application Default Credentials are configured."
+            ) from exc
+
+    @staticmethod
+    def _is_not_found(exc: Exception) -> bool:
+        """Duck-type not-found detection across SDK versions.
+
+        The google-cloud SDK raises ``google.api_core.exceptions.NotFound``
+        (code 404); duck-type rather than import to stay loosely coupled.
+        """
+        code = getattr(exc, "code", None)
+        if code == 404:
+            return True
+        grpc_code = getattr(exc, "grpc_status_code", None)
+        if grpc_code is not None and str(grpc_code) in ("StatusCode.NOT_FOUND", "5"):
+            return True
+        msg = str(exc).lower()
+        return "not found" in msg or "404" in msg

--- a/data-pipeline-libraries/data-pipeline-gcp-secrets/tests/test_secret_manager_provider.py
+++ b/data-pipeline-libraries/data-pipeline-gcp-secrets/tests/test_secret_manager_provider.py
@@ -1,0 +1,216 @@
+"""Tests for SecretManagerProvider — no real Secret Manager calls.
+
+Covers:
+  1. Unit tests (constructor, get, close, URI building, error mapping).
+  2. Contract tests — SecretProviderContract mixin bound to SecretManagerProvider
+     (deferred in T17.4; delivered here per T19.1).
+  3. AutoConfig discovery assertion — SecretManagerProvider must appear in
+     AutoConfig.discover().secrets after the editable install registers the
+     entry-point.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from data_pipeline_contract_tests import SecretProviderContract
+from data_pipeline_core.autoconfig import discover
+from data_pipeline_gcp_secrets import SecretManagerProvider
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_response(payload: str) -> MagicMock:
+    """Build a mock SecretManagerServiceClient response."""
+    response = MagicMock()
+    response.payload.data = payload.encode("utf-8")
+    return response
+
+
+def _make_client(secrets: dict[str, str]) -> MagicMock:
+    """Return a mock client where known secrets resolve and others raise 404."""
+    client = MagicMock()
+
+    def _access(request):
+        name = request["name"]
+        # Extract the secret name from projects/.../secrets/<name>/versions/...
+        parts = name.split("/")
+        # projects/{proj}/secrets/{secret_name}/versions/{version}
+        if len(parts) >= 4:
+            secret_name = parts[3]
+        else:
+            secret_name = name
+        if secret_name in secrets:
+            return _make_response(secrets[secret_name])
+        err = Exception("404 Secret not found")
+        err.code = 404
+        raise err
+
+    client.access_secret_version.side_effect = _access
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Contract tests (T17.4 binding — delivered in T19.1)
+# ---------------------------------------------------------------------------
+
+class TestSecretManagerProviderContract(SecretProviderContract):
+    """Bind SecretProviderContract to SecretManagerProvider.
+
+    Fixtures follow the mixin's documented interface:
+      ``provider`` — instance whose ``get("known")`` returns ``"the-secret"``
+                     and whose ``get("missing")`` raises ``KeyError``.
+    """
+
+    @pytest.fixture
+    def provider(self):
+        client = _make_client({"known": "the-secret"})
+        return SecretManagerProvider("test-project", client)
+
+
+# ---------------------------------------------------------------------------
+# Constructor tests
+# ---------------------------------------------------------------------------
+
+def test_constructor_two_arg():
+    client = MagicMock()
+    p = SecretManagerProvider("my-project", client)
+    assert p.project_id == "my-project"
+    assert p.client is client
+
+
+def test_constructor_rejects_empty_project_id():
+    with pytest.raises(ValueError):
+        SecretManagerProvider("", MagicMock())
+
+
+def test_constructor_rejects_none_client():
+    with pytest.raises(TypeError):
+        SecretManagerProvider("proj", None)
+
+
+def test_no_arg_constructor_reads_env(monkeypatch):
+    monkeypatch.setenv("GCP_PROJECT_ID", "env-project")
+    fake_client = MagicMock()
+    with patch.object(SecretManagerProvider, "_create_default_client", return_value=fake_client):
+        p = SecretManagerProvider()
+    assert p.project_id == "env-project"
+    assert p.client is fake_client
+
+
+def test_no_arg_constructor_raises_if_env_missing(monkeypatch):
+    monkeypatch.delenv("GCP_PROJECT_ID", raising=False)
+    with pytest.raises(EnvironmentError):
+        SecretManagerProvider()
+
+
+# ---------------------------------------------------------------------------
+# get() tests
+# ---------------------------------------------------------------------------
+
+def test_get_known_secret():
+    client = _make_client({"my-secret": "s3cr3t-value"})
+    p = SecretManagerProvider("proj", client)
+    assert p.get("my-secret") == "s3cr3t-value"
+
+
+def test_get_uses_default_version():
+    client = MagicMock()
+    client.access_secret_version.return_value = _make_response("val")
+    p = SecretManagerProvider("proj", client)
+    p.get("name")
+    call_args = client.access_secret_version.call_args
+    assert "latest" in call_args[1]["request"]["name"] or "latest" in call_args[0][0]["name"]
+
+
+def test_get_uses_explicit_version():
+    client = MagicMock()
+    client.access_secret_version.return_value = _make_response("val")
+    p = SecretManagerProvider("proj", client)
+    p.get("name", version="42")
+    call_args = client.access_secret_version.call_args
+    req_name = (call_args[1].get("request") or call_args[0][0])["name"]
+    assert "/versions/42" in req_name
+
+
+def test_get_raises_keyerror_on_404():
+    client = _make_client({})
+    p = SecretManagerProvider("proj", client)
+    with pytest.raises(KeyError):
+        p.get("missing")
+
+
+def test_get_propagates_other_errors():
+    client = MagicMock()
+    err = Exception("permission denied")
+    err.code = 403
+    client.access_secret_version.side_effect = err
+    p = SecretManagerProvider("proj", client)
+    with pytest.raises(Exception, match="permission denied"):
+        p.get("secret")
+
+
+def test_get_rejects_none_name():
+    client = MagicMock()
+    p = SecretManagerProvider("proj", client)
+    with pytest.raises(TypeError):
+        p.get(None)
+
+
+def test_secret_path_format():
+    """Verify the path format sent to the client."""
+    client = MagicMock()
+    client.access_secret_version.return_value = _make_response("v")
+    p = SecretManagerProvider("my-project", client)
+    p.get("api-key", version="3")
+    call_args = client.access_secret_version.call_args
+    req_name = (call_args[1].get("request") or call_args[0][0])["name"]
+    assert req_name == "projects/my-project/secrets/api-key/versions/3"
+
+
+# ---------------------------------------------------------------------------
+# close() tests
+# ---------------------------------------------------------------------------
+
+def test_close_delegates_to_client():
+    client = MagicMock()
+    p = SecretManagerProvider("proj", client)
+    p.close()
+    client.close.assert_called_once()
+
+
+def test_close_is_safe_if_client_has_no_close():
+    client = MagicMock(spec=[])  # no close attribute
+    p = SecretManagerProvider.__new__(SecretManagerProvider)
+    p.project_id = "proj"
+    p.client = client
+    # Should not raise
+    p.close()
+
+
+# ---------------------------------------------------------------------------
+# AutoConfig discovery assertion (critical — T19.1 requirement)
+# ---------------------------------------------------------------------------
+
+def test_discovery_includes_secret_manager_provider():
+    """Entry-point must be discoverable after editable install.
+
+    This test fails if:
+    - pyproject.toml entry-point is malformed/missing.
+    - The package is not pip install -e'd.
+    - The entry-point name does not match the AutoConfig field 'secrets'.
+    """
+    config = discover()
+    assert SecretManagerProvider in config.secrets, (
+        f"SecretManagerProvider not found in AutoConfig.discover().secrets. "
+        f"Found: {config.secrets}. "
+        "Ensure the package is installed with 'pip install -e .' and "
+        "pyproject.toml declares "
+        "[project.entry-points.\"data_pipeline_core.adapters\"] "
+        "secrets = \"data_pipeline_gcp_secrets:SecretManagerProvider\""
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ where = [
     "deployments/mainframe-segment-transform/src",
 ]
 
+[tool.pytest.ini_options]
+addopts = "--import-mode=importlib"
+
 [project.optional-dependencies]
 dev = [
     "pytest>=7.0.0",


### PR DESCRIPTION
Sprint-19 integration → main (Joseph's merge trigger). Epic #112. Java frozen at `java-1.0.0`.

### Landed (4 agents, disjoint ownership, under the dev-agent DoD)
- **T19.1 (#124)** — Python `gcp-secrets` (`SecretManagerProvider`), discoverable + `SecretProviderContract` bound.
- **T19.2 (#125)** — Python `gcp-observability` (CloudTrace hook, CloudMonitoring metrics, DataCatalog lineage, MDC populator), discoverable + `StageMetricsHookContract` bound.
- **T19.3 (#126)** — `BigQueryFinOpsSink` + BigQuery/GCS/PubSub cost trackers (pricing constants **and formulas** mirrored from Java, end-to-end cost-derivation tests), entry-points for all impls.
- **T19.4 (#127)** — wired `DataQualityTransform` masking → `Masker` (resolves #121).

### Systemic fix (not deferred): adapter auto-discovery
Existing Python adapters declared **no** entry-points, so `AutoConfig.discover()` found nothing. Wave C adds `data_pipeline_core.adapters` entry-points across all packages. `discover()` now resolves the full set: secrets, blob_store, warehouse, finops, stage_metrics, observability, source, sink.

### Verification (independent, per DoD)
Full combined suite across all 7 packages: **411 passed, 0 failed**. The combined run caught an integration failure isolation hid (two core 'bare classpath' tests broken by the new registration) — fixed by making them hermetic. T19.3 was recovered from a socket-dropped agent: work verified (pricing checked vs Java) and committed by the architect.

### Genuinely not-now (not flag-and-defer)
- **#122** (worker-side registry rebuild across T10.6 boundary) stays open — it requires distributed execution that Python's lane doesn't have (Dataflow is Java). No code path serializes a Python RuntimeContext today; implementing it now would be untestable speculation.

closes #124, closes #125, closes #126, closes #127, closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)