### PR TITLE
site: make the landing page the whole-company umbrella

### DIFF
--- a/site/culvert/index.html
+++ b/site/culvert/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Culvert — cloud-agnostic data-pipeline framework</title>
+<title>Culvert, the cloud-agnostic data-pipeline framework</title>
 <meta name="description" content="Culvert: data pipelines defined once against a language-neutral contract set, with adapters per cloud. Java and Python. pip install culvert.">
 <style>
   :root{
@@ -217,7 +217,7 @@
   <div class="channel" aria-hidden="true">
     <div class="terrain top"><span>GCP · live</span><span class="dim">AWS · Java family</span><span class="dim">Azure · roadmap</span></div>
     <canvas id="flow"></canvas>
-    <div class="terrain bot"><span class="dim">source</span><span>— the contract carries the flow —</span><span class="dim">warehouse</span></div>
+    <div class="terrain bot"><span class="dim">source</span><span>the contract carries the flow</span><span class="dim">warehouse</span></div>
   </div>
 </div>
 
@@ -246,7 +246,7 @@
       <div class="prose"><p>One package, extras for the adapters and roles you want. Core installs with no cloud SDKs at all.</p></div>
       <div class="code">
         <div class="head"><span>shell</span><span>Python ≥ 3.10</span></div>
-<pre><span class="c"># core contracts only — no cloud SDKs</span>
+<pre><span class="c"># core contracts only, no cloud SDKs</span>
 <span class="k">pip</span> install culvert
 
 <span class="c"># + BigQuery, GCS, Pub/Sub, Secret Manager, observability</span>
@@ -270,19 +270,19 @@ blob_store = autoconfig.discover().first(<span class="s">"blob_store"</span>)
 
   <section id="status">
     <div class="wrap">
-      <div class="sechead"><span class="num">03</span><h2>What's real — stated plainly</h2></div>
+      <div class="sechead"><span class="num">03</span><h2>What's real, stated plainly</h2></div>
       <div class="prose"><p>This project has a rule: nothing is announced before it has run on real infrastructure. So here is the honest state, not the roadmap in disguise.</p></div>
       <div class="spec">
-        <div class="row"><div class="lab">Python</div><div class="val">Released — <code style="font-family:var(--font-mono)">culvert 0.1.0</code> on PyPI <span class="tag live">live</span></div></div>
-        <div class="row"><div class="lab">Java</div><div class="val">Released — <code style="font-family:var(--font-mono)">com.enrichmeai.culvert:*</code> on Maven Central <span class="tag live">live</span></div></div>
-        <div class="row"><div class="lab">Clouds</div><div class="val">GCP — full implementation <span class="tag live">live</span> · AWS — Java adapter family <span class="tag">S3 · Athena · SQS · DynamoDB · CloudWatch</span> · Azure <span class="tag soon">roadmap</span></div></div>
+        <div class="row"><div class="lab">Python</div><div class="val">Released: <code style="font-family:var(--font-mono)">culvert 0.1.0</code> on PyPI <span class="tag live">live</span></div></div>
+        <div class="row"><div class="lab">Java</div><div class="val">Released: <code style="font-family:var(--font-mono)">com.enrichmeai.culvert:*</code> on Maven Central <span class="tag live">live</span></div></div>
+        <div class="row"><div class="lab">Clouds</div><div class="val">GCP: full implementation <span class="tag live">live</span> · AWS: Java adapter family <span class="tag">S3 · Athena · SQS · DynamoDB · CloudWatch</span> · Azure <span class="tag soon">roadmap</span></div></div>
         <div class="row"><div class="lab">Proof</div><div class="val">Ran end-to-end on a real GCP project (Cloud Run → BigQuery, event-driven) <b>before</b> release. It caught eight production-only bugs every local test had passed.</div></div>
         <div class="row"><div class="lab">Licence</div><div class="val">MIT</div></div>
       </div>
 
       <div class="creed" style="margin-top:40px">
         <p>“Both halves shipped only after the whole thing had run on real infrastructure. The first real deploy failed in eight ways that 1,145 green tests never saw. Releases here carry receipts, not promises.”</p>
-        <div class="by">— the release gate, in one sentence</div>
+        <div class="by">the release gate, in one sentence</div>
       </div>
     </div>
   </section>
@@ -293,8 +293,8 @@ blob_store = autoconfig.discover().first(<span class="s">"blob_store"</span>)
     <div class="cols">
       <div>
         <h4>Get it</h4>
-        <a href="https://pypi.org/project/culvert/">PyPI — pip install culvert ↗</a>
-        <a href="https://github.com/enrichmeai/culvert">GitHub — source ↗</a>
+        <a href="https://pypi.org/project/culvert/">PyPI: pip install culvert ↗</a>
+        <a href="https://github.com/enrichmeai/culvert">GitHub: source ↗</a>
         <a href="https://github.com/enrichmeai/culvert/blob/main/docs/CONTRACT.md">The contract spec ↗</a>
       </div>
       <div>
@@ -315,7 +315,7 @@ blob_store = autoconfig.discover().first(<span class="s">"blob_store"</span>)
 
 <script>
 (function(){
-  // theme toggle — stamps data-theme, overriding the media query both ways
+  // theme toggle: stamps data-theme, overriding the media query both ways
   var root=document.documentElement, btn=document.getElementById('theme');
   btn.addEventListener('click',function(){
     var cur=root.getAttribute('data-theme');

--- a/site/index.html
+++ b/site/index.html
@@ -79,6 +79,8 @@
   .proof .mono{font-size:13px;color:var(--flow)}
   @media(max-width:760px){.product{grid-template-columns:1fr}}
 
+  .nextcard{border:1px dashed var(--line);border-radius:4px;background:transparent;padding:20px 22px;margin-top:16px}
+
   .creed{border-left:3px solid var(--accent);padding:6px 0 6px 24px;max-width:56ch}
   .creed p{font-weight:600;font-size:clamp(19px,2.5vw,25px);letter-spacing:-.015em;line-height:1.36}
   .creed .by{margin-top:12px;font-family:var(--font-mono);font-size:12px;color:var(--muted)}
@@ -100,8 +102,9 @@
     <span class="brand">enrichme<span class="dot">·</span>ai</span>
     <nav class="navlinks">
       <a href="#thesis">Thesis</a>
-      <a href="#culvert">Culvert</a>
+      <a href="#work">Products</a>
       <a href="#writing">Writing</a>
+      <a href="#services">Work with us</a>
       <a href="https://github.com/enrichmeai">GitHub ↗</a>
       <button class="themebtn" id="theme" aria-label="Toggle colour theme">◐</button>
     </nav>
@@ -147,10 +150,11 @@
     </div>
   </section>
 
-  <section id="culvert">
+  <section id="work">
     <div class="wrap">
-      <span class="eyebrow">Flagship</span>
-      <div class="product" style="margin-top:14px">
+      <span class="eyebrow">Products</span>
+      <h2 style="margin-top:14px">What we build</h2>
+      <div class="product" style="margin-top:8px">
         <div>
           <h3>Culvert</h3>
           <div class="mono-sub">cloud-agnostic data-pipeline framework · Java + Python</div>
@@ -170,6 +174,23 @@
             <li>MIT licensed · honest limitations documented per adapter</li>
           </ul>
         </aside>
+      </div>
+      <div class="nextcard">
+        <div>
+          <h3 style="font-size:clamp(17px,2.2vw,21px);font-weight:700;letter-spacing:-.01em">Product two — personal data, back in personal hands</h3>
+          <p style="color:var(--muted);margin-top:8px;max-width:60ch">A server that stores your data where <i>you</i> decide, and lets applications ask permission instead of taking copies. In design now. Per the house rule below, it gets a name and a page when it runs on real infrastructure — not before.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="services">
+    <div class="wrap">
+      <span class="eyebrow">Work with us</span>
+      <h2 style="margin-top:14px">Free to use. Supported if you want backup.</h2>
+      <div class="prose">
+        <p>Culvert is MIT licensed — free for commercial use, no strings, no open-core bait. If you're putting it to work inside an organisation and want backup, EnrichMeAI offers <b>enterprise support</b> (prioritised fixes, upgrade help, direct maintainer access), <b>integration engagements</b>, and <b>sponsored features</b>.</p>
+        <p>Start with <a href="https://github.com/enrichmeai/culvert/blob/main/COMMERCIAL.md" style="color:var(--flow)">COMMERCIAL.md</a> or open a GitHub issue labelled <span class="mono" style="font-size:14px">commercial</span>.</p>
       </div>
     </div>
   </section>
@@ -213,6 +234,7 @@
   <div class="wrap foot">
     <div>
       <a href="culvert/">Culvert — data-pipeline framework</a>
+      <a href="https://github.com/enrichmeai/culvert/blob/main/COMMERCIAL.md">Work with us ↗</a>
       <a href="https://github.com/enrichmeai">github.com/enrichmeai ↗</a>
       <a href="https://pypi.org/project/culvert/">pypi.org/project/culvert ↗</a>
     </div>

--- a/site/index.html
+++ b/site/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>EnrichMeAI — code got cheap. Judgment didn't.</title>
+<title>EnrichMeAI. Code got cheap. Judgment didn't.</title>
 <meta name="description" content="EnrichMeAI builds open-source libraries and frameworks for the AI era. Code is cheap now; the contracts, tests and operational judgment inside a good library are not.">
 <style>
   :root{
@@ -153,7 +153,10 @@
   <section id="work">
     <div class="wrap">
       <span class="eyebrow">Products</span>
-      <h2 style="margin-top:14px">What we build</h2>
+      <h2 style="margin-top:14px">Software shouldn't be hard.</h2>
+      <div class="prose" style="margin-bottom:26px">
+        <p>Most of what makes software hard is the same plumbing, rebuilt badly on every project. We build libraries that take that plumbing off your plate: libraries for data pipelines, libraries for messaging systems, libraries for microservices. Data pipelines shipped first. The rest are on the way.</p>
+      </div>
       <div class="product" style="margin-top:8px">
         <div>
           <h3>Culvert</h3>
@@ -168,8 +171,8 @@
         <aside class="proof">
           <span class="k">Receipts, not claims</span>
           <ul>
-            <li><span class="mono">pip install culvert</span> — live on PyPI</li>
-            <li><span class="mono">com.enrichmeai.culvert:*</span> — Java twin on Maven Central</li>
+            <li><span class="mono">pip install culvert</span> is live on PyPI</li>
+            <li><span class="mono">com.enrichmeai.culvert:*</span> is the Java twin on Maven Central</li>
             <li>Proven end-to-end on a real cloud project before release. That deploy caught 8 bugs which 1,145 green tests had missed</li>
             <li>MIT licensed · honest limitations documented per adapter</li>
           </ul>
@@ -177,8 +180,8 @@
       </div>
       <div class="nextcard">
         <div>
-          <h3 style="font-size:clamp(17px,2.2vw,21px);font-weight:700;letter-spacing:-.01em">Product two — personal data, back in personal hands</h3>
-          <p style="color:var(--muted);margin-top:8px;max-width:60ch">A server that stores your data where <i>you</i> decide, and lets applications ask permission instead of taking copies. In design now. Per the house rule below, it gets a name and a page when it runs on real infrastructure — not before.</p>
+          <h3 style="font-size:clamp(17px,2.2vw,21px);font-weight:700;letter-spacing:-.01em">Product two: personal data, back in personal hands</h3>
+          <p style="color:var(--muted);margin-top:8px;max-width:60ch">A server that stores your data where <i>you</i> decide, and lets applications ask permission instead of taking copies. It is in design now. The house rule below applies: it gets a name and a page when it runs on real infrastructure, not before.</p>
         </div>
       </div>
     </div>
@@ -189,7 +192,7 @@
       <span class="eyebrow">Work with us</span>
       <h2 style="margin-top:14px">Free to use. Supported if you want backup.</h2>
       <div class="prose">
-        <p>Culvert is MIT licensed — free for commercial use, no strings, no open-core bait. If you're putting it to work inside an organisation and want backup, EnrichMeAI offers <b>enterprise support</b> (prioritised fixes, upgrade help, direct maintainer access), <b>integration engagements</b>, and <b>sponsored features</b>.</p>
+        <p>Culvert is MIT licensed. Free for commercial use, no strings, no open-core bait. If you're putting it to work inside an organisation and want backup, EnrichMeAI offers <b>enterprise support</b> (prioritised fixes, upgrade help, direct maintainer access), <b>integration engagements</b>, and <b>sponsored features</b>.</p>
         <p>Start with <a href="https://github.com/enrichmeai/culvert/blob/main/COMMERCIAL.md" style="color:var(--flow)">COMMERCIAL.md</a> or open a GitHub issue labelled <span class="mono" style="font-size:14px">commercial</span>.</p>
       </div>
     </div>
@@ -201,12 +204,12 @@
       <h2 style="margin-top:14px">The code is one part. The thinking is the product.</h2>
       <div class="product" style="margin-top:8px">
         <div>
-          <h3>The book — building Culvert, honestly</h3>
+          <h3>The book: building Culvert, honestly</h3>
           <div class="mono-sub">a practitioner&rsquo;s account · in progress</div>
           <p>Twenty-one chapters on designing a cloud-agnostic framework in the open: where the contract boundary sits, why the two languages split the work the way they do, an honest review of my own code, and what building with AI agents actually looks like when they're held to contracts and gates. Every technical claim cites the real source tree. It publishes once the 0.x line settles.</p>
         </div>
         <aside class="proof">
-          <span class="k">Essay series — starting soon</span>
+          <span class="k">Essay series, starting soon</span>
           <ul>
             <li>Why is there no Spring for data pipelines?</li>
             <li>1,145 green tests. The first real deploy failed 8 different ways.</li>
@@ -224,7 +227,7 @@
     <div class="wrap">
       <div class="creed">
         <p>“Nothing here is announced before it has run on real infrastructure. Claims are cheap now. Proof isn't.”</p>
-        <div class="by">— house rule</div>
+        <div class="by">house rule</div>
       </div>
     </div>
   </section>
@@ -233,7 +236,7 @@
 <footer>
   <div class="wrap foot">
     <div>
-      <a href="culvert/">Culvert — data-pipeline framework</a>
+      <a href="culvert/">Culvert, the data-pipeline framework</a>
       <a href="https://github.com/enrichmeai/culvert/blob/main/COMMERCIAL.md">Work with us ↗</a>
       <a href="https://github.com/enrichmeai">github.com/enrichmeai ↗</a>
       <a href="https://pypi.org/project/culvert/">pypi.org/project/culvert ↗</a>


### PR DESCRIPTION
Products section (Culvert flagship + a deliberately nameless product-two teaser — the house rule says it gets a name when it runs), a terse Work-with-us section linking COMMERCIAL.md (the site's first commercial surface), nav and footer updated. Based on #182; retargets to main when that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)