### PR TITLE
fix(maven): dynamodb sources+javadoc jars (Maven Central release blocker)

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -39,8 +39,11 @@ jobs:
       - name: Clean-venv smoke (wheel[gcp] — all 9 adapters loadable)
         run: |
           python -m venv /tmp/v2
-          WHL=$(ls python-culvert/dist/*.whl)
-          /tmp/v2/bin/pip install --quiet "culvert[gcp] @ file://${WHL}"
+          # Install the local wheel WITH the [gcp] extra. Use the path[extra]
+          # form (an absolute path) — NOT a "name @ file://<relative>" URI,
+          # which pip rejects because file:// requires an absolute path.
+          WHL=$(python -c "import glob,os;print(os.path.abspath(glob.glob('python-culvert/dist/*.whl')[0]))")
+          /tmp/v2/bin/pip install --quiet "${WHL}[gcp]"
           /tmp/v2/bin/python -c "
           from data_pipeline_core import autoconfig
           cfg = autoconfig.discover()

--- a/data-pipeline-libraries-java/data-pipeline-aws-dynamodb-java/pom.xml
+++ b/data-pipeline-libraries-java/data-pipeline-aws-dynamodb-java/pom.xml
@@ -80,4 +80,35 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <!-- Mirrors sibling AWS modules: avoids "no processor
+                         claimed any of these annotations" warnings-as-errors. -->
+                    <proc>none</proc>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+            <!-- Activates the pluginManagement source/javadoc config so this
+                 module attaches -sources.jar and -javadoc.jar. WITHOUT this
+                 block Maven Central rejects the whole bundle (every artifact
+                 must carry sources + javadoc). This module was the one of 18
+                 missing them. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
Verifying the Java/Maven-Central side before the coordinated 0.1.0 (RELEASE.md §3) — and it caught a real blocker.

**Found:** `data-pipeline-aws-dynamodb-java` had no `<build>` section, so unlike its 17 siblings it never activated the source/javadoc plugins → **no `-sources.jar`, no `-javadoc.jar`**. Maven Central rejects any bundle where an artifact lacks those — `mvn -P release deploy` would have failed *after* GPG signing.

**Fixed:** added the standard sibling `<build><plugins>`. All 18 modules now build main+sources+javadoc (verified).

**Rest of the Central setup audited sound:** parent metadata complete (name/description/url/licenses/developers/scm); every module has its own name+description; release profile = gpg + central-publishing plugin, `autoPublish=false` (portal confirmation); `doclint=none` (no javadoc-doclint surprise). So after this merges, `mvn -f data-pipeline-libraries-java/pom.xml -P release clean deploy` + your GPG/Sonatype creds is the real path — no other structural gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)