### PR TITLE
[sprint-24] Wave D: the culvert PyPI distribution + publish plumbing

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,75 @@
+# Publish the `culvert` distribution to PyPI via OIDC trusted publishing.
+#
+# JOSEPH-GATED: manual workflow_dispatch only, and the job runs in the `pypi`
+# environment — protect that environment (required reviewers) in repo settings
+# for a second gate. No tokens anywhere: PyPI trusts this exact repo + workflow
+# + environment via the pending publisher registered 2026-07.
+#
+# Publish is IRREVERSIBLE (version numbers are burned forever). The verify job
+# is the TestPyPI substitute: build → twine check → clean-venv install (wheel,
+# wheel[gcp], sdist) → import + discovery smoke. Publish only runs if verify
+# is green AND the confirm input is exactly "publish-culvert".
+name: publish-pypi
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type "publish-culvert" to confirm the irreversible PyPI publish'
+        required: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Build sdist + wheel
+        run: |
+          python -m pip install --quiet build twine
+          python -m build python-culvert
+      - name: twine check
+        run: python -m twine check python-culvert/dist/*
+      - name: Clean-venv smoke (wheel, core-only)
+        run: |
+          python -m venv /tmp/v1 && /tmp/v1/bin/pip install --quiet python-culvert/dist/*.whl
+          /tmp/v1/bin/python -c "import culvert; from data_pipeline_core import autoconfig; autoconfig.discover(); print('core-only ok', culvert.__version__)"
+      - name: Clean-venv smoke (wheel[gcp] — all 9 adapters loadable)
+        run: |
+          python -m venv /tmp/v2
+          WHL=$(ls python-culvert/dist/*.whl)
+          /tmp/v2/bin/pip install --quiet "culvert[gcp] @ file://${WHL}"
+          /tmp/v2/bin/python -c "
+          from data_pipeline_core import autoconfig
+          cfg = autoconfig.discover()
+          eps = ['blob_store','warehouse','finops','source','sink','secrets','observability','stage_metrics','lineage']
+          missing = [n for n in eps if cfg.first(n) is None]
+          assert not missing, f'unloadable adapters: {missing}'
+          print('all 9 adapters loadable')"
+      - name: Clean-venv smoke (sdist round-trip)
+        run: |
+          python -m venv /tmp/v3 && /tmp/v3/bin/pip install --quiet python-culvert/dist/*.tar.gz
+          /tmp/v3/bin/python -c "import culvert; print('sdist ok', culvert.__version__)"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: python-culvert/dist/
+
+  publish:
+    needs: verify
+    if: github.event.inputs.confirm == 'publish-culvert'
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write   # OIDC trusted publishing — no token, no secret
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,6 @@ deployments/*/helm/charts/*.tgz
 
 # Per-deployment terraform provider lock (single-platform; regenerated on init)
 **/.terraform.lock.hcl
+
+# culvert distribution build artifacts
+python-culvert/dist/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing to Culvert
+
+Thanks for your interest. Culvert is early (0.1.x) and moving quickly; small,
+focused contributions land fastest.
+
+## Ground rules
+
+- **One concern per PR.** If the title needs an "and", split it.
+- **Green suite is the bar.** Java: `mvn -f data-pipeline-libraries-java/pom.xml
+  test` (all modules). Python: `pytest` per touched library. New behaviour
+  needs a test that fails without your change.
+- **Contracts are the seam.** Business logic depends on contracts
+  (`docs/CONTRACT.md`), never on a cloud SDK. Cloud specifics live in adapter
+  modules; adapters bind the shared contract-test suites.
+- **Honesty over polish.** If an adapter can't support a contract method,
+  throw `UnsupportedOperationException` with the reason — never fake a partial
+  implementation. Limitations are documented where they live.
+
+## Getting started (fully local — no cloud account)
+
+```bash
+# Java (JDK 17+; Maven wrapper provisioning)
+mvn -f data-pipeline-libraries-java/pom.xml install
+mvn -f data-pipeline-libraries-java/pom.xml -P it verify   # emulators + LocalStack; needs Docker
+
+# Python
+python3 -m venv .venv && source .venv/bin/activate
+pip install -e data-pipeline-libraries/data-pipeline-core pytest
+pytest data-pipeline-libraries/data-pipeline-core/tests
+```
+
+Everything runs against emulators (Tier 1 in
+`docs/framework-evolution/14-execution-tiers.md`); cloud is for proving, not
+developing.
+
+## Where things live
+
+- `data-pipeline-libraries-java/` — Java reactor (contracts + adapters)
+- `data-pipeline-libraries/` — Python libraries (packaged to PyPI as `culvert`
+  from `python-culvert/`)
+- `deployments/` — worked example pipelines, each with its own terraform/ + helm/
+- `docs/framework-evolution/` — the why/what/when; disagreements resolve in its favour
+
+## Releases
+
+Maintainer-gated and coordinated across Maven Central + PyPI — see
+`RELEASE.md`. Contributors never need publishing credentials.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,68 +1,101 @@
-# Release procedure
+# Release procedure — coordinated 0.1.0 (Java + Python)
 
-Internal procedure for publishing Culvert framework releases. **Not automated.** Joseph triggers each step manually.
+Joseph triggers every publishing step manually. **Publishing is irreversible**:
+PyPI version numbers can never be reused and Maven Central artifacts are
+immutable. Nothing in this repo auto-publishes.
 
-## Prerequisites (one-time)
+The release gate (authoritative:
+[`docs/framework-evolution/13-python-parity-release.md`](docs/framework-evolution/13-python-parity-release.md) §2):
+deploy → test end-to-end → validate libraries → **publish both ecosystems
+together** → only then the book / release announcement.
 
