### PR TITLE
chore: re-version Culvert to 0.1.0 (first release is 0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 All notable changes to the Culvert data pipeline framework. See [DEV_PROCESS.md](docs/framework-evolution/03-dev-process.md) for the sprint workflow.
 
-## [1.0.0] — 2026-06-13
+## [0.1.0] — unreleased
 
-**All 16 contract interfaces have real Java adapters. The Java v1.0 feature bar is met — built and HELD, not yet published.**
+**All 16 contract interfaces have real Java adapters. The feature bar for the first release is met — built and HELD, not yet published.**
 
-This spans Sprints 9–16: every contract interface defined in `data-pipeline-core-java` now has at least one concrete adapter under `com.enrichmeai.culvert:*`. The Java reactor is frozen at tag `java-1.0.0`, but it does **not** publish alone — the release gate is Java **and** Python both ready, then a coordinated `1.0.0` to Maven Central **and** PyPI (`culvert`). See `docs/framework-evolution/13-python-parity-release.md`. The Python parity work (Sprints 17+) is in progress.
+Culvert's first public release is **0.1.0** (a real first release, not yet API-frozen at 1.0). This spans Sprints 9–16: every contract interface defined in `data-pipeline-core-java` now has at least one concrete adapter under `com.enrichmeai.culvert:*`. The Java reactor is frozen at tag `java-0.1.0`, but it does **not** publish alone — the release gate is Java **and** Python both ready, then a coordinated `0.1.0` to Maven Central **and** PyPI (`culvert`). See `docs/framework-evolution/13-python-parity-release.md`. The Python parity work (Sprints 17+) is in progress. (The predecessor framework's `1.0.x` line — last `1.0.29` — is unrelated and deprecated; Culvert versions start fresh at 0.1.0.)
 
 ### Java libraries (`com.enrichmeai.culvert:*`) — Sprint 9–16 additions
 
@@ -19,7 +19,7 @@ This spans Sprints 9–16: every contract interface defined in `data-pipeline-co
 - **Sprint 15 (CI gate)** — `.github/workflows/ci.yml`: per-module parallel matrix (Java 21); integration-test stage (`-P it verify`); PR check suite blocking merge until all contract modules pass.
 - **Sprint 16 (hardening)** — Dataflow perf/load-test notes (`docs/PERF_TUNING.md`); security review (`docs/SECURITY_IAM.md`, `docs/SECURITY_CVE.md`); operational runbook (`docs/RUNBOOK.md`); SLO/alerting docs (`docs/SLO_ALERTING.md`); release dry-run (T16.4, this ticket).
 
-### Contract completion status at 1.0.0
+### Contract completion status at 0.1.0
 
 | Contract | Adapter(s) |
 |---|---|
@@ -40,7 +40,7 @@ This spans Sprints 9–16: every contract interface defined in `data-pipeline-co
 | `FinOpsSink` | `BigQueryFinOpsSink` |
 | `SecretProvider` | `SecretManagerProvider` |
 
-**Java reactor at 1.0.0: 13 modules, 478 tests (0 failures, 0 errors).**
+**Java reactor at 0.1.0: 13 modules, 478 tests (0 failures, 0 errors).**
 
 ### Not published in this release
 
