### PR TITLE
fix(infra): flat-root Composer optional (default off) — no accidental Composer cost

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -1,24 +1,21 @@
 # =============================================================================
-# GCP Pipeline Reference — Terraform Root Configuration (Generic System)
+# DEPRECATED — legacy flat Terraform root (Generic System)
 # =============================================================================
 #
-# This is the complete infrastructure for the Generic data pipeline:
-#   - GCS buckets (landing, archive, error, temp)
-#   - BigQuery datasets (ODP, FDP, job_control)
-#   - Pub/Sub (file notifications + dead letter)
-#   - Cloud Composer (Airflow orchestration)
-#   - Service accounts (dataflow, dbt, composer)
-#   - IAM bindings (least-privilege per service account)
-#   - Entity folder scaffolding in landing bucket
+# SUPERSEDED BY infrastructure/terraform/systems/generic (canonical: layered
+# ingestion/transformation/orchestration, Composer-optional, Cloud Run). Do NOT
+# apply this layer for new work — use:
+#   cd infrastructure/terraform/systems/generic/ingestion && terraform apply ...
 #
-# Usage:
-#   cd infrastructure/terraform
-#   terraform init
-#   terraform plan -var="gcp_project_id=<your-project>"
-#   terraform apply -var="gcp_project_id=<your-project>"
-#
-# Destroy:
-#   terraform destroy -var="gcp_project_id=<your-project>" -var="force_destroy=true"
+# This file is retained only until its KMS keys (security.tf) are confirmed
+# covered by systems/generic, then it is retired. Two safety changes were made
+# so a stray apply can't cost money or fail:
+#   - Cloud Composer is now gated by var.enable_composer (default FALSE) — no
+#     standing ~£8-12/day environment unless explicitly enabled.
+#   - Fixed a pre-existing dangling reference (generic_notifications ->
+#     generic_file_notifications_sub) that meant this layer never planned.
+# NOTE: the Composer block still pins predecessor pypi packages; that is dead
+# config on a deprecated, off-by-default resource and is removed at retirement.
 # =============================================================================
 
 terraform {
@@ -406,9 +403,10 @@ resource "google_pubsub_subscription_iam_member" "generic_composer_subscriber" {
 # =============================================================================
 
 resource "google_composer_environment" "generic_composer" {
-  name    = "${local.prefix}-composer"
-  region  = local.region
-  labels  = local.common_labels
+  count  = var.enable_composer ? 1 : 0
+  name   = "${local.prefix}-composer"
+  region = local.region
+  labels = local.common_labels
 
   config {
     environment_size = "ENVIRONMENT_SIZE_SMALL"
@@ -417,9 +415,9 @@ resource "google_composer_environment" "generic_composer" {
       image_version = "composer-2-airflow-2"
 
       pypi_packages = {
-        gcp-pipeline-core                 = "==1.0.26"
-        gcp-pipeline-orchestration        = "==1.0.26"
-        apache-airflow-providers-google   = ">=10.0.0"
+        gcp-pipeline-core               = "==1.0.26"
+        gcp-pipeline-orchestration      = "==1.0.26"
+        apache-airflow-providers-google = ">=10.0.0"
       }
 
       airflow_config_overrides = {
@@ -451,35 +449,36 @@ resource "google_composer_environment" "generic_composer" {
 # =============================================================================
 
 resource "null_resource" "airflow_variables" {
+  count      = var.enable_composer ? 1 : 0
   depends_on = [google_composer_environment.generic_composer]
 
   provisioner "local-exec" {
     command = <<-EOT
-      gcloud composer environments run ${google_composer_environment.generic_composer.name} \
+      gcloud composer environments run ${google_composer_environment.generic_composer[0].name} \
         --location=${local.region} \
         variables set -- gcp_project_id ${local.project_id}
 
-      gcloud composer environments run ${google_composer_environment.generic_composer.name} \
+      gcloud composer environments run ${google_composer_environment.generic_composer[0].name} \
         --location=${local.region} \
         variables set -- gcp_region ${local.region}
 
-      gcloud composer environments run ${google_composer_environment.generic_composer.name} \
+      gcloud composer environments run ${google_composer_environment.generic_composer[0].name} \
         --location=${local.region} \
         variables set -- environment ${local.environment}
 
-      gcloud composer environments run ${google_composer_environment.generic_composer.name} \
+      gcloud composer environments run ${google_composer_environment.generic_composer[0].name} \
         --location=${local.region} \
         variables set -- dataflow_templates_bucket ${google_storage_bucket.temp.name}
 
-      gcloud composer environments run ${google_composer_environment.generic_composer.name} \
+      gcloud composer environments run ${google_composer_environment.generic_composer[0].name} \
         --location=${local.region} \
-        variables set -- generic_pubsub_subscription ${google_pubsub_subscription.generic_notifications.name}
+        variables set -- generic_pubsub_subscription ${google_pubsub_subscription.generic_file_notifications_sub.name}
     EOT
   }
 
   triggers = {
     # Re-run if Composer environment changes
-    composer_id = google_composer_environment.generic_composer.id
+    composer_id = google_composer_environment.generic_composer[0].id
   }
 }
 

--- a/infrastructure/terraform/outputs.tf
+++ b/infrastructure/terraform/outputs.tf
@@ -88,12 +88,12 @@ output "composer_service_account_email" {
 # ============================================================================
 
 output "composer_airflow_uri" {
-  value       = google_composer_environment.generic_composer.config[0].airflow_uri
+  value       = one(google_composer_environment.generic_composer[*].config[0].airflow_uri)
   description = "Airflow web UI URL"
 }
 
 output "composer_dag_gcs_prefix" {
-  value       = google_composer_environment.generic_composer.config[0].dag_gcs_prefix
+  value       = one(google_composer_environment.generic_composer[*].config[0].dag_gcs_prefix)
   description = "GCS path for DAG uploads"
 }
 
@@ -133,9 +133,9 @@ output "deployment_summary" {
       file_notifications_sub   = google_pubsub_subscription.generic_file_notifications_sub.name
     }
     composer = {
-      environment = google_composer_environment.generic_composer.name
-      airflow_uri = google_composer_environment.generic_composer.config[0].airflow_uri
-      dag_gcs     = google_composer_environment.generic_composer.config[0].dag_gcs_prefix
+      environment = one(google_composer_environment.generic_composer[*].name)
+      airflow_uri = one(google_composer_environment.generic_composer[*].config[0].airflow_uri)
+      dag_gcs     = one(google_composer_environment.generic_composer[*].config[0].dag_gcs_prefix)
     }
   }
   description = "Summary of all deployed resources"

--- a/infrastructure/terraform/services.tf
+++ b/infrastructure/terraform/services.tf
@@ -23,31 +23,31 @@ variable "required_services" {
     # ==========================================================================
     # Compute Services
     # ==========================================================================
-    "container.googleapis.com",            # GKE (for Airflow)
-    "dataflow.googleapis.com",             # Dataflow (for Beam pipelines)
-    "compute.googleapis.com",              # Compute Engine (for GKE nodes)
+    "container.googleapis.com", # GKE (for Airflow)
+    "dataflow.googleapis.com",  # Dataflow (for Beam pipelines)
+    "compute.googleapis.com",   # Compute Engine (for GKE nodes)
 
     # ==========================================================================
     # Build & Deploy Services
     # ==========================================================================
-    "cloudbuild.googleapis.com",           # Cloud Build
-    "containerregistry.googleapis.com",    # Container Registry (GCR)
-    "artifactregistry.googleapis.com",     # Artifact Registry
+    "cloudbuild.googleapis.com",        # Cloud Build
+    "containerregistry.googleapis.com", # Container Registry (GCR)
+    "artifactregistry.googleapis.com",  # Artifact Registry
 
     # ==========================================================================
     # Monitoring & Observability
     # ==========================================================================
-    "monitoring.googleapis.com",           # Cloud Monitoring
-    "logging.googleapis.com",              # Cloud Logging
-    "cloudtrace.googleapis.com",           # Cloud Trace
-    "clouderrorreporting.googleapis.com",  # Error Reporting
+    "monitoring.googleapis.com",          # Cloud Monitoring
+    "logging.googleapis.com",             # Cloud Logging
+    "cloudtrace.googleapis.com",          # Cloud Trace
+    "clouderrorreporting.googleapis.com", # Error Reporting
 
     # ==========================================================================
     # Security Services
     # ==========================================================================
-    "secretmanager.googleapis.com",        # Secret Manager
-    "cloudkms.googleapis.com",             # Cloud KMS (encryption)
-    "iamcredentials.googleapis.com",       # IAM Credentials
+    "secretmanager.googleapis.com",  # Secret Manager
+    "cloudkms.googleapis.com",       # Cloud KMS (encryption)
+    "iamcredentials.googleapis.com", # IAM Credentials
 
     # ==========================================================================
     # Optional Services (uncomment if needed)

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -1,8 +1,25 @@
 # GCP Pipeline Reference - Terraform Variables
+#
+# DEPRECATED LAYER. This flat root is the legacy single-file infrastructure and
+# is superseded by infrastructure/terraform/systems/generic (canonical: layered,
+# Composer-optional, Cloud Run). Nothing applies this layer (the bootstrap script
+# targets bootstrap/ and directs users to systems/generic/ingestion). It is kept
+# only until its KMS keys (security.tf) are confirmed covered by systems/generic,
+# then retired. Do not apply it for new work.
 
 # ============================================================================
 # GCP CONFIGURATION
 # ============================================================================
+
+# Composer is OFF by default here so a stray apply of this deprecated layer never
+# stands up a costly Cloud Composer environment (~£8-12/day). Composer is optional
+# and lives in systems/generic for real use. See
+# docs/framework-evolution/14-execution-tiers.md.
+variable "enable_composer" {
+  type        = bool
+  default     = false
+  description = "When true, provision the (legacy) Cloud Composer environment. Default false: no standing Composer cost."
+}
 
 variable "gcp_project_id" {
   description = "GCP Project ID"


### PR DESCRIPTION
The demo must not incur Cloud Composer cost. The legacy flat Terraform root (`infrastructure/terraform`) declared Composer **unconditionally** — a stray `terraform apply` there would stand up a ~£8-12/day environment.

**Investigation** (before touching anything): `systems/generic` is the **canonical** layer (107 resources, layered, already Composer-optional + Cloud Run; the bootstrap script and guidance point there). The flat root is legacy (45 resources, 2 months staler) and **nothing applies it** — confirmed it's referenced only by docs, called as a module by nothing, and absent from CI.

**Changes (safe, focused):**
- Composer gated by `var.enable_composer` (default **false**) — guarded the resource, the `airflow_variables` null_resource, and the composer outputs. The composer SA/IAM (free) are untouched.
- Deprecation banner → `systems/generic`.
- Fixed a **pre-existing dangling reference** (`generic_notifications` → `generic_file_notifications_sub`) that meant this layer never even planned — more proof it's dead. `terraform validate` now passes.

**Why not delete it outright:** its `security.tf` provisions **KMS keys** whose coverage in `systems/generic` I haven't confirmed — deleting encryption infra unverified is not worth the risk. Full retirement (incl. removing the predecessor `gcp-pipeline-core` pypi pins on the now-off Composer) is scoped as a follow-up once KMS coverage is verified.

Ties to #157 (execution tiers — Composer optional) / #156 (deploy cost plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)