### PR TITLE
fix(release): central-publishing plugin 0.5.0 → 0.11.0 (status-poll false-negative)

### DIFF
--- a/data-pipeline-libraries-java/pom.xml
+++ b/data-pipeline-libraries-java/pom.xml
@@ -132,7 +132,7 @@
         <maven.source.plugin.version>3.3.1</maven.source.plugin.version>
         <maven.javadoc.plugin.version>3.7.0</maven.javadoc.plugin.version>
         <maven.gpg.plugin.version>3.2.4</maven.gpg.plugin.version>
-        <central.publishing.plugin.version>0.5.0</central.publishing.plugin.version>
+        <central.publishing.plugin.version>0.11.0</central.publishing.plugin.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
The Maven upload **succeeded** (deploymentId `c03439c4`, bundle in the portal awaiting the manual Publish) but the workflow showed red: plugin 0.5.0's post-upload status poll can't parse Central's newer API response (unknown `warnings` field → Jackson crash). Cosmetic false-negative, fixed by bumping to the current 0.11.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)