@@ -50,9 +50,9 @@ This spans Sprints 9–16: every contract interface defined in `data-pipeline-co
 
 ---
 
-## [0.1.0] — unreleased
+### 0.1.0 foundation — the first feature-complete dev-cycle (Sprints 0–8)
 
-The framework's first feature-complete dev-cycle. **Not yet published to PyPI / Maven Central** — that step waits for explicit go.
+The earlier foundation of the same unreleased 0.1.0 (the Sprint 9–16 additions above build on this). **Not yet published to PyPI / Maven Central** — that step waits for explicit go.
 
 ### Java libraries (`com.enrichmeai.culvert:*`)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Culvert is a framework for building data pipelines that are **defined once against a language-neutral contract and implemented in the language that fits the job**. The same 16 contracts (Source, Sink, Transform, Pipeline, RuntimeContext, BlobStore, Warehouse, FinOpsSink, GovernancePolicy, …) are realised in both a Java library set and a Python library set; cloud specifics live behind adapters, so the core stays portable across clouds.
 
-> **Status — in progress.** The Java reactor has reached its v1.0 feature bar (all 16 contract interfaces have real adapters) and is **frozen at tag `java-1.0.0`**. It is **built and held, not yet published**: the release gate is **Java _and_ Python both ready**, then a single coordinated `1.0.0` to Maven Central (`com.enrichmeai.culvert:*`) and PyPI (`culvert`). Python parity is underway — contracts, core depth, and the GCP adapters have landed; `culvert` packaging and publish-from-git remain. **Nothing is on Maven Central or PyPI yet.** Authoritative plan: [`docs/framework-evolution/13-python-parity-release.md`](docs/framework-evolution/13-python-parity-release.md).
+> **Status — in progress.** The Java reactor has reached its v1.0 feature bar (all 16 contract interfaces have real adapters) and is **frozen at tag `java-0.1.0`**. It is **built and held, not yet published**: the release gate is **Java _and_ Python both ready**, then a single coordinated `0.1.0` to Maven Central (`com.enrichmeai.culvert:*`) and PyPI (`culvert`). Python parity is underway — contracts, core depth, and the GCP adapters have landed; `culvert` packaging and publish-from-git remain. **Nothing is on Maven Central or PyPI yet.** Authoritative plan: [`docs/framework-evolution/13-python-parity-release.md`](docs/framework-evolution/13-python-parity-release.md).
 
 > **Repo vs product.** The GitHub repo is `enrichmeai/culvert`; the working-tree folder is still `gcp-pipeline-reference`. The folder name is an operational identifier, not the product name.
 
@@ -76,10 +76,10 @@ The 16 contract interfaces are the heart of the framework. Read [`docs/CONTRACT.
 
 The framework is being completed in sprint waves; the authoritative plan is [`docs/framework-evolution/13-python-parity-release.md`](docs/framework-evolution/13-python-parity-release.md).
 
-- ✅ **Java reactor 1.0.0** — all 16 contracts have adapters; frozen at `java-1.0.0`.
+- ✅ **Java reactor 0.1.0** — all 16 contracts have adapters; frozen at `java-0.1.0`.
 - ✅ **Python contracts + core depth** — Protocols reconciled to Java; `DefaultRuntimeContext`, data-quality, governance policies, FinOps cost model.
 - ✅ **Python GCP adapters** — secrets, observability, and per-service cost trackers; all auto-discoverable.
-- ⏳ **Packaging & coordinated release** — `culvert` PyPI distribution + publish-from-git, then a single `1.0.0` to Maven Central **and** PyPI.
+- ⏳ **Packaging & coordinated release** — `culvert` PyPI distribution + publish-from-git, then a single `0.1.0` to Maven Central **and** PyPI.
 
 Architecture: [`docs/framework-evolution/10-architecture.md`](docs/framework-evolution/10-architecture.md). Full series (audit, redesign, dev process, sprint plans): [`docs/framework-evolution/`](docs/framework-evolution/).
 

--- a/data-pipeline-libraries-java/data-pipeline-aws-s3-java/pom.xml
+++ b/data-pipeline-libraries-java/data-pipeline-aws-s3-java/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.enrichmeai.culvert</groupId>
         <artifactId>data-pipeline-libraries-parent</artifactId>
-        <version>1.0.0</version>
+        <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/data-pipeline-libraries-java/data-pipeline-azure-blob-java/pom.xml
+++ b/data-pipeline-libraries-java/data-pipeline-azure-blob-java/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.enrichmeai.culvert</groupId>
         <artifactId>data-pipeline-libraries-parent</artifactId>
-        <version>1.0.0</version>
+        <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/data-pipeline-libraries-java/data-pipeline-contract-tests-java/pom.xml
+++ b/data-pipeline-libraries-java/data-pipeline-contract-tests-java/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.enrichmeai.culvert</groupId>
         <artifactId>data-pipeline-libraries-parent</artifactId>
-        <version>1.0.0</version>
+        <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/data-pipeline-libraries-java/data-pipeline-core-java/pom.xml
+++ b/data-pipeline-libraries-java/data-pipeline-core-java/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.enrichmeai.culvert</groupId>
         <artifactId>data-pipeline-libraries-parent</artifactId>