-- **PyPI:** Create an API token at https://pypi.org/manage/account/token/. Store as the `PYPI_TOKEN` env var or in `~/.pypirc`.
-- **Maven Central / Sonatype Central:** Create an account at https://central.sonatype.com/. Register the `com.enrichmeai.culvert` namespace (verification via DNS TXT on `enrichmeai.com`). Generate a user token. Set up GPG: `gpg --gen-key`, `gpg --export-secret-keys --armor <KEY_ID>` and add to `~/.m2/settings.xml` under the `central` server.
-- **Re-enable GitHub Actions workflows** (see #14): `for id in 243664542 243664544 ...; do gh workflow enable $id; done`. The workflows themselves are wired and just disabled.
+---
 
-## Publishing Python packages to PyPI
+## 0. State of the gate (update as steps complete)
 
-For each `data-pipeline-*` directory under `data-pipeline-libraries/`:
+| Step | Status |
+|---|---|
+| Reference deployments on real GCP (cloudrun-only) | ✅ 2026-07-10 — full ODP→FDP→CDP chain, event-driven |
+| Libraries validated (unit + emulator IT + real-deploy exercise) | ✅ (the deploy caught 8 prod-only bugs; all fixed) |
+| Composer one-day validation (the deliberate pre-publish spend) | ⬜ see §4 |
+| PyPI publish | ⬜ §2 |
+| Maven Central publish | ⬜ §3 |
+| Book / announcement | ⬜ after both publishes |
+
+## 1. Prerequisites (one-time, Joseph)
+
+- **PyPI — trusted publishing (NO tokens).** A *pending publisher* for project
+  `culvert` is registered (✅ 2026-07): owner `enrichmeai`, repo `culvert`,
+  workflow `publish-pypi.yml`, environment `pypi`. Optional second gate:
+  repo Settings → Environments → `pypi` → required reviewers → yourself.
+- **Maven Central (Sonatype Central).** Account at central.sonatype.com;
+  namespace `com.enrichmeai.culvert` verified; user token in
+  `~/.m2/settings.xml` (server id `central`); GPG key generated and its public
+  key published to a keyserver. These are Joseph's secrets — never in the
+  repo, never handled by agents.
+- **PyPI organization (optional, later).** The community-org `enrichmeai`
+  request can proceed in parallel; transfer the `culvert` project into it when
+  approved. Does not block 0.1.0.
+
+## 2. Publish `culvert` to PyPI
+
+The distribution is `python-culvert/` (single dist + extras — the D1
+decision; all ten library import packages ship inside one wheel).
+
+1. Confirm `main` is green and contains everything intended for 0.1.0.
+2. GitHub → Actions → **publish-pypi** → *Run workflow* → type
+   `publish-culvert` in the confirm box.
+3. The `verify` job re-runs the full validation (build → `twine check` →
+   clean-venv wheel install → `[gcp]` adapter-discovery smoke → sdist
+   round-trip). The `publish` job only runs after verify is green, inside the
+   protected `pypi` environment, via OIDC.
+4. Post-publish check: `pip install culvert[gcp]` in a fresh venv from the
+   real index; confirm `culvert.__version__` and that the project page
+   renders.
+
+If a broken release ships anyway: **yank** it on PyPI (never delete), fix,
+release `0.1.1`.
+
+## 3. Publish the Java reactor to Maven Central
+
+From the release state of `main` (the reactor freeze is tagged
+`java-0.1.0`; tag `v0.1.0` on the release commit):
 
 ```bash
-cd data-pipeline-libraries/<package>
-python3 -m pip install --upgrade build twine
-python3 -m build  # produces dist/*.whl and dist/*.tar.gz
-python3 -m twine upload --repository pypi dist/*
+mvn -f data-pipeline-libraries-java/pom.xml -P release clean deploy
 ```
 
-Order matters because of inter-package dependencies:
+- The `release` profile signs with GPG and uploads via
+  `central-publishing-maven-plugin` with `autoPublish=false`.
+- Sonatype Central holds the bundle in **validation** — review it at
+  https://central.sonatype.com/, then confirm release. That confirmation is
+  the Java point-of-no-return.
+- Post-publish check: artifacts visible under `com.enrichmeai.culvert`; a
+  scratch Maven project resolves `data-pipeline-core:0.1.0`.
 
-1. `data-pipeline-core` (no deps inside the framework)
-2. `data-pipeline-contract-tests` (depends on core)
-3. `data-pipeline-tester` (depends on core)
-4. `data-pipeline-gcp-bigquery`, `data-pipeline-gcp-gcs`, `data-pipeline-gcp-pubsub` (depend on core)
-5. `data-pipeline-transform`, `data-pipeline-framework`, `data-pipeline-orchestration` (renamed legacy)
-6. The deprecation-shim `gcp-pipeline-*` distributions (depend on renamed packages)
+## 4. Pre-publish Composer validation (one day, then teardown)
 
-## Publishing Java artefacts to Maven Central
+The single deliberate Composer spend (doc 13 §2a): apply
+`infrastructure/terraform/systems/generic` with `enable_composer=true`,
+deploy `deployments/data-pipeline-orchestrator/dags/culvert_dags.py`, verify
+the DAGs parse and one ingestion DAG runs green on real Composer, capture
+evidence, then re-apply with `enable_composer=false` — **same day**.
+Everything else already runs cloudrun-only (no Airflow).
 
-From `data-pipeline-libraries-java/`:
+## 5. Coordinated order
 
-```bash
-# Validates GPG + Sonatype credentials before deploying.
-mvn -P release clean deploy
-```
+1. §4 Composer validation (the last evidence for the gate)
+2. §2 PyPI and §3 Maven Central in the same sitting — PyPI first (it has the
+   stronger automated pre-verify); announce nothing between the two
+3. Tag `v0.1.0` (`git tag v0.1.0 && git push --tags`); update
+   [CHANGELOG.md](CHANGELOG.md) to a dated release; GitHub release notes with
+   the honest status (two clouds: GCP full, AWS Java adapter family, Azure
+   roadmap)
+4. Book + Medium launch pieces follow the release, never precede it
 
-The `release` profile is already configured in the parent POM:
-- Signs all artefacts with GPG.
-- Uploads via `central-publishing-maven-plugin` to the central staging repo.
-- `autoPublish=false` means a manual close+release step at https://central.sonatype.com/ after upload completes.
+## 6. Version discipline
 
-To publish a single module:
-
-```bash
-mvn -P release -pl data-pipeline-gcp-bigquery-java -am clean deploy
-```
-
-## Versioning
-
-Currently all artefacts are version `0.1.0`. Bumps happen via:
-
-- **Java:** `mvn versions:set -DnewVersion=0.2.0 -DgenerateBackupPoms=false` from `data-pipeline-libraries-java/`. Commit and push before deploy.
-- **Python:** Edit each `pyproject.toml`'s `version = "..."`. Or use `bumpver` / `hatch version` if you adopt one.
-
-The two languages currently version in lockstep; that may change post-1.0.
-
-## Post-release checklist
-
-- Tag the release: `git tag v0.1.0 && git push --tags`.
-- Update [CHANGELOG.md](CHANGELOG.md) to move the `[0.1.0] — unreleased` heading to a dated release.
-- Announce: GitHub release notes, blog post, book chapter linking the published artefacts.
-
-## What CANNOT be automated until the rename happens
-
-Maven artefact `groupId` is `com.enrichmeai.culvert` — that's stable. PyPI package names are `data-pipeline-*` — also stable. The GitHub repo name `culvert` is misleading post-Stage-2; see [REPO_RENAME.md](REPO_RENAME.md). The repo rename does NOT block publishing.
+- Reactor, Python dist, deployments and docs all say **0.1.0** before the
+  trigger; verify with grep, not memory.
+- After release, bump `main` in one PR: `mvn versions:set -DnewVersion=0.2.0-SNAPSHOT`
+  (Java) and `version = "0.2.0.dev0"` in `python-culvert/pyproject.toml`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Supported versions
+
+| Version | Supported |
+|---|---|
+| 0.1.x | ✅ |
+
+## Reporting a vulnerability
+
+Please **do not** open a public issue for suspected vulnerabilities.
+
+Use GitHub's private vulnerability reporting on this repository
+(Security → Report a vulnerability), which reaches the maintainer directly.
+You should receive an acknowledgement within a few days.
+
+## Scope notes
+
+- Culvert's adapters execute with the credentials of the runtime service
+  account you configure — least-privilege IAM per deployment is provided in
+  each `deployments/*/terraform/` and is the recommended posture.
+- No component ever transmits data to any endpoint other than the cloud
+  services you configure. There is no telemetry.
+- Secrets are never accepted via code or config files: cloud secret managers
+  (via the `SecretProvider` contract) and workload identity are the supported
+  mechanisms.

--- a/data-pipeline-libraries/data-pipeline-orchestration/pyproject.toml
+++ b/data-pipeline-libraries/data-pipeline-orchestration/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "google-cloud-storage",
     "google-cloud-pubsub",
     "PyYAML>=6.0",
-    "gcp-pipeline-core",
+    "google-cloud-bigquery>=3.11.0",
 ]
 
 [project.optional-dependencies]

