### PR TITLE
site: slim footers to org-level (multi-product ready)

### DIFF
--- a/site/culvert/index.html
+++ b/site/culvert/index.html
@@ -305,9 +305,8 @@ blob_store = autoconfig.discover().first(<span class="s">"blob_store"</span>)
       </div>
     </div>
     <div class="meta">
-      culvert 0.1.0 · MIT<br>
-      built in the open<br>
-      EnrichMeAI · Joseph Aruja<br>
+      culvert 0.1.0 · MIT · built in the open<br>
+      EnrichMeAI<br>
       EnrichMeAI is a trading name of Good Shepherd Software Consultancy Limited,<br>
       registered in England &amp; Wales, company no. 09702990.
     </div>

--- a/site/index.html
+++ b/site/index.html
@@ -217,8 +217,7 @@
       <a href="https://pypi.org/project/culvert/">pypi.org/project/culvert ↗</a>
     </div>
     <div class="meta">
-      EnrichMeAI · Joseph Aruja<br>
-      built in the open · MIT<br>
+      EnrichMeAI · built in the open · MIT<br>
       EnrichMeAI is a trading name of Good Shepherd Software Consultancy Limited,<br>
       registered in England &amp; Wales, company no. 09702990.
     </div>


### PR DESCRIPTION
Footers now carry EnrichMeAI + the statutory disclosure only; Joseph stays front-and-centre in the who-section where the author-led argument lives. Prep for the umbrella hosting more than one product.

🤖 Generated with [Claude Code](https://claude.com/claude-code)