### PR TITLE
docs: reflect culvert 0.1.0 published to PyPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,24 @@
 
 All notable changes to the Culvert data pipeline framework. See [DEV_PROCESS.md](docs/framework-evolution/03-dev-process.md) for the sprint workflow.
 
-## [0.1.0] — unreleased
+## [0.1.0]
 
-**All 16 contract interfaces have real Java adapters. The feature bar for the first release is met — built and HELD, not yet published.**
+**Python: released to PyPI as `culvert` 0.1.0 (2026-07-11). Java: built and
+Maven-Central-ready, publish pending.**
 
-Culvert's first public release is **0.1.0** (a real first release, not yet API-frozen at 1.0). This spans Sprints 9–16: every contract interface defined in `data-pipeline-core-java` now has at least one concrete adapter under `com.enrichmeai.culvert:*`. The Java reactor is frozen at tag `java-0.1.0`, but it does **not** publish alone — the release gate is Java **and** Python both ready, then a coordinated `0.1.0` to Maven Central **and** PyPI (`culvert`). See `docs/framework-evolution/13-python-parity-release.md`. The Python parity work (Sprints 17+) is in progress. (The predecessor framework's `1.0.x` line — last `1.0.29` — is unrelated and deprecated; Culvert versions start fresh at 0.1.0.)
+Culvert's first public release. Every contract interface in the core has at
+least one concrete adapter; the Python distribution `culvert` (one wheel with
+`[gcp]`/`[orchestration]`/`[transform]`/`[all]` extras, all nine GCP adapters
+auto-discoverable) is **live on PyPI** — published only after the reference
+deployments ran end-to-end on a real GCP project (Cloud Run + BigQuery +
+Pub/Sub, event-driven), which caught eight production-only bugs that every
+local/emulator test had passed. The Java reactor is at the same feature bar,
+frozen at tag `java-0.1.0` and verified Maven-Central-ready (all 18 modules
+carry sources+javadoc; POM metadata complete); its publish to
+`com.enrichmeai.culvert:*` is the remaining half of the coordinated release.
+See `docs/framework-evolution/13-python-parity-release.md` and `RELEASE.md`.
+(The predecessor framework's `1.0.x` line is unrelated and retired; Culvert
+versions start fresh at 0.1.0.)
 
 ### Java libraries (`com.enrichmeai.culvert:*`) — Sprint 9–16 additions
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Culvert is a framework for building data pipelines that are **defined once against a language-neutral contract and implemented in the language that fits the job**. The same 16 contracts (Source, Sink, Transform, Pipeline, RuntimeContext, BlobStore, Warehouse, FinOpsSink, GovernancePolicy, …) are realised in both a Java library set and a Python library set; cloud specifics live behind adapters, so the core stays portable across clouds.
 
