### PR TITLE
feat(orchestration): event-driven cloudrun-only chain (Eventarc → Workflows → Jobs)

### DIFF
--- a/infrastructure/terraform/systems/generic/orchestration_cloudrun.tf
+++ b/infrastructure/terraform/systems/generic/orchestration_cloudrun.tf
@@ -1,0 +1,113 @@
+# =============================================================================
+# Event-driven cloudrun-only orchestration (the no-Composer path)
+# =============================================================================
+# File lands in the landing bucket -> Eventarc (object.finalized) -> Cloud
+# Workflows (infrastructure/workflows/ingest-on-landing.yaml) -> ingestion
+# Cloud Run Job (per-event arg overrides) -> dbt Cloud Run Job.
+#
+# This is the enable_composer=false counterpart: Workflows has no standing
+# cost and the jobs scale to zero. The Cloud Run JOBS themselves belong to the
+# per-deployment terraform (docs/framework-evolution/15) — this file owns only
+# the orchestration plane (SA + IAM + workflow + trigger).
+#
+# NOTE (culvert-501806): these resources were first created by hand on
+# 2026-07-10 (PR #161). To adopt them instead of recreating:
+#   terraform import google_service_account.orchestrator projects/<p>/serviceAccounts/culvert-orchestrator@<p>.iam.gserviceaccount.com
+#   terraform import 'google_workflows_workflow.ingest_on_landing' projects/<p>/locations/europe-west2/workflows/culvert-ingest-on-landing
+#   terraform import 'google_eventarc_trigger.landing' projects/<p>/locations/europe-west2/triggers/culvert-landing-trigger
+#
+# IAM learnings encoded below (hard-won on the first deploy):
+#   - jobs.run WITH containerOverrides needs run.jobs.runWithOverrides
+#     (roles/run.developer) — roles/run.invoker alone 403s.
+#   - The GCS service agent needs pubsub.publisher for Eventarc GCS triggers.
+#   - The Eventarc service agent must exist (provisioned on first API use or
+#     via `gcloud beta services identity create`) with eventarc.serviceAgent.
+#   - Trigger location must equal the bucket's region.
+
+variable "enable_event_orchestration" {
+  description = "Deploy the Eventarc -> Workflows -> Cloud Run Jobs orchestration plane (no standing cost)."
+  type        = bool
+  default     = true
+}
+
+resource "google_service_account" "orchestrator" {
+  count        = var.enable_event_orchestration ? 1 : 0
+  account_id   = "culvert-orchestrator"
+  display_name = "Culvert workflow orchestrator"
+  description  = "Runs ingest-on-landing: receives GCS events, executes Cloud Run jobs."
+}
+
+resource "google_project_iam_member" "orchestrator_run_developer" {
+  count   = var.enable_event_orchestration ? 1 : 0
+  project = var.gcp_project_id
+  # run.developer, not run.invoker: jobs.run WITH overrides requires
+  # run.jobs.runWithOverrides, which invoker lacks.
+  role   = "roles/run.developer"
+  member = "serviceAccount:${google_service_account.orchestrator[0].email}"
+}
+
+resource "google_project_iam_member" "orchestrator_workflows_invoker" {
+  count   = var.enable_event_orchestration ? 1 : 0
+  project = var.gcp_project_id
+  role    = "roles/workflows.invoker"
+  member  = "serviceAccount:${google_service_account.orchestrator[0].email}"
+}
+
+resource "google_project_iam_member" "orchestrator_event_receiver" {
+  count   = var.enable_event_orchestration ? 1 : 0
+  project = var.gcp_project_id
+  role    = "roles/eventarc.eventReceiver"
+  member  = "serviceAccount:${google_service_account.orchestrator[0].email}"
+}
+
+resource "google_project_iam_member" "orchestrator_log_writer" {
+  count   = var.enable_event_orchestration ? 1 : 0
+  project = var.gcp_project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.orchestrator[0].email}"
+}
+
+# Eventarc GCS triggers deliver via Pub/Sub published by the GCS service agent.
+resource "google_project_iam_member" "gcs_agent_pubsub_publisher" {
+  count   = var.enable_event_orchestration ? 1 : 0
+  project = var.gcp_project_id
+  role    = "roles/pubsub.publisher"
+  member  = "serviceAccount:${data.google_storage_project_service_account.gcs_account.email_address}"
+}
+
+resource "google_workflows_workflow" "ingest_on_landing" {
+  count           = var.enable_event_orchestration ? 1 : 0
+  name            = "culvert-ingest-on-landing"
+  region          = var.gcp_region
+  service_account = google_service_account.orchestrator[0].email
+  source_contents = file("${path.module}/../../../workflows/ingest-on-landing.yaml")
+}
+
+resource "google_eventarc_trigger" "landing" {
+  count = var.enable_event_orchestration ? 1 : 0
+  name  = "culvert-landing-trigger"
+  # Must match the landing bucket's region.
+  location = var.gcp_region
+
+  matching_criteria {
+    attribute = "type"
+    value     = "google.cloud.storage.object.v1.finalized"
+  }
+  matching_criteria {
+    attribute = "bucket"
+    value     = google_storage_bucket.landing.name
+  }
+
+  destination {
+    workflow = google_workflows_workflow.ingest_on_landing[0].id
+  }
+
+  service_account = google_service_account.orchestrator[0].email
+
+  depends_on = [google_project_iam_member.gcs_agent_pubsub_publisher]
+}
+
+output "event_orchestration_workflow" {
+  description = "Ingest-on-landing workflow name ('disabled' when off)."
+  value       = var.enable_event_orchestration ? google_workflows_workflow.ingest_on_landing[0].name : "disabled"
+}

