### PR TITLE
Repo governance: MIT LICENSE consistency, DCO, COMMERCIAL.md

### DIFF
--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -1,0 +1,22 @@
+# Commercial use & support
+
+Culvert is free for commercial use under its open-source [MIT license](LICENSE).
+No strings: use it in proprietary systems, modify it, ship it. You never need a
+commercial licence to run Culvert.
+
+If you want more than the licence gives you, EnrichMeAI offers:
+
+- **Enterprise support** — prioritised bug fixes, upgrade assistance, and
+  direct access to the maintainers.
+- **Integration & adoption engagements** — getting Culvert running against
+  your cloud estate, migrating existing pipelines onto the contracts.
+- **Sponsored features** — adapters, contracts, or execution layers your
+  organisation needs, built into the open-source core.
+
+Contact: [enrichmeai.com](https://enrichmeai.com/) or open a GitHub issue
+labelled `commercial`.
+
+---
+
+EnrichMeAI is a trading name of Good Shepherd Software Consultancy Ltd
+(registered in the United Kingdom), the copyright holder of Culvert.

--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -18,5 +18,6 @@ labelled `commercial`.
 
 ---
 
-EnrichMeAI is a trading name of Good Shepherd Software Consultancy Ltd
-(registered in the United Kingdom), the copyright holder of Culvert.
+EnrichMeAI is a trading name of Good Shepherd Software Consultancy Limited,
+registered in England & Wales, company no. 09702990 — the copyright holder
+of Culvert.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,19 @@ developing.
 - `deployments/` — worked example pipelines, each with its own terraform/ + helm/
 - `docs/framework-evolution/` — the why/what/when; disagreements resolve in its favour
 
+## Sign your commits (DCO)
+
+Every commit must carry a `Signed-off-by` line matching the commit author,
+certifying the [Developer Certificate of Origin 1.1](https://developercertificate.org/).
+No CLA — the sign-off is the whole agreement.
+
+```bash
+git commit -s                      # adds Signed-off-by: Your Name <you@example.com>
+git rebase --signoff main          # fix up an existing branch
+```
+
+PRs with unsigned commits fail the DCO check and can't merge.
+
 ## Releases
 
 Maintainer-gated and coordinated across Maven Central + PyPI — see

--- a/HANDOFF-console-ui.md
+++ b/HANDOFF-console-ui.md
@@ -138,10 +138,11 @@ contracts are unbound.
 
 ## 7. Known repo hygiene backlog (separate from this work; do only if asked)
 
-1. License mismatch: root `LICENSE` is Apache-2.0 (GitHub shows apache-2.0)
-   but module POMs + README say MIT — align to one (Apache-2.0 suggested).
-2. Legacy `v1.0.x` GitHub releases (predecessor framework) — `v1.0.29` shows
-   as "Latest"; mark legacy/delete before the 0.1.0 launch.
+1. ~~License mismatch~~ — resolved 2026-07-16: root `LICENSE` is now MIT,
+   matching the module POMs, pyprojects, and the published artifacts.
+2. Legacy `v1.0.x` GitHub releases (predecessor framework) — the published
+   ones are gone and `v0.1.0` is Latest; six `v1.0.2x` drafts still await
+   deletion (maintainer action).
 3. Repo storefront empty: no description, topics, or homepage on GitHub.
 
 ## 8. Out of scope

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Good Shepherd Software Consultancy Ltd (trading as EnrichMeAI)
+Copyright (c) 2026 Good Shepherd Software Consultancy Limited (trading as EnrichMeAI)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,201 +1,21 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+MIT License
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Copyright (c) 2026 Good Shepherd Software Consultancy Ltd (trading as EnrichMeAI)
 
-   1. Definitions.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for describing the origin of the Work and
-      reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may accept additional
-      terms and conditions, or offer support, warranty, indemnity, or
-      other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright 2026 Good Shepherd Software Consultancy Limited
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-   implied. See the License for the specific language governing permissions
-   and limitations under the License.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -129,4 +129,6 @@ Culvert grew out of an earlier GCP-only internal iteration; that code is fully r
 
 ## License
 
-MIT — see each module's `pom.xml` / `pyproject.toml`.
+MIT — see [LICENSE](LICENSE). Copyright Good Shepherd Software Consultancy Ltd
+(trading as EnrichMeAI). Free for commercial use; for enterprise support,
+integration engagements, or sponsored features, see [COMMERCIAL.md](COMMERCIAL.md).

--- a/README.md
+++ b/README.md
@@ -129,6 +129,6 @@ Culvert grew out of an earlier GCP-only internal iteration; that code is fully r
 
 ## License
 
-MIT — see [LICENSE](LICENSE). Copyright Good Shepherd Software Consultancy Ltd
+MIT — see [LICENSE](LICENSE). Copyright Good Shepherd Software Consultancy Limited
 (trading as EnrichMeAI). Free for commercial use; for enterprise support,
 integration engagements, or sponsored features, see [COMMERCIAL.md](COMMERCIAL.md).

--- a/site/culvert/index.html
+++ b/site/culvert/index.html
@@ -307,7 +307,9 @@ blob_store = autoconfig.discover().first(<span class="s">"blob_store"</span>)
     <div class="meta">
       culvert 0.1.0 · MIT<br>
       built in the open<br>
-      EnrichMeAI · Joseph Aruja
+      EnrichMeAI · Joseph Aruja<br>
+      EnrichMeAI is a trading name of Good Shepherd Software Consultancy Limited,<br>
+      registered in England &amp; Wales, company no. 09702990.
     </div>
   </div>
 </footer>

--- a/site/index.html
+++ b/site/index.html
@@ -218,7 +218,9 @@
     </div>
     <div class="meta">
       EnrichMeAI · Joseph Aruja<br>
-      built in the open · MIT
+      built in the open · MIT<br>
+      EnrichMeAI is a trading name of Good Shepherd Software Consultancy Limited,<br>
+      registered in England &amp; Wales, company no. 09702990.
     </div>
   </div>
 </footer>


### PR DESCRIPTION
One concern: repo governance, per Joseph's spec.

1. **LICENSE → MIT.** The root LICENSE was Apache-2.0 while every module pom, every pyproject, the README, and the artifacts already published to Maven Central and PyPI say MIT — MIT is what the world has, so the repo now matches. Copyright line names **Good Shepherd Software Consultancy Ltd (trading as EnrichMeAI)**. Grepped the repo: no other Apache-licence references remain (the surviving "apache" hits are Beam/Airflow dependency mentions).
2. **DCO.** CONTRIBUTING.md gains a terse "Sign your commits (DCO)" section — DCO 1.1 sign-off on every commit, no CLA, `git rebase --signoff main` for fixing up branches. This commit is itself signed off. Enforcement: the DCO GitHub App is being enabled on the repo (browser flow — not API-installable).
3. **COMMERCIAL.md** — free for commercial use, no strings; enterprise support, integration/adoption engagements, and sponsored features from EnrichMeAI; contact via enrichmeai.com or a `commercial`-labelled issue; trading-name note at the bottom. Linked from README §License.

Also marks the stale licence-mismatch item in HANDOFF-console-ui.md resolved.

No code changes — docs/metadata only; suite unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)