### PR TITLE
fix(ci): publish-pypi verify — wheel[gcp] install path (unblocks publish)

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -39,8 +39,11 @@ jobs:
       - name: Clean-venv smoke (wheel[gcp] — all 9 adapters loadable)
         run: |
           python -m venv /tmp/v2
-          WHL=$(ls python-culvert/dist/*.whl)
-          /tmp/v2/bin/pip install --quiet "culvert[gcp] @ file://${WHL}"
+          # Install the local wheel WITH the [gcp] extra. Use the path[extra]
+          # form (an absolute path) — NOT a "name @ file://<relative>" URI,
+          # which pip rejects because file:// requires an absolute path.
+          WHL=$(python -c "import glob,os;print(os.path.abspath(glob.glob('python-culvert/dist/*.whl')[0]))")
+          /tmp/v2/bin/pip install --quiet "${WHL}[gcp]"
           /tmp/v2/bin/python -c "
           from data_pipeline_core import autoconfig
           cfg = autoconfig.discover()


### PR DESCRIPTION
The publish attempt's `verify` job failed on the `[gcp]` smoke step: `non-local file URIs are not supported: 'file://python-culvert/dist/...'`. The `name @ file://` form needs an **absolute** path; the workflow passed a relative one (my local test used `$PWD`, hiding it). **Nothing was published** — `publish` was correctly skipped, `0.1.0` is not burned.

Fix: install the local wheel via the `${ABS_WHEEL}[gcp]` path-with-extra form (no `file://` URI). Proven locally — all 9 adapters loadable. This is the gate doing its job.

After merge, re-run the publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)