--- a/infrastructure/workflows/ingest-on-landing.yaml
+++ b/infrastructure/workflows/ingest-on-landing.yaml
@@ -26,6 +26,7 @@ main:
           - object: ${event.data.name}
           - ingestion_job: "ingestion-generic"
           - dbt_job: "dbt-mapped-product"
+          - cdp_job: "dbt-consumable-product"
     - skip_non_csv:
         switch:
           - condition: '${not text.match_regex(object, "^generic/[^/]+/.+\\.csv$")}'
@@ -64,11 +65,17 @@ main:
         args:
           name: ${"projects/" + project + "/locations/" + region + "/jobs/" + dbt_job}
         result: dbt_execution
+    - run_cdp:
+        call: googleapis.run.v2.projects.locations.jobs.run
+        args:
+          name: ${"projects/" + project + "/locations/" + region + "/jobs/" + cdp_job}
+        result: cdp_execution
     - done:
         return:
           entity: ${entity}
           extract_date: ${extract_date}
           ingestion: ${ingestion_execution.name}
           dbt: ${dbt_execution.name}
+          cdp: ${cdp_execution.name}
     - skipped:
         return: '${"skipped non-entity object. " + object}'

--- a/infrastructure/workflows/ingest-on-landing.yaml
+++ b/infrastructure/workflows/ingest-on-landing.yaml
@@ -1,0 +1,74 @@
+# Culvert cloudrun-only orchestration: landing file → ingest → transform.
+#
+# Eventarc (GCS object.finalized on the landing bucket) triggers this Cloud
+# Workflow; it runs the ingestion Cloud Run JOB for the file's entity (args
+# overridden per event), waits, then runs the dbt transform job. This is the
+# no-Airflow/no-Composer orchestration path (docs/framework-evolution/
+# 14-execution-tiers.md): Workflows has no standing cost and the jobs scale
+# to zero.
+#
+# Event contract: objects land as generic/<entity>/generic_<entity>_<yyyyMMdd>.csv
+# (the substrate's storage-notification prefix is generic/). Non-CSV objects
+# (e.g. .keep scaffolding) are skipped. Entities map to odp_generic.<entity>.
+#
+# Deploy (see repo docs):
+#   gcloud workflows deploy culvert-ingest-on-landing \
+#     --source=infrastructure/workflows/ingest-on-landing.yaml \
+#     --location=europe-west2 --service-account=<orchestrator SA>
+main:
+  params: [event]
+  steps:
+    - init:
+        assign:
+          - project: ${sys.get_env("GOOGLE_CLOUD_PROJECT_ID")}
+          - region: "europe-west2"
+          - bucket: ${event.data.bucket}
+          - object: ${event.data.name}
+          - ingestion_job: "ingestion-generic"
+          - dbt_job: "dbt-mapped-product"
+    - skip_non_csv:
+        switch:
+          - condition: '${not text.match_regex(object, "^generic/[^/]+/.+\\.csv$")}'
+            next: skipped
+        next: parse_object
+    - parse_object:
+        assign:
+          - parts: ${text.split(object, "/")}
+          - entity: ${parts[1]}
+          - filename: ${parts[2]}
+          # generic_<entity>_<yyyyMMdd>.csv → extract date is the last _-token
+          - name_tokens: ${text.split(text.replace_all(filename, ".csv", ""), "_")}
+          - extract_date: ${name_tokens[len(name_tokens) - 1]}
+          - source_uri: ${"gs://" + bucket + "/" + object}
+          - target_table: ${"odp_generic." + entity}
+    - run_ingestion:
+        call: googleapis.run.v2.projects.locations.jobs.run
+        args:
+          name: ${"projects/" + project + "/locations/" + region + "/jobs/" + ingestion_job}
+          body:
+            overrides:
+              containerOverrides:
+                - args:
+                    - ${"--entity=" + entity}
+                    - ${"--sourceUri=" + source_uri}
+                    - ${"--extractDate=" + extract_date}
+                    - ${"--project=" + project}
+                    - ${"--targetTable=" + target_table}
+                    - ${"--stagingPathPrefix=gs://" + project + "-generic-int-temp/staging"}
+                    - ${"--errorPathPrefix=gs://" + project + "-generic-int-error/errors"}
+                    - "--runner=DirectRunner"
+                    - "--cloud=gcp"
+        result: ingestion_execution
+    - run_dbt:
+        call: googleapis.run.v2.projects.locations.jobs.run
+        args:
+          name: ${"projects/" + project + "/locations/" + region + "/jobs/" + dbt_job}
+        result: dbt_execution
+    - done:
+        return:
+          entity: ${entity}
+          extract_date: ${extract_date}
+          ingestion: ${ingestion_execution.name}
+          dbt: ${dbt_execution.name}
+    - skipped:
+        return: '${"skipped non-entity object. " + object}'


### PR DESCRIPTION
The **no-Airflow orchestration**, live and verified on `culvert-501806`:

```
file lands in bucket → Eventarc (object.finalized) → Cloud Workflows (this YAML = the DAG)
   → ingestion-generic Cloud Run Job (args derived from the event: entity, extract date, URI)
   → dbt-mapped-product Cloud Run Job → FDP
```

**Zero-manual-step verification:** dropped `generic_customers_20260701.csv` + `generic_accounts_20260701.csv` → 2 SUCCEEDED workflow executions → new ODP rows (audit columns) → `fdp_generic.event_transaction_excess` materialised the new join row. No Airflow, no Composer, no standing cost (Workflows free tier; jobs scale to zero).

**IAM learnings encoded in the commit** for the terraform follow-up — notably `jobs.run` **with overrides** needs `run.jobs.runWithOverrides` (`roles/run.developer`), not just `run.invoker`; plus Eventarc/GCS service-agent provisioning and the trigger-location = bucket-region constraint.

**Follow-up:** terraform-ise the workflow + trigger + SA/IAM into `systems/generic` (the `enable_composer=false` counterpart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)