--- a/data-pipeline-libraries/data-pipeline-orchestration/src/data_pipeline_orchestration/_job_control.py
+++ b/data-pipeline-libraries/data-pipeline-orchestration/src/data_pipeline_orchestration/_job_control.py
@@ -1,0 +1,91 @@
+"""Minimal BigQuery-backed job-control reader for orchestration callers.
+
+Replaces the retired first-iteration job-control repository
+fallback (T11.2b follow-up, closed for the 0.1.0 publish). This is a *reader*,
+not the write-side contract implementation: the DAG factory, dependency checker
+and status DAG only ever need "what happened for this system on this date",
+so this module exposes exactly that against the standardised
+``job_control.pipeline_jobs`` table (the schema the Java
+``BigQueryJobControlRepository`` writes — see
+``infrastructure/terraform/systems/generic/main.tf``).
+
+Values are Culvert's wire values: statuses are lowercase (``succeeded``,
+``failed``, ...; ``JobStatus`` in both cores) and failure stages are lowercase
+(``ingestion``, ``validation``, ``load``, ``reconciliation``, ...). The
+predecessor's uppercase ``SUCCESS`` / ``ODP_LOAD`` era is gone.
+
+``google-cloud-bigquery`` is imported lazily so importing orchestration modules
+stays dependency-light (mirrors the module's lazy-Airflow discipline).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any, Dict, List
+
+#: Culvert wire value for a successful run (JobStatus.SUCCEEDED).
+SUCCEEDED = "succeeded"
+
+
+class BigQueryJobControl:
+    """Read-only job-control queries used by orchestration.
+
+    Satisfies the ``get_entity_status`` shape ``EntityDependencyChecker``
+    expects, plus ``get_failed_jobs`` for the error-handling DAG.
+    """
+
+    def __init__(
+        self,
+        project_id: str,
+        dataset: str = "job_control",
+        table: str = "pipeline_jobs",
+    ) -> None:
+        if not project_id:
+            raise ValueError("project_id is required")
+        self._project_id = project_id
+        self._fqtn = f"`{project_id}.{dataset}.{table}`"
+
+    def _client(self):
+        from google.cloud import bigquery  # noqa: PLC0415 — lazy by design
+
+        return bigquery.Client(project=self._project_id)
+
+    def get_entity_status(self, system_id: str, extract_date: date) -> List[Dict[str, Any]]:
+        """Latest status per entity for a system + extract date."""
+        sql = f"""
+            SELECT entity_type, status
+            FROM {self._fqtn}
+            WHERE LOWER(system_id) = LOWER(@system_id)
+              AND extract_date = @extract_date
+            QUALIFY ROW_NUMBER() OVER (
+                PARTITION BY entity_type ORDER BY updated_at DESC) = 1
+        """
+        return self._run(sql, system_id, extract_date)
+
+    def get_failed_jobs(self, system_id: str, extract_date: date) -> List[Dict[str, Any]]:
+        """Failed runs for a system + extract date (stage, retry_count, entity)."""
+        sql = f"""
+            SELECT entity_type,
+                   run_id,
+                   COALESCE(failure_stage, 'unknown') AS stage,
+                   COALESCE(retry_count, 0) AS retry_count,
+                   error_code,
+                   error_message
+            FROM {self._fqtn}
+            WHERE LOWER(system_id) = LOWER(@system_id)
+              AND extract_date = @extract_date
+              AND status = 'failed'
+        """
+        return self._run(sql, system_id, extract_date)
+
+    def _run(self, sql: str, system_id: str, extract_date: date) -> List[Dict[str, Any]]:
+        from google.cloud import bigquery  # noqa: PLC0415
+
+        job_config = bigquery.QueryJobConfig(
+            query_parameters=[
+                bigquery.ScalarQueryParameter("system_id", "STRING", system_id),
+                bigquery.ScalarQueryParameter("extract_date", "DATE", extract_date),
+            ]
+        )
+        rows = self._client().query(sql, job_config=job_config).result()
+        return [dict(row.items()) for row in rows]

--- a/data-pipeline-libraries/data-pipeline-orchestration/src/data_pipeline_orchestration/callbacks/dlq.py
+++ b/data-pipeline-libraries/data-pipeline-orchestration/src/data_pipeline_orchestration/callbacks/dlq.py
@@ -4,13 +4,14 @@ DLQ (Dead Letter Queue) Publishing Utilities.
 Functions for publishing error messages to Pub/Sub DLQ.
 """
 
+import json
+import logging
 from datetime import datetime, timezone
 from typing import Dict, Any, Optional
