### PR TITLE
docs: Medium problem-phase drafts (01 Spring-gap, 02 deploy war story)

### DIFF
--- a/book/articles/01-why-is-there-no-spring-for-data-pipelines.md
+++ b/book/articles/01-why-is-there-no-spring-for-data-pipelines.md
@@ -1,0 +1,57 @@
+# Why is there no Spring for data pipelines?
+
+*Twenty-five years of building the same scaffolding on every platform, and the question that finally made me stop.*
+
+---
+
+I have been shipping software for twenty-five years, and for most of that time the platforms would not sit still. Oracle SOA Suite. JBoss. WebLogic. Spring. Dropwizard. Kubernetes. AWS. GCP. Every few years the ground moved, and every few years I rebuilt the same things on top of it: audit trails, cost tracking, error classification, schema drift handling, reconciliation. The hard parts never changed. Only the logos did.
+
+Around year fifteen I noticed something embarrassing: every data team I joined was rebuilding the same scaffolding, and none of us called it that. We called it "the platform", or "the framework", or — my favourite — "utils". Different company, different cloud, same six months of building the unglamorous machinery that makes a pipeline trustworthy rather than merely functional.
+
+Then I would look across at my colleagues writing ordinary backend services, and they did not have this problem. They had Spring.
+
+## What Spring actually got right
+
+It is easy to forget what the JVM world looked like before Spring, so let me remind you: it looked like data engineering today. Every company had its own way of wiring components together, its own transaction handling, its own configuration story. Portability between application servers was a slideware promise.
+
+Spring's insight was not dependency injection, whatever the interview questions say. Spring's insight was that **a small, honest core of contracts could stay stable while everything around it stayed swappable**. `DataSource` doesn't care which database you use. `PlatformTransactionManager` doesn't care who commits. When MongoDB arrived years later, `spring-data-mongodb` slotted in beside JPA without a single existing application changing a line. The core had drawn the portability boundary in the right place, and an entire ecosystem grew on top of it.
+
+Now name the equivalent for data pipelines.
+
+You can't, because it doesn't exist. We have magnificent *engines* — Beam for execution, Airflow for orchestration, dbt for transformation. But engines are not frameworks. Nobody has drawn the boundary that says: *this* part of your pipeline is about data engineering, and *that* part is about the cloud you happen to be renting this year.
+
+## The ninth gap
+
+Teams that get serious about data infrastructure eventually build an internal framework. I have watched it happen — and done it — several times. The framework solves the real gaps: auditability, data quality, job control, cost visibility, lineage. And it embeds the cloud's fingerprints at every layer while doing so. The schema validator calls BigQuery directly. The cost tracker has Dataflow slot prices as module-level constants. The audit publisher is hard-wired to Pub/Sub.
+
+Nobody decides this. It happens because the project is on GCP, the engineers know GCP, and there is no reason — on any individual Tuesday — to do otherwise. The cloud-specific assumptions are not design choices; they are habits.
+
+I know because I built exactly that framework. Years of production hardening, all the gaps closed, genuinely good software — and when I finally audited it honestly, I found something that changed how I think about this whole problem: **most of the code was already cloud-neutral. It just didn't know it.** The audit trails, the reconciliation logic, the quality scoring, the job-state machine — none of it had any business knowing which cloud it ran on. The GCP parts were a thin layer on the outside.
+
+But thin layers that are not *identified* as thin layers become load-bearing walls. When someone asks "could we run this on AWS?", the honest answer is a rewrite — not because the code is cloud-specific, but because nobody ever said out loud which parts weren't.
+
+That is the ninth gap. The frameworks we build solve auditability and quality and cost, and then create a portability problem that none of the engines above them can solve, because the problem lives in *our* code, not theirs.
+
+## What the boundary looks like
+
+The fix is not "abstract everything", which is how you get frameworks nobody can debug. The fix is Spring's fix: a deliberately small set of contracts at exactly the seam where data engineering ends and cloud vendoring begins.
+
+A `BlobStore` is eight operations on bytes and URIs. It does not mention buckets, containers, or eventual consistency. A `Warehouse` covers what any serious analytical store supports — load, query, table existence — and nothing more; the clustering tricks stay in the BigQuery adapter where they belong. A `JobControlRepository` records what ran and what happened, and could not care less whether that record lives in BigQuery or DynamoDB. (Interestingly, when I implemented both, DynamoDB turned out to be *better* at it — conditional writes give you an atomic control plane BigQuery structurally can't. You only learn that when a contract forces the comparison.)
+
+Sixteen interfaces, in my current counting. Business logic depends on the contracts. Adapters implement them per cloud. Conformance is enforced by a shared test suite every adapter must pass — because an interface without enforcement is documentation, and documentation drifts.
+
+And the payoff isn't only cross-*cloud*. The same seam is what lets a pipeline run against emulators on your laptop, against a dev project from your laptop, and against production from CI — same business logic, different wiring at the edge. The developers-run-everything-locally experience that made Spring pleasant to live with falls out of the same boundary.
+
+## Someone should build this
+
+For the last while I have been building it, in the open — contracts first, Java and Python implementations, GCP as the first cloud (a concrete target keeps you honest), AWS as the proof the seam is real. The repository is public, the mistakes are in the commit history, and the framework is called Culvert — the unglamorous pipe under the road that just works, which is the whole ambition.
+
+I am not here to sell it to you today; nothing is published yet, and I have strong opinions about not announcing things that haven't survived a real deployment. (That story — what happened when eleven hundred green tests met an actual cloud project — is the next article, and it is humbling.)
+
+I am here for the argument: **data engineering deserves its Spring.** A small honest core, swappable cloud modules, contracts enforced by tests rather than intentions. Twenty-five years of rebuilt scaffolding says the demand is there.
+
+If you have built one of these internal frameworks — or are trapped inside one — I would genuinely like to hear what your version of the ninth gap looks like.
+
+---
+
+*Joseph Aruja has spent 25 years building software for banks and enterprises, and too much of it was the same software. Culvert is being built in the open at [github.com/enrichmeai/culvert](https://github.com/enrichmeai/culvert).*

--- a/book/articles/02-1145-green-tests-8-production-failures.md
+++ b/book/articles/02-1145-green-tests-8-production-failures.md
@@ -1,0 +1,58 @@
+# 1,145 green tests. The first real deploy failed 8 different ways.
+
+*What a £2 cloud bill taught me that a year of test suites couldn't.*
+
+---
+
+I want to tell you about the most valuable £2 I have spent in twenty-five years of software.
+
+The setup: I have been building a data-pipeline framework in the open — contracts in the core, cloud adapters at the edge, Java and Python. By early July it had 1,145 passing tests. Unit tests, integration tests against Google Cloud emulators, integration tests against LocalStack for the AWS adapters, contract-conformance suites that every adapter must pass. The kind of coverage you put in a conference talk.
+
+Then I deployed it to a real Google Cloud project for the first time, dropped one CSV file into a bucket, and watched it fail.
+
+Then I fixed that and watched it fail differently. Eight times.
+
+Not one of those eight failures had been visible to the test suite. Every single one was invisible *by construction* — and that is the interesting part, because the classes of bug that only surface on a real deployment are predictable, and most teams' test strategies (including, evidently, mine) are structurally blind to all of them.
+
+## The eight failures
+
+**1. The jar that wouldn't start.** The Maven Shade configuration set the main class as a bare config child instead of inside a `ManifestResourceTransformer` — a one-line mistake that produces a fat jar with no `Main-Class`. `java -jar` fails instantly. No test caught it because tests run classes, not jars. The artefact you ship is not the code you test.
+
+**2. The architectural one.** Apache Beam serialises your pipeline to workers — even the "local" DirectRunner does, deliberately, to catch exactly this. My framework's runtime context keeps its adapter registry `transient` and rebuilds it on the worker via ServiceLoader discovery. Except the BigQuery adapters needed constructor arguments, so ServiceLoader silently skipped them, so the worker threw `No implementation registered for Warehouse` on the very first element. Every local test had injected adapters as plain fields — never once crossing the serialisation boundary the framework itself documents. The fix (self-configuring constructors reading worker environment) was in the code as a TODO. Written by me, months earlier, describing precisely this failure.
+
+**3. IAM, part one.** The pipeline's service account had dataset-level write permission but not project-level `bigquery.jobUser` — it could edit data but not *run jobs*. Emulators do not do IAM. Production does nothing but.
+
+**4. Schema drift, part one.** The Terraform that provisioned the job-control table carried an old column layout; the code inserting into it had evolved. `Column pipeline_name is not present`. Two artefacts, both version-controlled, both individually reviewed, never once tested *against each other* — because the tests used H2 and the emulator, and both were set up by the code, not by the Terraform.
+
+**5. The container that couldn't be built.** The dbt runner's Dockerfile installed our transform library from local source — but not the core library it depends on, because nothing is on PyPI yet. Local dev environments had it installed already. Clean cloud builds start from nothing, and nothing is where dependency lies get exposed.
+
+**6. The template that didn't render.** dbt project variables in `dbt_project.yml` are not Jinja-rendered — a fact I half-knew and fully forgot. The literal string `{{ env_var('GCP_PROJECT_ID') }}` arrived in BigQuery as a project identifier. BigQuery was unimpressed.
+
+**7. IAM, part two.** dbt's custom schemas mean it creates datasets at runtime. Dataset-scoped permissions can't create datasets. Same lesson as #3, one layer up — least-privilege IAM is itself a system you have to test.
+
+**8. The phantom column.** The consumption-layer dbt model selected `facility_key` from an upstream table whose producing model had never emitted such a column. Two deployments, each with passing tests against its *own* fixtures, each certain about a contract that existed only in fixtures. Only running the real chain — ingest, then transform, then consume, same warehouse — exposed that the handshake was imaginary.
+
+## The pattern
+
+Look at the list again. It is not eight random bugs. It is four categories, and none of them live where unit tests look:
+
+- **Artefact packaging** (1, 5): you test code; you ship jars and containers.
+- **Serialisation and process boundaries** (2): frameworks that ship work to workers have a second startup path, and it is the one your tests bypass.
+- **Identity and permissions** (3, 7): emulators are anarchists; production is a bureaucracy.
+- **Cross-artefact contracts** (4, 6, 8): schema in Terraform vs schema in code; fixtures in one repo vs reality in another; template engines that render some files and not others.
+
+Every one of these is a *seam between things that are tested separately*. The unit suite was not wrong — every green test was telling the truth about its own little world. The lie was in the gaps between the worlds.
+
+## The £2 gate
+
+Here is what it cost to find all eight: one Google Cloud project, Cloud Run jobs that scale to zero, BigQuery and Pub/Sub inside the free tier, a few container builds. Under £2. No Kubernetes cluster, no standing orchestrator, nothing left running overnight. (The event-driven version — file lands, Eventarc fires, Workflows runs the ingestion job, then the transforms — costs effectively nothing at rest.)
+
+That is the actual lesson, and it is the policy I have now written into the project's release gate: **green tests earn you a deployment, not a release.** Nothing gets published — not the libraries, not the book I am writing about them, nothing — until the reference deployments have run end-to-end on a real cloud project and the bugs that only reality can catch have been caught. The gate costs £2 and a day. Bug #2 alone — shipped to users — would have cost the project its credibility in week one.
+
+I used to read "works on my machine" as a joke about junior developers. I now read it as a precise technical description of what a test suite is: your machine, formalised. The other machine — the one with IAM and cold starts and serialisation boundaries and the Terraform nobody ran — has to be visited in person.
+
+Eleven hundred green tests, and the most important quality signal of the year was a £2 bill and a stack trace.
+
+---
+
+*This is part of a series about building Culvert, a cloud-agnostic data-pipeline framework, in the open: [github.com/enrichmeai/culvert](https://github.com/enrichmeai/culvert). The previous article asked why data engineering never got its Spring.*

--- a/book/articles/README.md
+++ b/book/articles/README.md
@@ -1,0 +1,20 @@
+# Medium series — Culvert (problem-phase)
+
+Drafts for Joseph's Medium series. **Voice-ownership rule: Joseph edits and
+publishes every article personally; nothing here is final until he has done a
+full pass.** British spelling; first-person practitioner voice; every claim
+grounded in the repo.
+
+Gate discipline (docs/framework-evolution/13 §2): problem-phase articles are
+publishable BEFORE the 0.1.0 release — they discuss the gap and the build, and
+make no product claims (nothing is installable yet, and the articles say so).
+Launch-phase articles ("install it", benchmarks) wait for the coordinated
+publish.
+
+| # | Article | Phase | Status |
+|---|---|---|---|
+| 01 | Why is there no Spring for data pipelines? | problem | draft for Joseph's pass |
+| 02 | 1,145 green tests. The first real deploy failed 8 different ways. | problem (war story) | draft for Joseph's pass |
+
+The predecessor-era series under `book/medium/` is retired — do not reuse or
+update it (one-brand decision).


### PR DESCRIPTION
Two drafts for your voice pass — both **gate-safe** (publishable before the 0.1.0 release: they argue the problem and tell the build story, claim nothing installable, and say so in-text).

**01 — Why is there no Spring for data pipelines?** The thesis opener: 25 years of rebuilt scaffolding → what Spring actually got right (the stable core / swappable modules boundary) → the ninth gap (internal frameworks weld to one cloud by habit; thin layers become load-bearing walls) → what the contract boundary looks like (incl. the DynamoDB-beats-BigQuery control-plane discovery) → building-in-the-open close + repo link.

**02 — 1,145 green tests. The first real deploy failed 8 different ways.** The war story, categorised: artefact packaging / serialisation boundaries / IAM / cross-artefact contracts — every failure a seam *between* separately-tested worlds — closing on the £2 release-gate policy and 'a test suite is your machine, formalised'.

Voice-ownership: these are 90% drafts — you own every word before anything goes out under your name. Suggested order: 01 first (thesis), 02 a week later (the grabber referencing it). Publish from your Medium account whenever you're happy; no dependency on the release timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)