### PR TITLE
feat: publish Maven Central from git (publish-maven workflow)

### DIFF
--- a/.github/workflows/publish-maven.yml
+++ b/.github/workflows/publish-maven.yml
@@ -1,0 +1,77 @@
+# Publish the Java reactor to Maven Central from git.
+#
+# JOSEPH-GATED: manual workflow_dispatch only + typed confirm phrase + the
+# `maven-central` environment (protect it with required reviewers for a second
+# gate). Unlike PyPI, Maven Central has NO OIDC keyless publishing — this job
+# needs your GPG private key and Sonatype token as GitHub SECRETS (added by you
+# in repo Settings → Secrets and variables → Actions; agents never handle them):
+#
+#   MAVEN_GPG_PRIVATE_KEY   ASCII-armored secret key:
+#                             gpg --export-secret-keys --armor <KEY_ID>
+#   MAVEN_GPG_PASSPHRASE    the key's passphrase
+#   CENTRAL_USERNAME        Sonatype Central portal token — username half
+#   CENTRAL_PASSWORD        Sonatype Central portal token — password half
+#
+# The release profile uses central-publishing-maven-plugin with
+# autoPublish=false, so this uploads the signed bundle to Central's VALIDATION
+# stage and stops. You then review and click "Publish" at
+# https://central.sonatype.com/ — the actual irreversible release. Publishing a
+# version is permanent; Maven Central artifacts cannot be changed or deleted.
+name: publish-maven
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type "publish-maven" to upload the signed bundle to Maven Central validation'
+        required: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+      - name: Build + sources + javadoc (no secrets — proves the bundle assembles)
+        run: mvn -B -f data-pipeline-libraries-java/pom.xml clean install -DskipTests
+      - name: Assert every module has main + sources + javadoc
+        run: |
+          cd data-pipeline-libraries-java
+          missing=0
+          for m in */ ; do
+            [ -f "$m/pom.xml" ] || continue
+            grep -q '<packaging>pom</packaging>' "$m/pom.xml" && continue
+            for suffix in "" "-sources" "-javadoc"; do
+              ls "$m"target/*-0.1.0${suffix}.jar >/dev/null 2>&1 || { echo "MISSING ${suffix:-main} jar in $m"; missing=1; }
+            done
+          done
+          [ "$missing" = 0 ] && echo "all modules carry main+sources+javadoc"
+          exit $missing
+
+  deploy:
+    needs: verify
+    if: github.event.inputs.confirm == 'publish-maven'
+    runs-on: ubuntu-latest
+    environment: maven-central
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+          server-id: central
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+      - name: Deploy to Maven Central (validation stage; you confirm in the portal)
+        run: mvn -B -f data-pipeline-libraries-java/pom.xml -P release clean deploy -DskipTests
+        env:
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -29,10 +29,24 @@ together** → only then the book / release announcement.
   workflow `publish-pypi.yml`, environment `pypi`. Optional second gate:
   repo Settings → Environments → `pypi` → required reviewers → yourself.
 - **Maven Central (Sonatype Central).** Account at central.sonatype.com;
-  namespace `com.enrichmeai.culvert` verified; user token in
-  `~/.m2/settings.xml` (server id `central`); GPG key generated and its public
-  key published to a keyserver. These are Joseph's secrets — never in the
-  repo, never handled by agents.
+  namespace `com.enrichmeai.culvert` verified; a portal user token; a GPG key
+  whose **public** key is on a keyserver (`gpg --keyserver
+  keyserver.ubuntu.com --send-keys <KEY_ID>`). Maven Central has **no OIDC**, so
+  — unlike PyPI — publishing from git needs four **GitHub Actions secrets**
+  (repo Settings → Secrets and variables → Actions). Add them yourself; agents
+  never see them:
+
+  | Secret | Value |
+  |---|---|
+  | `MAVEN_GPG_PRIVATE_KEY` | `gpg --export-secret-keys --armor <KEY_ID>` (the full ASCII block) |
+  | `MAVEN_GPG_PASSPHRASE` | the key's passphrase |
+  | `CENTRAL_USERNAME` | Sonatype portal token — username half |
+  | `CENTRAL_PASSWORD` | Sonatype portal token — password half |
+
+  Optional second gate: repo Settings → Environments → `maven-central` →
+  required reviewers → yourself. Publishing locally instead needs no GitHub
+  secret — put the token in `~/.m2/settings.xml` (server id `central`) and use
+  §3's local command.
 - **PyPI organization (optional, later).** The community-org `enrichmeai`
   request can proceed in parallel; transfer the `culvert` project into it when
   approved. Does not block 0.1.0.
@@ -58,18 +72,26 @@ release `0.1.1`.
 
 ## 3. Publish the Java reactor to Maven Central
 
-From the release state of `main` (the reactor freeze is tagged
-`java-0.1.0`; tag `v0.1.0` on the release commit):
+**From git (preferred), once the §1 secrets are added:** GitHub → Actions →
+**publish-maven** → *Run workflow* → type `publish-maven`. The `verify` job
+builds the reactor and asserts every module carries main+sources+javadoc; the
+`deploy` job (protected `maven-central` environment) imports the GPG key, signs,
+and runs `mvn -P release deploy`.
+
+**Locally (alternative, no GitHub secret):**
 
 ```bash
 mvn -f data-pipeline-libraries-java/pom.xml -P release clean deploy
 ```
 
-- The `release` profile signs with GPG and uploads via
-  `central-publishing-maven-plugin` with `autoPublish=false`.
+Either way:
+
+- The `release` profile signs with GPG (loopback pinentry for headless CI) and
+  uploads via `central-publishing-maven-plugin` with `autoPublish=false`.
 - Sonatype Central holds the bundle in **validation** — review it at
-  https://central.sonatype.com/, then confirm release. That confirmation is
-  the Java point-of-no-return.
+  https://central.sonatype.com/, then click **Publish**. That portal
+  confirmation is the Java point-of-no-return (a second human gate beyond the
+  workflow trigger).
 - Post-publish check: artifacts visible under `com.enrichmeai.culvert`; a
   scratch Maven project resolves `data-pipeline-core:0.1.0`.
 

--- a/data-pipeline-libraries-java/pom.xml
+++ b/data-pipeline-libraries-java/pom.xml
@@ -283,6 +283,18 @@
                                 <goals>
                                     <goal>sign</goal>
                                 </goals>
+                                <configuration>
+                                    <!-- Loopback pinentry: headless CI runners
+                                         have no interactive prompt, so gpg must
+                                         take the passphrase non-interactively
+                                         (from MAVEN_GPG_PASSPHRASE via the
+                                         setup-java settings). Harmless locally —
+                                         gpg still prompts at the terminal. -->
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
**"How to release Maven from git"** — the Java analogue of publish-pypi.

**The key difference from PyPI, up front:** Maven Central has **no OIDC keyless publishing**. So publishing from Actions needs four **GitHub secrets** you add (Settings → Secrets → Actions; I never see them):

| Secret | Value |
|---|---|
| `MAVEN_GPG_PRIVATE_KEY` | `gpg --export-secret-keys --armor <KEY_ID>` |
| `MAVEN_GPG_PASSPHRASE` | key passphrase |
| `CENTRAL_USERNAME` / `CENTRAL_PASSWORD` | Sonatype portal token halves |

**Workflow** (`publish-maven.yml`): `workflow_dispatch` + typed `publish-maven` confirm + protected `maven-central` environment. `verify` builds the reactor and asserts every module has main+sources+javadoc (the #165 blocker class); `deploy` imports the key via `setup-java`, signs, `mvn -P release deploy`. `autoPublish=false` → uploads to Central **validation**; **you** click Publish in the portal (a second human gate). 

**pom**: added GPG loopback pinentry (headless CI has no prompt; harmless locally). Release profile verified to build the full triad with `-Dgpg.skip=true`.

RELEASE.md §1/§3 updated: from-git preferred, local `mvn -P release deploy` as the alternative.

Nothing ships without your secrets + trigger + portal confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)