-        <version>1.0.0</version>
+        <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/data-pipeline-libraries-java/data-pipeline-gcp-bigquery-java/pom.xml
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-bigquery-java/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.enrichmeai.culvert</groupId>
         <artifactId>data-pipeline-libraries-parent</artifactId>
-        <version>1.0.0</version>
+        <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/data-pipeline-libraries-java/data-pipeline-gcp-dataflow-java/pom.xml
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-dataflow-java/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.enrichmeai.culvert</groupId>
         <artifactId>data-pipeline-libraries-parent</artifactId>
-        <version>1.0.0</version>
+        <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/data-pipeline-libraries-java/data-pipeline-gcp-gcs-java/pom.xml
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-gcs-java/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.enrichmeai.culvert</groupId>
         <artifactId>data-pipeline-libraries-parent</artifactId>
-        <version>1.0.0</version>
+        <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/data-pipeline-libraries-java/data-pipeline-gcp-observability-java/pom.xml
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-observability-java/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.enrichmeai.culvert</groupId>
         <artifactId>data-pipeline-libraries-parent</artifactId>
-        <version>1.0.0</version>
+        <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/data-pipeline-libraries-java/data-pipeline-gcp-pubsub-java/pom.xml
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-pubsub-java/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.enrichmeai.culvert</groupId>
         <artifactId>data-pipeline-libraries-parent</artifactId>
-        <version>1.0.0</version>
+        <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/data-pipeline-libraries-java/data-pipeline-gcp-secrets-java/pom.xml
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-secrets-java/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.enrichmeai.culvert</groupId>
         <artifactId>data-pipeline-libraries-parent</artifactId>
-        <version>1.0.0</version>
+        <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/data-pipeline-libraries-java/data-pipeline-it-support-java/pom.xml
+++ b/data-pipeline-libraries-java/data-pipeline-it-support-java/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.enrichmeai.culvert</groupId>
         <artifactId>data-pipeline-libraries-parent</artifactId>
-        <version>1.0.0</version>
+        <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/data-pipeline-libraries-java/data-pipeline-orchestration-java/pom.xml
+++ b/data-pipeline-libraries-java/data-pipeline-orchestration-java/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.enrichmeai.culvert</groupId>
         <artifactId>data-pipeline-libraries-parent</artifactId>
-        <version>1.0.0</version>
+        <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/data-pipeline-libraries-java/data-pipeline-tester-java/pom.xml
+++ b/data-pipeline-libraries-java/data-pipeline-tester-java/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.enrichmeai.culvert</groupId>
         <artifactId>data-pipeline-libraries-parent</artifactId>
-        <version>1.0.0</version>
+        <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/data-pipeline-libraries-java/pom.xml
+++ b/data-pipeline-libraries-java/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.enrichmeai.culvert</groupId>
     <artifactId>data-pipeline-libraries-parent</artifactId>
-    <version>1.0.0</version>
+    <version>0.1.0</version>
     <packaging>pom</packaging>
 
     <name>Culvert :: data-pipeline-libraries (parent)</name>

--- a/data-pipeline-libraries/data-pipeline-contract-tests/src/data_pipeline_contract_tests/__init__.py
+++ b/data-pipeline-libraries/data-pipeline-contract-tests/src/data_pipeline_contract_tests/__init__.py
@@ -18,7 +18,7 @@ from data_pipeline_contract_tests.secrets import SecretProviderContract
 from data_pipeline_contract_tests.stage_metrics_hook import StageMetricsHookContract
 from data_pipeline_contract_tests.warehouse import WarehouseContract
 
