### PR TITLE
feat(site): holistic umbrella + fix false Maven claim on /culvert

### DIFF
--- a/site/culvert/index.html
+++ b/site/culvert/index.html
@@ -274,14 +274,14 @@ blob_store = autoconfig.discover().first(<span class="s">"blob_store"</span>)
       <div class="prose"><p>This project has a rule: nothing is announced before it has run on real infrastructure. So here is the honest state, not the roadmap in disguise.</p></div>
       <div class="spec">
         <div class="row"><div class="lab">Python</div><div class="val">Released — <code style="font-family:var(--font-mono)">culvert 0.1.0</code> on PyPI <span class="tag live">live</span></div></div>
-        <div class="row"><div class="lab">Java</div><div class="val">Built &amp; Maven-Central-ready — <code style="font-family:var(--font-mono)">com.enrichmeai.culvert:*</code> <span class="tag soon">publish pending</span></div></div>
+        <div class="row"><div class="lab">Java</div><div class="val">Released — <code style="font-family:var(--font-mono)">com.enrichmeai.culvert:*</code> on Maven Central <span class="tag live">live</span></div></div>
         <div class="row"><div class="lab">Clouds</div><div class="val">GCP — full implementation <span class="tag live">live</span> · AWS — Java adapter family <span class="tag">S3 · Athena · SQS · DynamoDB · CloudWatch</span> · Azure <span class="tag soon">roadmap</span></div></div>
         <div class="row"><div class="lab">Proof</div><div class="val">Ran end-to-end on a real GCP project — Cloud Run → BigQuery, event-driven — <b>before</b> release. It caught eight production-only bugs every local test had passed.</div></div>
         <div class="row"><div class="lab">Licence</div><div class="val">MIT</div></div>
       </div>
 
       <div class="creed" style="margin-top:40px">
-        <p>“The Java libraries aren't on Maven Central yet — and this page tells you so. That honesty is the point, not a caveat.”</p>
+        <p>“Both halves shipped only after the whole thing had run on real infrastructure — and the first real deploy failed eight ways that 1,145 green tests never saw. Releases here carry receipts, not promises.”</p>
         <div class="by">— the release gate, in one sentence</div>
       </div>
     </div>

--- a/site/index.html
+++ b/site/index.html
@@ -101,6 +101,7 @@
     <nav class="navlinks">
       <a href="#thesis">Thesis</a>
       <a href="#culvert">Culvert</a>
+      <a href="#writing">Writing</a>
       <a href="https://github.com/enrichmeai">GitHub ↗</a>
       <button class="themebtn" id="theme" aria-label="Toggle colour theme">◐</button>
     </nav>
@@ -169,6 +170,31 @@
             <li>MIT licensed · honest limitations documented per adapter</li>
           </ul>
         </aside>
+      </div>
+    </div>
+  </section>
+
+  <section id="writing">
+    <div class="wrap">
+      <span class="eyebrow">Writing</span>
+      <h2 style="margin-top:14px">The code is one part. The thinking is the product.</h2>
+      <div class="product" style="margin-top:8px">
+        <div>
+          <h3>The book — building Culvert, honestly</h3>
+          <div class="mono-sub">a practitioner&rsquo;s account · in progress</div>
+          <p>Twenty-one chapters on designing a cloud-agnostic framework in the open: the contract boundary, the polyglot split, an unflinching review of the author&rsquo;s own code, and what it&rsquo;s like to build with AI agents held to contracts and gates. Every technical claim cites the real source tree. Publishing after the 0.x line settles.</p>
+        </div>
+        <aside class="proof">
+          <span class="k">Essay series — starting soon</span>
+          <ul>
+            <li>Why is there no Spring for data pipelines?</li>
+            <li>1,145 green tests. The first real deploy failed 8 different ways.</li>
+            <li>Follow along: <a href="https://github.com/enrichmeai/culvert" style="color:var(--flow)">github.com/enrichmeai ↗</a></li>
+          </ul>
+        </aside>
+      </div>
+      <div class="prose" style="margin-top:34px">
+        <p><b>Who is behind this?</b> Joseph Antony Aruja — twenty-five years building software for banks and enterprises, too much of it the same scaffolding rebuilt on each new platform. EnrichMeAI is where that experience becomes things other people can use: libraries, writing, and the occasional strong opinion, all in the open.</p>
       </div>
     </div>
   </section>


### PR DESCRIPTION
1) **/culvert correction** — it claimed the Java libraries weren't on Maven Central; they are. Status row → live; creed replaced with the true receipts line.
2) **Holistic umbrella** — new Writing section: the in-progress book (honest framing), the essay series (titles, 'starting soon'), and a Who paragraph. Coding is one part; the thinking is the product.

🤖 Generated with [Claude Code](https://claude.com/claude-code)