-from gcp_pipeline_core.utilities.logging import get_logger
 
 from .types import ErrorHandlerConfig, ErrorType, get_default_config
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def _get_project_id(
@@ -120,7 +121,9 @@ def publish_to_dlq(
         return None
 
     try:
-        from gcp_pipeline_core.clients.pubsub_client import PubSubClient
+        # google-cloud-pubsub is a declared dependency; imported lazily so the
+        # callbacks package stays import-light (mirrors the lazy-Airflow rule).
+        from google.cloud import pubsub_v1  # noqa: PLC0415
 
         project_id = _get_project_id(context, cfg)
         if not project_id:
@@ -139,14 +142,15 @@ def publish_to_dlq(
         # Use provided topic or default from config
         dlq_topic = topic or cfg.dlq_topic
 
-        # Publish to DLQ
-        client = PubSubClient(project=project_id)
-        message_id = client.publish_event(
-            topic=dlq_topic,
-            message=error_payload,
-            error_type=error_type,
-            dag_id=error_payload.get("dag_id", "unknown"),
-        )
+        # Publish to DLQ (JSON payload; error_type/dag_id as attributes so
+        # subscribers can filter without decoding the body).
+        publisher = pubsub_v1.PublisherClient()
+        message_id = publisher.publish(
+            publisher.topic_path(project_id, dlq_topic),
+            json.dumps(error_payload).encode("utf-8"),
+            error_type=str(error_type),
+            dag_id=str(error_payload.get("dag_id", "unknown")),
+        ).result(timeout=30)
 
         logger.info(
             f"Published error to DLQ: message_id={message_id}, "
@@ -155,7 +159,7 @@ def publish_to_dlq(
         return message_id
 
     except ImportError:
-        logger.error("Could not import PubSubClient - DLQ publishing not available")
+        logger.error("google-cloud-pubsub not installed - DLQ publishing not available")
         return None
     except Exception as e:
         logger.error(f"Failed to publish to DLQ: {e}")

--- a/data-pipeline-libraries/data-pipeline-orchestration/src/data_pipeline_orchestration/dependency.py
+++ b/data-pipeline-libraries/data-pipeline-orchestration/src/data_pipeline_orchestration/dependency.py
@@ -27,13 +27,10 @@ from datetime import date
 from typing import Any, List, Optional
 
 # ---------------------------------------------------------------------------
-# gcp_pipeline_core coupling REMOVED (T11.2b)
+# Job-control coupling (T11.2b — CLOSED for the 0.1.0 publish)
 #
-# Legacy code imported:
-#   from gcp_pipeline_core.job_control import JobControlRepository, JobStatus
-#
-# Target Culvert seam (TODO — T11.2b follow-up, out of scope for config/DAG
-# factory agents #84/#86/#87):
+# The default reader is Culvert's own ``._job_control.BigQueryJobControl``
+# (lazy google-cloud-bigquery). Injectable seam:
 #   - Repository protocol:
 #       data_pipeline_core.contracts.job_control.JobControlRepository
 #       (runtime_checkable Protocol, 11 methods, no GCP-type leakage)
@@ -58,10 +55,9 @@ from typing import Any, List, Optional
 #      is responsible for injecting a concrete implementation.
 # ---------------------------------------------------------------------------
 
-# SUCCESS status string — matches gcp_pipeline_core.job_control.types.JobStatus.SUCCESS
-# When migrating to Culvert contracts, update to "succeeded" AND ensure the
-# concrete adapter returns that value from get_entity_status().
-_SUCCESS_STATUS: str = "SUCCESS"
+# SUCCESS status string — Culvert wire value (JobStatus.SUCCEEDED in both the
+# Java and Python cores; the Java BigQueryJobControlRepository stores this).
+_SUCCESS_STATUS: str = "succeeded"
 
 logger = logging.getLogger(__name__)
 
@@ -81,13 +77,9 @@ class EntityDependencyChecker:
     ``data_pipeline_core.contracts.job_control.JobControlRepository``
     (a ``runtime_checkable`` Protocol).  Callers inject the concrete
     BigQuery-backed adapter; the library itself does not import
-    ``google-cloud-bigquery`` or ``gcp_pipeline_core`` at module load
-    time.
-
-    TODO (T11.2b follow-up): once the concrete ``BigQueryJobControlRepository``
-    adapter migrates from gcp_pipeline_core to data_pipeline_core, add a
-    type annotation here:
-        job_repo: Optional[data_pipeline_core.contracts.job_control.JobControlRepository]
+    ``google-cloud-bigquery`` at module load time (the default
+    ``._job_control.BigQueryJobControl`` reader imports it lazily on first
+    query).
 
     Example:
         >>> checker = EntityDependencyChecker(
@@ -136,13 +128,10 @@ class EntityDependencyChecker:
             # Lazy import — keeps google-cloud-bigquery out of module load
             # time while preserving the original constructor contract for
             # callers that don't supply a repo (DAG factory, deployments).
-            # TODO (T11.2b follow-up): replace with the Culvert adapter once
-            # gcp_pipeline_core migrates to satisfy
-            # data_pipeline_core.contracts.job_control.JobControlRepository.
-            # Note: that migration must also normalise the status value
-            # (SUCCESS -> succeeded) before returning from get_entity_status().
-            from gcp_pipeline_core.job_control import JobControlRepository  # noqa: PLC0415
-            job_repo = JobControlRepository(
+            # T11.2b closed for the 0.1.0 publish: the default reader is
+            # Culvert's own (_job_control), not the predecessor's.
+            from ._job_control import BigQueryJobControl  # noqa: PLC0415
+            job_repo = BigQueryJobControl(
                 project_id,
                 dataset=job_control_dataset,
                 table=job_control_table,

--- a/data-pipeline-libraries/data-pipeline-orchestration/src/data_pipeline_orchestration/factories/_dag_builders.py
+++ b/data-pipeline-libraries/data-pipeline-orchestration/src/data_pipeline_orchestration/factories/_dag_builders.py
@@ -117,11 +117,10 @@ def _system_tags(cfg: Dict[str, Any]) -> List[str]:
 def _failure_callback():
     """Return the global ``on_failure_callback`` (DLQ/quarantine router).
 
-    Imported lazily inside the builder body so that ``dag_factory`` and this
-    module stay import-safe without ``gcp_pipeline_core`` at module load time
-    (``callbacks.dlq`` imports ``gcp_pipeline_core`` at its top level). When the
-    callbacks package cannot be imported, returns ``None`` so DAG construction
-    still succeeds (the DAG simply carries no failure callback).
+    Imported lazily inside the builder body so DAG construction stays
+    import-light. When the callbacks package cannot be imported, returns
+    ``None`` so DAG construction still succeeds (the DAG simply carries no
+    failure callback).
     """
     try:
         from data_pipeline_orchestration.callbacks import on_failure_callback
@@ -728,9 +727,9 @@ def build_error_handling_dag(factory_config: dict) -> "Any":  # noqa: ANN401
             project_id = Variable.get(
                 "gcp_project_id", default_var=os.environ.get("GCP_PROJECT_ID", "")
             )
-            from gcp_pipeline_core.job_control import JobControlRepository, FailureStage  # type: ignore
+            from .._job_control import BigQueryJobControl  # noqa: PLC0415
             today = datetime.now(tz=timezone.utc).date()
-            repo = JobControlRepository(project_id=project_id)
+            repo = BigQueryJobControl(project_id)
             failed = repo.get_failed_jobs(system_id, today)
         except Exception as exc:
             log.warning("Could not scan failed jobs (non-fatal): %s", exc)
@@ -740,8 +739,11 @@ def build_error_handling_dag(factory_config: dict) -> "Any":  # noqa: ANN401
             return "no_errors"
 
         critical, retryable, manual = [], [], []
-        _critical_stages = {"FILE_DISCOVERY", "FDP_DEPENDENCY"}
-        _retryable_stages = {"ODP_LOAD", "RECONCILIATION", "FDP_MODEL", "FDP_STAGING", "FDP_TEST"}
+        # Culvert FailureStage wire values (lowercase — FailureStage.getValue()).
+        # validation failures are critical (bad source file; a retry cannot
+        # help); execution-side stages are retryable up to the max.
+        _critical_stages = {"validation"}
+        _retryable_stages = {"ingestion", "load", "reconciliation", "transformation"}
 
         for job in failed:
             stage = job.get("stage", "UNKNOWN")
@@ -863,9 +865,9 @@ def build_status_dag(factory_config: dict) -> "Any":  # noqa: ANN401
             project_id = Variable.get(
                 "gcp_project_id", default_var=os.environ.get("GCP_PROJECT_ID", "")
             )
-            from gcp_pipeline_core.job_control import JobControlRepository  # type: ignore
+            from .._job_control import BigQueryJobControl  # noqa: PLC0415
             date_obj = datetime.strptime(today, "%Y%m%d").date()
-            repo = JobControlRepository(project_id=project_id)
+            repo = BigQueryJobControl(project_id)
             statuses = repo.get_entity_status(system_id, date_obj)
             status_map = {s["entity_type"]: s["status"] for s in statuses}
         except Exception as exc:
@@ -875,11 +877,11 @@ def build_status_dag(factory_config: dict) -> "Any":  # noqa: ANN401
         issues = []
         for entity in entities:
             status = status_map.get(entity)
-            if status != "SUCCESS":
+            if status != "succeeded":
                 issues.append(f"ODP {entity}: {status or 'NOT LOADED'}")
         for model in fdp_models:
             status = status_map.get(model)
-            if status != "SUCCESS":
+            if status != "succeeded":
                 issues.append(f"FDP {model}: {status or 'NOT RUN'}")
 
         if issues:

--- a/data-pipeline-libraries/data-pipeline-orchestration/src/data_pipeline_orchestration/factories/dag_factory.py
+++ b/data-pipeline-libraries/data-pipeline-orchestration/src/data_pipeline_orchestration/factories/dag_factory.py
@@ -27,8 +27,8 @@ reachable via :class:`DagFactory.error_handling_dag` but is intentionally NOT
 wired into ``create_dags`` — #87's acceptance gate is the 4-type set above
 (the 2 ingestion-side types from #86 plus transformation + pipeline_status).
 
-This module is import-safe **without** Airflow installed and **without** the
-legacy ``gcp_pipeline_core`` package: the heavy lifting is delegated to
+This module is import-safe **without** Airflow installed: the heavy
+lifting is delegated to
 :mod:`data_pipeline_orchestration.factories._dag_builders`, whose builders
 lazy-import Airflow inside the function body and raise a clear ``ImportError``
 when it is absent.
@@ -58,7 +58,7 @@ logger = logging.getLogger(__name__)
 
 
 # =============================================================================
-# Helpers (pure; no Airflow / no gcp_pipeline_core)
+# Helpers (pure; no Airflow, no cloud SDKs)
 # =============================================================================
 
 def _entity_names(config: Dict[str, Any]) -> List[str]:

--- a/data-pipeline-libraries/data-pipeline-orchestration/src/data_pipeline_orchestration/sensors/pubsub.py
+++ b/data-pipeline-libraries/data-pipeline-orchestration/src/data_pipeline_orchestration/sensors/pubsub.py
@@ -278,7 +278,9 @@ class PubSubCompletionSensor(BasePubSubPullSensor):
     def __init__(
         self,
         *args,
-        expected_status: str = "SUCCESS",
+        # Culvert wire value (JobStatus.SUCCEEDED); completion publishers
+        # write lowercase statuses.
+        expected_status: str = "succeeded",
         **kwargs
     ):
         super().__init__(*args, **kwargs)

--- a/data-pipeline-libraries/data-pipeline-orchestration/tests/unit/callbacks/test_routing.py
+++ b/data-pipeline-libraries/data-pipeline-orchestration/tests/unit/callbacks/test_routing.py
@@ -37,25 +37,30 @@ class TestFailureRoutesToDLQ(unittest.TestCase):
     """A failed task's on_failure_callback publishes to the DLQ topic."""
 
     @patch("data_pipeline_orchestration.callbacks.dlq._get_project_id", return_value="proj-123")
-    @patch("gcp_pipeline_core.clients.pubsub_client.PubSubClient")
+    @patch("google.cloud.pubsub_v1.PublisherClient")
     def test_failure_callback_publishes_to_dlq_topic(self, mock_client_cls, _proj):
+        import json
+
         stub_client = MagicMock()
-        stub_client.publish_event.return_value = "msg-id-987"
+        stub_client.topic_path.side_effect = (
+            lambda project, topic: f"projects/{project}/topics/{topic}")
+        stub_client.publish.return_value.result.return_value = "msg-id-987"
         mock_client_cls.return_value = stub_client
 
         cfg = ErrorHandlerConfig(dlq_topic="generic-dlq")
         ctx = _fake_context(exc=ValueError("dataflow boom"))
 
-        # on_failure_callback → publish_to_dlq → PubSubClient.publish_event
+        # on_failure_callback → publish_to_dlq → PublisherClient.publish
         on_failure_callback(ctx, cfg)
 
-        stub_client.publish_event.assert_called_once()
-        kwargs = stub_client.publish_event.call_args.kwargs
-        self.assertEqual(kwargs["topic"], "generic-dlq")
-        self.assertEqual(kwargs["error_type"], ErrorType.TASK_FAILURE)
-        self.assertIn("dataflow boom", kwargs["message"]["error_message"])
+        stub_client.publish.assert_called_once()
+        args = stub_client.publish.call_args
+        self.assertEqual(args.args[0], "projects/proj-123/topics/generic-dlq")
+        payload = json.loads(args.args[1].decode("utf-8"))
+        self.assertIn("dataflow boom", payload["error_message"])
+        self.assertEqual(args.kwargs["error_type"], str(ErrorType.TASK_FAILURE))
 
-    @patch("gcp_pipeline_core.clients.pubsub_client.PubSubClient")
+    @patch("google.cloud.pubsub_v1.PublisherClient")
     def test_disabled_dlq_does_not_publish(self, mock_client_cls):
         cfg = ErrorHandlerConfig(enable_dlq=False)
         on_failure_callback(_fake_context(exc=RuntimeError("x")), cfg)

--- a/data-pipeline-libraries/data-pipeline-orchestration/tests/unit/test_create_dags.py
+++ b/data-pipeline-libraries/data-pipeline-orchestration/tests/unit/test_create_dags.py
@@ -504,10 +504,10 @@ class TestPipelineStatusCallables:
         context = _make_context(ds_nodash="20260317")
 
         statuses = [
-            {"entity_type": "customers", "status": "SUCCESS", "run_id": "r1"},
-            {"entity_type": "accounts", "status": "SUCCESS", "run_id": "r2"},
-            {"entity_type": "event_transaction_excess", "status": "SUCCESS", "run_id": "r3"},
-            {"entity_type": "portfolio_account_excess", "status": "SUCCESS", "run_id": "r4"},
+            {"entity_type": "customers", "status": "succeeded", "run_id": "r1"},
+            {"entity_type": "accounts", "status": "succeeded", "run_id": "r2"},
+            {"entity_type": "event_transaction_excess", "status": "succeeded", "run_id": "r3"},
+            {"entity_type": "portfolio_account_excess", "status": "succeeded", "run_id": "r4"},
         ]
 
         with patch("data_pipeline_orchestration.factories.dag_factory.JobControlRepository") as mock_repo_cls:
@@ -524,9 +524,9 @@ class TestPipelineStatusCallables:
 
         # customers missing from results
         statuses = [
-            {"entity_type": "accounts", "status": "SUCCESS", "run_id": "r1"},
-            {"entity_type": "event_transaction_excess", "status": "SUCCESS", "run_id": "r2"},
-            {"entity_type": "portfolio_account_excess", "status": "SUCCESS", "run_id": "r3"},
+            {"entity_type": "accounts", "status": "succeeded", "run_id": "r1"},
+            {"entity_type": "event_transaction_excess", "status": "succeeded", "run_id": "r2"},
+            {"entity_type": "portfolio_account_excess", "status": "succeeded", "run_id": "r3"},
         ]
 
         with patch("data_pipeline_orchestration.factories.dag_factory.JobControlRepository") as mock_repo_cls:
@@ -543,9 +543,9 @@ class TestPipelineStatusCallables:
 
         statuses = [
             {"entity_type": "customers", "status": "FAILED", "run_id": "r1"},
-            {"entity_type": "accounts", "status": "SUCCESS", "run_id": "r2"},
-            {"entity_type": "event_transaction_excess", "status": "SUCCESS", "run_id": "r3"},
-            {"entity_type": "portfolio_account_excess", "status": "SUCCESS", "run_id": "r4"},
+            {"entity_type": "accounts", "status": "succeeded", "run_id": "r2"},
+            {"entity_type": "event_transaction_excess", "status": "succeeded", "run_id": "r3"},
+            {"entity_type": "portfolio_account_excess", "status": "succeeded", "run_id": "r4"},
         ]
 
         with patch("data_pipeline_orchestration.factories.dag_factory.JobControlRepository") as mock_repo_cls:
@@ -562,8 +562,8 @@ class TestPipelineStatusCallables:
 
         # All ODP entities present but FDP models missing
         statuses = [
-            {"entity_type": "customers", "status": "SUCCESS", "run_id": "r1"},
-            {"entity_type": "accounts", "status": "SUCCESS", "run_id": "r2"},
+            {"entity_type": "customers", "status": "succeeded", "run_id": "r1"},
+            {"entity_type": "accounts", "status": "succeeded", "run_id": "r2"},
         ]
 
         with patch("data_pipeline_orchestration.factories.dag_factory.JobControlRepository") as mock_repo_cls:
@@ -579,10 +579,10 @@ class TestPipelineStatusCallables:
         context = _make_context(ds_nodash="20260317")
 
         statuses = [
-            {"entity_type": "customers", "status": "SUCCESS", "run_id": "r1"},
-            {"entity_type": "accounts", "status": "SUCCESS", "run_id": "r2"},
+            {"entity_type": "customers", "status": "succeeded", "run_id": "r1"},
+            {"entity_type": "accounts", "status": "succeeded", "run_id": "r2"},
             {"entity_type": "event_transaction_excess", "status": "FAILED", "run_id": "r3"},
-            {"entity_type": "portfolio_account_excess", "status": "SUCCESS", "run_id": "r4"},
+            {"entity_type": "portfolio_account_excess", "status": "succeeded", "run_id": "r4"},
         ]
 
         with patch("data_pipeline_orchestration.factories.dag_factory.JobControlRepository") as mock_repo_cls:

--- a/data-pipeline-libraries/data-pipeline-orchestration/tests/unit/test_dependency.py
+++ b/data-pipeline-libraries/data-pipeline-orchestration/tests/unit/test_dependency.py
@@ -41,8 +41,8 @@ class TestEntityDependencyChecker(unittest.TestCase):
     def test_get_loaded_entities(self):
         """Test getting loaded entities from job repo."""
         self.mock_repo.get_entity_status.return_value = [
-            {"entity_type": "CUSTOMERS", "status": "SUCCESS", "run_id": "run_001"},
-            {"entity_type": "ACCOUNTS", "status": "SUCCESS", "run_id": "run_002"},
+            {"entity_type": "CUSTOMERS", "status": "succeeded", "run_id": "run_001"},
+            {"entity_type": "ACCOUNTS", "status": "succeeded", "run_id": "run_002"},
             {"entity_type": "DECISION", "status": "RUNNING", "run_id": "run_003"},
         ]
 
@@ -58,9 +58,9 @@ class TestEntityDependencyChecker(unittest.TestCase):
     def test_all_entities_loaded_true(self):
         """Test all entities loaded returns True."""
         self.mock_repo.get_entity_status.return_value = [
-            {"entity_type": "CUSTOMERS", "status": "SUCCESS", "run_id": "run_001"},
-            {"entity_type": "ACCOUNTS", "status": "SUCCESS", "run_id": "run_002"},
-            {"entity_type": "DECISION", "status": "SUCCESS", "run_id": "run_003"},
+            {"entity_type": "CUSTOMERS", "status": "succeeded", "run_id": "run_001"},
+            {"entity_type": "ACCOUNTS", "status": "succeeded", "run_id": "run_002"},
+            {"entity_type": "DECISION", "status": "succeeded", "run_id": "run_003"},
         ]
 
         result = self.checker.all_entities_loaded(date(2026, 1, 1))
@@ -70,7 +70,7 @@ class TestEntityDependencyChecker(unittest.TestCase):
     def test_all_entities_loaded_false(self):
         """Test all entities loaded returns False when missing."""
         self.mock_repo.get_entity_status.return_value = [
-            {"entity_type": "CUSTOMERS", "status": "SUCCESS", "run_id": "run_001"},
+            {"entity_type": "CUSTOMERS", "status": "succeeded", "run_id": "run_001"},
             # accounts and decision missing
         ]
 
@@ -88,7 +88,7 @@ class TestEntityDependencyChecker(unittest.TestCase):
         )
 
         self.mock_repo.get_entity_status.return_value = [
-            {"entity_type": "APPLICATIONS", "status": "SUCCESS", "run_id": "run_001"},
+            {"entity_type": "APPLICATIONS", "status": "succeeded", "run_id": "run_001"},
         ]
 
         result = application2_checker.all_entities_loaded(date(2026, 1, 1))
@@ -98,7 +98,7 @@ class TestEntityDependencyChecker(unittest.TestCase):
     def test_get_missing_entities(self):
         """Test getting list of missing entities."""
         self.mock_repo.get_entity_status.return_value = [
-            {"entity_type": "CUSTOMERS", "status": "SUCCESS", "run_id": "run_001"},
+            {"entity_type": "CUSTOMERS", "status": "succeeded", "run_id": "run_001"},
         ]
 
         missing = self.checker.get_missing_entities(date(2026, 1, 1))
@@ -110,9 +110,9 @@ class TestEntityDependencyChecker(unittest.TestCase):
     def test_get_missing_entities_none_missing(self):
         """Test get_missing_entities returns empty when all loaded."""
         self.mock_repo.get_entity_status.return_value = [
-            {"entity_type": "CUSTOMERS", "status": "SUCCESS", "run_id": "run_001"},
-            {"entity_type": "ACCOUNTS", "status": "SUCCESS", "run_id": "run_002"},
-            {"entity_type": "DECISION", "status": "SUCCESS", "run_id": "run_003"},
+            {"entity_type": "CUSTOMERS", "status": "succeeded", "run_id": "run_001"},
+            {"entity_type": "ACCOUNTS", "status": "succeeded", "run_id": "run_002"},
+            {"entity_type": "DECISION", "status": "succeeded", "run_id": "run_003"},
         ]
 
         missing = self.checker.get_missing_entities(date(2026, 1, 1))
@@ -122,8 +122,8 @@ class TestEntityDependencyChecker(unittest.TestCase):
     def test_get_loaded_count(self):
         """Test getting count of loaded entities."""
         self.mock_repo.get_entity_status.return_value = [
-            {"entity_type": "CUSTOMERS", "status": "SUCCESS", "run_id": "run_001"},
-            {"entity_type": "ACCOUNTS", "status": "SUCCESS", "run_id": "run_002"},
+            {"entity_type": "CUSTOMERS", "status": "succeeded", "run_id": "run_001"},
+            {"entity_type": "ACCOUNTS", "status": "succeeded", "run_id": "run_002"},
         ]
 
         count = self.checker.get_loaded_count(date(2026, 1, 1))
@@ -133,8 +133,8 @@ class TestEntityDependencyChecker(unittest.TestCase):
     def test_get_status_summary(self):
         """Test getting detailed status summary."""
         self.mock_repo.get_entity_status.return_value = [
-            {"entity_type": "CUSTOMERS", "status": "SUCCESS", "run_id": "run_001"},
-            {"entity_type": "ACCOUNTS", "status": "SUCCESS", "run_id": "run_002"},
+            {"entity_type": "CUSTOMERS", "status": "succeeded", "run_id": "run_001"},
+            {"entity_type": "ACCOUNTS", "status": "succeeded", "run_id": "run_002"},
         ]
 
         status = self.checker.get_status_summary(date(2026, 1, 1))

--- a/python-culvert/README.md
+++ b/python-culvert/README.md
@@ -1,0 +1,56 @@
+# Culvert
+
+**A cloud-agnostic, polyglot data-pipeline framework.** One contract set —
+`Source`, `Sink`, `Transform`, `Pipeline`, `RuntimeContext`, `BlobStore`,
+`Warehouse`, `JobControlRepository`, and friends — realised in **Java and
+Python**, with cloud specifics behind adapters. Define the pipeline once
+against contracts; point it at an emulator on your laptop, a dev project, or
+production by wiring, not rewriting.
+
+- **Contract-driven** — the [language-neutral spec](https://github.com/enrichmeai/culvert/blob/main/docs/CONTRACT.md)
+  is the portability boundary. Business logic depends only on contracts.
+- **Two clouds today** — GCP is the first full implementation; AWS is a real
+  (Java) adapter family with the same pipeline proven on both. Azure is on the
+  roadmap.
+- **No application framework in the core** — plain Python Protocols +
+  entry-point auto-discovery; composes into Beam pipelines, Airflow DAGs, or a
+  script on your laptop.
+- **Local-first** — the whole stack runs against emulators with zero cloud
+  account; cloud is where you prove and ship, not where you develop.
+
+## Install
+
+```bash
+pip install culvert                 # core contracts only (no cloud SDKs)
+pip install culvert[gcp]            # + BigQuery, GCS, Pub/Sub, Secret Manager, observability
+pip install culvert[orchestration]  # + Airflow-side DAG factory, operators, sensors
+pip install culvert[transform]      # + dbt integration
+pip install culvert[all]
+```
+
+Python ≥ 3.10. For 0.1.0 the import packages keep their library names — the
+contracts live in `data_pipeline_core`:
+
+```python
+from data_pipeline_core import autoconfig
+
+config = autoconfig.discover()          # entry-point adapter discovery
+blob_store = config.blob_store()        # GcsBlobStore if culvert[gcp] installed
+```
+
+The Java twin ships as `com.enrichmeai.culvert:*` on Maven Central — same
+contracts, Java owns the Beam/Dataflow execution layer; Python owns the
+Airflow runtime and dbt packaging.
+
+## Status
+
+`0.1.0` — first public release. Built and validated against a real GCP
+project (Cloud Run, BigQuery, Pub/Sub, event-driven end-to-end) before
+publishing. GCP adapters are production-shaped; the AWS family is Java-side;
+Azure is a roadmap skeleton. Honest limitations are documented per adapter in
+the source.
+
+Docs, architecture, worked example deployments, and the engineering story:
+**https://github.com/enrichmeai/culvert**
+
+MIT licensed.

--- a/python-culvert/hatch_build.py
+++ b/python-culvert/hatch_build.py
@@ -1,0 +1,48 @@
+"""Hatchling build hook: locate the library packages in either context.
+
+The wheel is built from two places:
+  - the repo (CI / local): packages live at ../data-pipeline-libraries/*/src/
+  - an extracted sdist (pip building from source): packages were packed into
+    this project's own src/ by the sdist force-include
+
+A static [tool.hatch.build.targets.wheel.force-include] can only express one
+of those, so this hook resolves each package at build time.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+# import package -> distribution dir under data-pipeline-libraries/
+PACKAGES = {
+    "data_pipeline_core": "data-pipeline-core",
+    "data_pipeline_gcp_bigquery": "data-pipeline-gcp-bigquery",
+    "data_pipeline_gcp_gcs": "data-pipeline-gcp-gcs",
+    "data_pipeline_gcp_pubsub": "data-pipeline-gcp-pubsub",
+    "data_pipeline_gcp_secrets": "data-pipeline-gcp-secrets",
+    "data_pipeline_gcp_observability": "data-pipeline-gcp-observability",
+    "data_pipeline_orchestration": "data-pipeline-orchestration",
+    "data_pipeline_transform": "data-pipeline-transform",
+    "data_pipeline_tester": "data-pipeline-tester",
+    "data_pipeline_contract_tests": "data-pipeline-contract-tests",
+}
+
+
+class LibraryPackagesHook(BuildHookInterface):
+    PLUGIN_NAME = "library-packages"
+
+    def initialize(self, version, build_data):
+        if self.target_name != "wheel":
+            return
+        root = Path(self.root)
+        force_include = build_data.setdefault("force_include", {})
+        for pkg, dist in PACKAGES.items():
+            repo_src = root.parent / "data-pipeline-libraries" / dist / "src" / pkg
+            sdist_src = root / "src" / pkg
+            src = repo_src if repo_src.is_dir() else sdist_src
+            if not src.is_dir():
+                raise FileNotFoundError(
+                    f"package {pkg} not found at {repo_src} or {sdist_src}")
+            force_include[str(src)] = pkg

--- a/python-culvert/pyproject.toml
+++ b/python-culvert/pyproject.toml
@@ -1,0 +1,118 @@
+# The `culvert` PyPI distribution (D1 decision, 2026-07: ONE distribution with
+# extras — the Maven side stays modular; Python presents one front door).
+#
+# This pyproject assembles the data-pipeline-libraries/* import packages into a
+# single wheel via hatchling force-include. Import names stay `data_pipeline_*`
+# for 0.1.0 so every path:line citation in the book remains true; the `culvert`
+# import package is a thin front door (version + re-exports).
+#
+# Excluded on purpose: data_pipeline_framework (the legacy bundle — predecessor
+# deps; removed entirely at the F1 legacy cleanup).
+#
+# Entry points: the per-library `data_pipeline_core.adapters` registrations are
+# merged here — without them AutoConfig discovery finds nothing. autoconfig
+# skips entry points whose deps aren't installed (core-only install is safe).
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "culvert"
+version = "0.1.0"
+description = "Cloud-agnostic, polyglot data-pipeline framework: one contract set, adapters per cloud. Python side of Culvert (Java twin on Maven Central: com.enrichmeai.culvert)."
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.10"
+authors = [{ name = "Joseph Aruja" }]
+keywords = ["data-pipeline", "framework", "cloud-agnostic", "gcp", "bigquery", "dbt", "airflow", "contracts"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
+]
+dependencies = [
+    "typing-extensions>=4.7",
+]
+
+[project.urls]
+Homepage = "https://github.com/enrichmeai/culvert"
+Repository = "https://github.com/enrichmeai/culvert"
+Issues = "https://github.com/enrichmeai/culvert/issues"
+
+[project.optional-dependencies]
+gcp = [
+    "google-cloud-bigquery>=3.11.0",
+    "google-cloud-storage>=2.10.0",
+    "google-cloud-pubsub>=2.18.0",
+    "google-cloud-secret-manager>=2.16.0",
+    "google-cloud-monitoring>=2.14.0",
+    "google-cloud-datacatalog>=3.14.0",
+    "opentelemetry-api>=1.20.0",
+]
+orchestration = [
+    "PyYAML>=6.0",
+    "google-cloud-storage>=2.10.0",
+    "google-cloud-pubsub>=2.18.0",
+    "google-cloud-bigquery>=3.11.0",
+]
+transform = [
+    "dbt-bigquery>=1.5.0",
+]
+tester = [
+    "pytest>=7.0.0",
+    "pytest-cov>=4.0.0",
+    "pytest-mock>=3.10.0",
+    "apache-beam[gcp]==2.56.0",
+    "google-cloud-bigquery>=3.11.0",
+    "google-cloud-storage>=2.10.0",
+    "google-cloud-pubsub>=2.18.0",
+]
+contract-tests = [
+    "pytest>=7.4",
+]
+all = [
+    "culvert[gcp,orchestration,transform]",
+]
+
+[project.entry-points."data_pipeline_core.adapters"]
+blob_store = "data_pipeline_gcp_gcs:GcsBlobStore"
+warehouse = "data_pipeline_gcp_bigquery:BigQueryWarehouse"
+finops = "data_pipeline_gcp_bigquery:BigQueryFinOpsSink"
+source = "data_pipeline_gcp_pubsub:PubSubSource"
+sink = "data_pipeline_gcp_pubsub:PubSubSink"
+secrets = "data_pipeline_gcp_secrets:SecretManagerProvider"
+observability = "data_pipeline_gcp_observability:CloudTraceObservabilityHook"
+stage_metrics = "data_pipeline_gcp_observability:CloudMonitoringMetricsHook"
+lineage = "data_pipeline_gcp_observability:DataCatalogLineageEmitter"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/culvert"]
+
+# Library packages are force-included by the build hook (hatch_build.py),
+# which resolves them from the repo or from an extracted sdist.
+[tool.hatch.build.targets.wheel.hooks.custom]
+path = "hatch_build.py"
+
+
+[tool.hatch.build.targets.sdist]
+include = ["src/culvert", "README.md", "pyproject.toml", "hatch_build.py"]
+
+[tool.hatch.build.targets.sdist.force-include]
+"../data-pipeline-libraries/data-pipeline-core/src/data_pipeline_core" = "src/data_pipeline_core"
+"../data-pipeline-libraries/data-pipeline-gcp-bigquery/src/data_pipeline_gcp_bigquery" = "src/data_pipeline_gcp_bigquery"
+"../data-pipeline-libraries/data-pipeline-gcp-gcs/src/data_pipeline_gcp_gcs" = "src/data_pipeline_gcp_gcs"
+"../data-pipeline-libraries/data-pipeline-gcp-pubsub/src/data_pipeline_gcp_pubsub" = "src/data_pipeline_gcp_pubsub"
+"../data-pipeline-libraries/data-pipeline-gcp-secrets/src/data_pipeline_gcp_secrets" = "src/data_pipeline_gcp_secrets"
+"../data-pipeline-libraries/data-pipeline-gcp-observability/src/data_pipeline_gcp_observability" = "src/data_pipeline_gcp_observability"
+"../data-pipeline-libraries/data-pipeline-orchestration/src/data_pipeline_orchestration" = "src/data_pipeline_orchestration"
+"../data-pipeline-libraries/data-pipeline-transform/src/data_pipeline_transform" = "src/data_pipeline_transform"
+"../data-pipeline-libraries/data-pipeline-tester/src/data_pipeline_tester" = "src/data_pipeline_tester"
+"../data-pipeline-libraries/data-pipeline-contract-tests/src/data_pipeline_contract_tests" = "src/data_pipeline_contract_tests"
+
+[tool.hatch.build]
+exclude = ["**/__pycache__", "**/*.pyc", "**/.pytest_cache", "**/*.egg-info"]

--- a/python-culvert/src/culvert/__init__.py
+++ b/python-culvert/src/culvert/__init__.py
@@ -1,0 +1,27 @@
+"""Culvert — a cloud-agnostic, polyglot data-pipeline framework.
+
+One language-neutral contract set (Source, Sink, Transform, Pipeline,
+RuntimeContext, BlobStore, Warehouse, JobControlRepository, ...), realised in
+Java and Python, with cloud specifics behind adapters. This distribution is the
+Python side; the Java twin ships as ``com.enrichmeai.culvert:*`` on Maven
+Central.
+
+For 0.1.0 the import packages keep their library names — start at
+``data_pipeline_core`` for the contracts::
+
+    from data_pipeline_core import autoconfig
+    from data_pipeline_core.contracts.blob_store import BlobStore
+
+Install extras for the adapters you need::
+
+    pip install culvert[gcp]            # BigQuery, GCS, Pub/Sub, Secret Manager, observability
+    pip install culvert[orchestration]  # Airflow-side DAG factory, operators, sensors
+    pip install culvert[transform]      # dbt runner assets
+    pip install culvert[all]
+
+Docs and worked examples: https://github.com/enrichmeai/culvert
+"""
+
+__version__ = "0.1.0"
+
+__all__ = ["__version__"]


### PR DESCRIPTION
Everything needed for the 0.1.0 PyPI trigger except the trigger itself (yours).

### T24.1 — publish blocker: predecessor decoupling (T11.2b closed)
`data-pipeline-orchestration` still **depended on and imported the predecessor package** (unpinned dep + 5 import sites + predecessor-era wire values). Shipping culvert with that would pull the retired framework into every install. Fixed with a Culvert-native lazy-BigQuery job-control reader, direct `pubsub_v1` DLQ publishing, stdlib logging, and the real wire values (`succeeded`, lowercase FailureStage names). **124 tests passed, 0 failed.**

### T24.2 — the `culvert` distribution (D1: one dist + extras)
`python-culvert/`: one wheel assembling all ten library import packages (legacy bundle excluded); `import culvert` front door; extras `[gcp] [orchestration] [transform] [tester] [contract-tests] [all]`; **all 9 adapter entry points merged** (AutoConfig discovery verified). Custom hatchling build hook resolves packages from repo *or* extracted sdist (a static force-include can't do both — wheel-from-sdist was failing).

**Verified** (the TestPyPI substitute): twine check PASSED ×2 · wheel contents clean incl. dbt data files · fresh-venv core-only install with graceful discovery · `[gcp]` → all 9 adapters loadable · sdist round-trip.

`publish-pypi.yml`: workflow_dispatch only + typed confirm phrase (`publish-culvert`) + protected `pypi` environment + OIDC (zero tokens) + the full verify job gating publish. Matches the registered pending publisher exactly.

### T24.3 — launch hardening
RELEASE.md rewritten (was three decisions stale) as the coordinated-release runbook with gate-state table. CONTRIBUTING.md (local-first quickstart, contracts-are-the-seam, honesty-over-polish). SECURITY.md (private reporting, no telemetry). Secret scan clean.

### After merge, the path to publish is:
1. One-day Composer validation (RELEASE.md §4) — the last gate evidence
2. Actions → publish-pypi → type `publish-culvert` (you)
3. `mvn -P release clean deploy` + Sonatype portal confirm (you)
4. Tag v0.1.0 → release notes → then book/Medium launch pieces

🤖 Generated with [Claude Code](https://claude.com/claude-code)