-__version__ = "0.2.0"
+__version__ = "0.1.0"
 
 __all__ = [
     "BlobStoreContract",

--- a/data-pipeline-libraries/data-pipeline-framework/pyproject.toml
+++ b/data-pipeline-libraries/data-pipeline-framework/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "data-pipeline-framework"
-version = "1.0.0"
+version = "0.1.0"
 description = "Umbrella metapackage for the Culvert data pipeline framework. Installs the full reference stack (core + tester + transform + orchestration). Includes bundled deployment templates, Terraform modules, and CI workflow templates. Renamed successor of `data-pipeline-framework`."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/data-pipeline-libraries/data-pipeline-orchestration/pyproject.toml
+++ b/data-pipeline-libraries/data-pipeline-orchestration/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "data-pipeline-orchestration"
-version = "1.0.0"
+version = "0.1.0"
 description = "Orchestration library for the Culvert data pipeline framework. Airflow DAG factory, operators, sensors, and callbacks. Cloud-coupled to Composer/Airflow — Airflow is Python-only and is not being polyglot-ported. Renamed successor of `gcp-pipeline-orchestration`."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/data-pipeline-libraries/data-pipeline-orchestration/src/data_pipeline_orchestration/__init__.py
+++ b/data-pipeline-libraries/data-pipeline-orchestration/src/data_pipeline_orchestration/__init__.py
@@ -33,7 +33,7 @@ Example:
     ```
 """
 
-__version__ = "1.0.29"
+__version__ = "0.1.0"
 
 # Non-Airflow modules: safe to import anywhere
 from .factories import (

--- a/data-pipeline-libraries/data-pipeline-tester/pyproject.toml
+++ b/data-pipeline-libraries/data-pipeline-tester/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "data-pipeline-tester"
-version = "1.0.0"
+version = "0.1.0"
 description = "Testing framework for the Culvert data pipeline framework. Base test classes, builders, assertions, BDD steps, mocks, and fixtures for Source/Sink/Transform pipelines and their cloud-specific implementations. Renamed successor of `gcp-pipeline-tester`."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/data-pipeline-libraries/data-pipeline-tester/src/data_pipeline_tester/__init__.py
+++ b/data-pipeline-libraries/data-pipeline-tester/src/data_pipeline_tester/__init__.py
@@ -10,7 +10,7 @@ Example:
     >>> from data_pipeline_tester.mocks import GCSClientMock, BigQueryClientMock
 """
 
-__version__ = "1.0.29"
+__version__ = "0.1.0"
 
 from .base import (
     TestResult,

--- a/data-pipeline-libraries/data-pipeline-transform/pyproject.toml
+++ b/data-pipeline-libraries/data-pipeline-transform/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "data-pipeline-transform"
-version = "1.0.0"
+version = "0.1.0"
 description = "dbt macro library for the Culvert data pipeline framework (audit columns, PII masking, data-quality checks). Renamed successor of `gcp-pipeline-transform`. dbt-SQL only — no Apache Beam, no Airflow."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/data-pipeline-libraries/data-pipeline-transform/src/data_pipeline_transform/__init__.py
+++ b/data-pipeline-libraries/data-pipeline-transform/src/data_pipeline_transform/__init__.py
@@ -1,4 +1,4 @@
 """
 GCP Pipeline Transform Library
 """
-__version__ = "1.0.29"
+__version__ = "0.1.0"

--- a/docs/framework-evolution/13-python-parity-release.md
+++ b/docs/framework-evolution/13-python-parity-release.md
@@ -2,13 +2,13 @@
 
 **Status:** in progress. Wave A (S17, contract reconciliation) **merged to `main`**;
 Wave B (S18, core depth) **in PR #123**. Successor to the 9–16 Java block (Java
-reactor at `1.0.0` on `main`, frozen at tag `java-1.0.0`).
+reactor at `0.1.0` on `main`, frozen at tag `java-0.1.0`).
 
 **One-line:** Culvert is one polyglot, cloud-agnostic framework with GCP as its
-first implementation. Java is built to `1.0.0` but does **not** ship alone — the
+first implementation. Java is built to `0.1.0` but does **not** ship alone — the
 release gate is **Java *and* Python both ready**, then a single coordinated
 publish to Maven Central (`com.enrichmeai.culvert:*`) **and** PyPI (`culvert`).
-This epic closes the Python side and ships the coordinated `1.0.0`.
+This epic closes the Python side and ships the coordinated `0.1.0`.
 
 ---
 
@@ -32,13 +32,13 @@ scope** for this release (defer to a later block).
 ## 2. Release gate
 
 ```
-Java 1.0.0 (built, frozen)  ─┐
-                             ├─►  coordinated 1.0.0  ──►  Maven Central + PyPI (culvert), together
+Java 0.1.0 (built, frozen)  ─┐
+                             ├─►  coordinated 0.1.0  ──►  Maven Central + PyPI (culvert), together
 Python parity (this epic)  ──┘                       └─►  legacy gcp-pipeline-framework: deprecate-in-place
 ```
 
-- Java 1.0.0 is **built but held**. It does not publish to Maven Central on its
-  own. **Action: freeze it now** — tag/branch `java-1.0.0` so the coordinated
+- Java 0.1.0 is **built but held**. It does not publish to Maven Central on its
+  own. **Action: freeze it now** — tag/branch `java-0.1.0` so the coordinated
   release ships exactly what was tested, and the Java side can't silently drift
   under the epic and publish something un-re-verified.
 - Publish is **from git / GitHub Actions** for both ecosystems (per Joseph):
@@ -47,7 +47,7 @@ Python parity (this epic)  ──┘                       └─►  legacy gcp
 - **Irreversible.** PyPI version numbers can't be reused; Maven Central is
   immutable. The publish itself stays a Joseph-gated manual trigger.
 
-## 3. Current state — Python vs Java 1.0.0 (baseline content-verified 2026-06-14)
+## 3. Current state — Python vs Java 0.1.0 (baseline content-verified 2026-06-14)
 
 **Python already has more than a filename scan suggests.** Verified by grepping
 class definitions, not directory names. *This was the pre-Wave-A baseline; the
@@ -64,7 +64,7 @@ gap table below is annotated with what Waves A/B since closed.*
 - **Adapters**: `data-pipeline-gcp-bigquery`, `-gcs`, `-pubsub`,
   `-orchestration` (runtime), `-transform` (dbt), `-tester`, `-contract-tests`.
 
-### Gaps vs Java 1.0.0 (with Wave A/B status)
+### Gaps vs Java 0.1.0 (with Wave A/B status)
 | Gap | Kind | Status |
 |---|---|---|
 | `StageMetrics` / `StageMetricsHook` | **Contract** | ✅ **DONE** — Wave A (T17.1, #113). |
@@ -126,7 +126,7 @@ within ~30 min; worktrees pre-created off the sprint branch per `CLAUDE.md`).
   unreusable, breaks pinned dependents for zero benefit).
 
 **G. Docs / CHANGELOG**
-- G1: Reframe the `1.0.0` CHANGELOG entry — Java is **built and held for the
+- G1: Reframe the `0.1.0` CHANGELOG entry — Java is **built and held for the
   coordinated polyglot release**, not "done/shipped". Currently it reads as a
   Java-only milestone already complete, which is premature under the both-ready
   gate.


### PR DESCRIPTION
Culvert's first public release is **0.1.0** (real first release, not yet API-frozen at 1.0). The inherited `1.0.0` across the reactor and the stale legacy `1.0.29` strings were wrong; this aligns everything to one honest version.

### Changes
- **Java** — parent pom + all module parent-refs `1.0.0` → `0.1.0` (15 poms).
- **Python** — 4 `pyproject.toml` `1.0.0` → `0.1.0`; `__init__` `1.0.29` (3 legacy) + `0.2.0` (1) → `0.1.0`; all 10 package `__version__` now uniform `0.1.0`.
- **CHANGELOG** — `[1.0.0]` → `[0.1.0] unreleased` + reframed; reconciled the duplicate `0.1.0` heading into one entry (foundation Sprints 0–8 + Sprint 9–16 additions).
- **docs/framework-evolution/13** — `1.0.0` → `0.1.0`, `java-1.0.0` → `java-0.1.0`.

### Post-merge step (Joseph or me, after merge)
Re-tag the freeze point: `git tag -d java-1.0.0 && git push origin :java-1.0.0` then `git tag -a java-0.1.0 <merge-sha> && git push origin java-0.1.0`. Left for after merge so the tag points at the 0.1.0 pom state.

### Not touched
- Historical sprint-plan docs (04/06/08) keep their dated "1.0.0 milestone" wording — they're records, not current state.
- The book chapters' version refs are fixed separately on `book/culvert-v2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)