-> **Status — in progress.** The Java reactor has reached its v1.0 feature bar (all 16 contract interfaces have real adapters) and is **frozen at tag `java-0.1.0`**. It is **built and held, not yet published**: the release gate is **Java _and_ Python both ready**, then a single coordinated `0.1.0` to Maven Central (`com.enrichmeai.culvert:*`) and PyPI (`culvert`). Python parity is underway — contracts, core depth, and the GCP adapters have landed; `culvert` packaging and publish-from-git remain. **Nothing is on Maven Central or PyPI yet.** Authoritative plan: [`docs/framework-evolution/13-python-parity-release.md`](docs/framework-evolution/13-python-parity-release.md).
+> **Status — Python released; Java pending.** The Python side is **live on PyPI as [`culvert` 0.1.0](https://pypi.org/project/culvert/)** — `pip install culvert[gcp]` and the GCP adapters auto-discover. It was published only after the reference deployments ran end-to-end on a real GCP project (Cloud Run, BigQuery, Pub/Sub, event-driven). The Java reactor is at the same feature bar (all 16 contract interfaces have adapters), frozen at tag `java-0.1.0` and verified Maven-Central-ready, but **not yet on Maven Central** — that publish (`com.enrichmeai.culvert:*`) is the remaining half of the coordinated `0.1.0`. Authoritative plan: [`docs/framework-evolution/13-python-parity-release.md`](docs/framework-evolution/13-python-parity-release.md).
 
 > **Repo vs product.** The GitHub repo is `enrichmeai/culvert`; the working-tree folder is still `gcp-pipeline-reference`. The folder name is an operational identifier, not the product name.
 
@@ -49,6 +49,27 @@ docs/framework-evolution/       # canonical "why / what / when" for the redesign
 ```
 
 > The legacy Python trees (`gcp-pipeline-libraries/`, the `gcp_pipeline_*` egg-info) belong to the predecessor framework and are being retired — see [Legacy](#legacy).
+
+## Install (Python)
+
+`culvert` is on PyPI. Install the core contracts, then the extras for the
+clouds/roles you need:
+
+```bash
+pip install culvert                 # core contracts only (no cloud SDKs)
+pip install culvert[gcp]            # + BigQuery, GCS, Pub/Sub, Secret Manager, observability
+pip install culvert[orchestration]  # + Airflow-side DAG factory, operators, sensors
+pip install culvert[transform]      # + dbt integration
+pip install culvert[all]
+```
+
+```python
+from data_pipeline_core import autoconfig
+blob_store = autoconfig.discover().first("blob_store")   # GcsBlobStore with culvert[gcp]
+```
+
+The Java libraries (`com.enrichmeai.culvert:*`) are not on Maven Central yet;
+build them from source per **Build & test** below until that release lands.
 
 ## Build & test
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,7 +18,7 @@ together** → only then the book / release announcement.
 | Reference deployments on real GCP (cloudrun-only) | ✅ 2026-07-10 — full ODP→FDP→CDP chain, event-driven |
 | Libraries validated (unit + emulator IT + real-deploy exercise) | ✅ (the deploy caught 8 prod-only bugs; all fixed) |
 | Composer one-day validation (the deliberate pre-publish spend) | ⬜ see §4 |
-| PyPI publish | ⬜ §2 |
+| PyPI publish | ✅ 2026-07-11 — culvert 0.1.0 live, verified from the index |
 | Maven Central publish | ⬜ §3 |
 | Book / announcement | ⬜ after both publishes |
 

--- a/docs/framework-evolution/13-python-parity-release.md
+++ b/docs/framework-evolution/13-python-parity-release.md
@@ -1,8 +1,10 @@
 # 13 — Python parity → coordinated polyglot release
 
-**Status:** in progress. Waves **A (S17, contracts), B (S18, core depth), and
-C (S19, adapter parity) are all merged to `main`**; **Wave D (packaging +
-coordinated release) is the remaining gate**. Successor to the 9–16 Java block
+**Status:** Python **RELEASED** — `culvert` 0.1.0 live on PyPI (2026-07-11),
+verified from the index (`pip install culvert[gcp]`, all 9 adapters discover).
+Waves A–D (contracts → core depth → adapter parity → packaging) merged. The
+remaining half is the **Java publish to Maven Central** (`com.enrichmeai.culvert:*`);
+the coordinated release became Python-first in practice. Successor to the 9–16 Java block
 (Java reactor at `0.1.0` on `main`, frozen at tag `java-0.1.0`).
 
 **One-line:** Culvert is one polyglot, cloud-agnostic framework with GCP as its


### PR DESCRIPTION
`culvert` 0.1.0 is **live on PyPI** — so 'nothing on PyPI yet' on the README/CHANGELOG/plan is now false. Corrected the live public surfaces to the honest split (Python released; Java Maven-Central pending):

- **README**: status banner → 'Python released; Java pending' with the PyPI link; new **Install** section (`pip install culvert[gcp]`); from-source block reframed for contributors.
- **CHANGELOG**: `[0.1.0]` dated/released for Python, notes the real-GCP-deploy validation (the 8 prod-only bugs) and Java-pending.
- **RELEASE.md** gate table: PyPI ✅ 2026-07-11. **doc-13** status: Python RELEASED, Maven Central remaining.

Book chapters that still say 'not published' are deliberately left for the book's own pre-publish pass — the manuscript isn't public, and it's cleaner to fix once when Maven Central also ships (so it reads 'both published' rather than editing twice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)