### PR TITLE
chore: bump main to 0.2.0-dev (post-release)

### DIFF
--- a/data-pipeline-libraries-java/data-pipeline-aws-athena-java/pom.xml
+++ b/data-pipeline-libraries-java/data-pipeline-aws-athena-java/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.enrichmeai.culvert</groupId>
         <artifactId>data-pipeline-libraries-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/data-pipeline-libraries-java/data-pipeline-aws-cloudwatch-java/pom.xml
+++ b/data-pipeline-libraries-java/data-pipeline-aws-cloudwatch-java/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.enrichmeai.culvert</groupId>
         <artifactId>data-pipeline-libraries-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/data-pipeline-libraries-java/data-pipeline-aws-dynamodb-java/pom.xml
+++ b/data-pipeline-libraries-java/data-pipeline-aws-dynamodb-java/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.enrichmeai.culvert</groupId>
         <artifactId>data-pipeline-libraries-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/data-pipeline-libraries-java/data-pipeline-aws-s3-java/pom.xml
+++ b/data-pipeline-libraries-java/data-pipeline-aws-s3-java/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.enrichmeai.culvert</groupId>
         <artifactId>data-pipeline-libraries-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/data-pipeline-libraries-java/data-pipeline-aws-secrets-java/pom.xml
+++ b/data-pipeline-libraries-java/data-pipeline-aws-secrets-java/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.enrichmeai.culvert</groupId>
         <artifactId>data-pipeline-libraries-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/data-pipeline-libraries-java/data-pipeline-aws-sqs-java/pom.xml
+++ b/data-pipeline-libraries-java/data-pipeline-aws-sqs-java/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.enrichmeai.culvert</groupId>
         <artifactId>data-pipeline-libraries-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/data-pipeline-libraries-java/data-pipeline-azure-blob-java/pom.xml
+++ b/data-pipeline-libraries-java/data-pipeline-azure-blob-java/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.enrichmeai.culvert</groupId>
         <artifactId>data-pipeline-libraries-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/data-pipeline-libraries-java/data-pipeline-contract-tests-java/pom.xml
+++ b/data-pipeline-libraries-java/data-pipeline-contract-tests-java/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.enrichmeai.culvert</groupId>
         <artifactId>data-pipeline-libraries-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/data-pipeline-libraries-java/data-pipeline-core-java/pom.xml
+++ b/data-pipeline-libraries-java/data-pipeline-core-java/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.enrichmeai.culvert</groupId>
         <artifactId>data-pipeline-libraries-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/data-pipeline-libraries-java/data-pipeline-gcp-bigquery-java/pom.xml
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-bigquery-java/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.enrichmeai.culvert</groupId>
         <artifactId>data-pipeline-libraries-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/data-pipeline-libraries-java/data-pipeline-gcp-dataflow-java/pom.xml
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-dataflow-java/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.enrichmeai.culvert</groupId>
         <artifactId>data-pipeline-libraries-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/data-pipeline-libraries-java/data-pipeline-gcp-gcs-java/pom.xml
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-gcs-java/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.enrichmeai.culvert</groupId>
         <artifactId>data-pipeline-libraries-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/data-pipeline-libraries-java/data-pipeline-gcp-observability-java/pom.xml
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-observability-java/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.enrichmeai.culvert</groupId>
         <artifactId>data-pipeline-libraries-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/data-pipeline-libraries-java/data-pipeline-gcp-pubsub-java/pom.xml
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-pubsub-java/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.enrichmeai.culvert</groupId>
         <artifactId>data-pipeline-libraries-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/data-pipeline-libraries-java/data-pipeline-gcp-secrets-java/pom.xml
+++ b/data-pipeline-libraries-java/data-pipeline-gcp-secrets-java/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.enrichmeai.culvert</groupId>
         <artifactId>data-pipeline-libraries-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/data-pipeline-libraries-java/data-pipeline-it-support-java/pom.xml
+++ b/data-pipeline-libraries-java/data-pipeline-it-support-java/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.enrichmeai.culvert</groupId>
         <artifactId>data-pipeline-libraries-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/data-pipeline-libraries-java/data-pipeline-orchestration-java/pom.xml
+++ b/data-pipeline-libraries-java/data-pipeline-orchestration-java/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.enrichmeai.culvert</groupId>
         <artifactId>data-pipeline-libraries-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/data-pipeline-libraries-java/data-pipeline-tester-java/pom.xml
+++ b/data-pipeline-libraries-java/data-pipeline-tester-java/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.enrichmeai.culvert</groupId>
         <artifactId>data-pipeline-libraries-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/data-pipeline-libraries-java/pom.xml
+++ b/data-pipeline-libraries-java/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.enrichmeai.culvert</groupId>
     <artifactId>data-pipeline-libraries-parent</artifactId>
-    <version>0.1.0</version>
+    <version>0.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Culvert :: data-pipeline-libraries (parent)</name>

--- a/python-culvert/pyproject.toml
+++ b/python-culvert/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "culvert"
-version = "0.1.1"
+version = "0.2.0.dev0"
 description = "Cloud-agnostic, polyglot data-pipeline framework: one contract set, adapters per cloud. Python side of Culvert (Java twin on Maven Central: com.enrichmeai.culvert)."
 readme = "README.md"
 license = { text = "MIT" }

--- a/python-culvert/src/culvert/__init__.py
+++ b/python-culvert/src/culvert/__init__.py
@@ -22,6 +22,6 @@ Install extras for the adapters you need::
 Docs and worked examples: https://github.com/enrichmeai/culvert
 """
 
-__version__ = "0.1.1"
+__version__ = "0.2.0.dev0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
The RELEASE.md §post-release step: `main` moves off the released versions so no future build can shadow a published artifact.

- Java reactor: `0.1.0` → `0.2.0-SNAPSHOT` (`mvn versions:set`, all module poms)
- Python: `culvert` `0.1.1` → `0.2.0.dev0` (`pyproject.toml` + `__version__`)

Sanity: `data-pipeline-core-java` tests green on the new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)