### PR TITLE
site: cut the last four machine-scented lines

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -115,7 +115,7 @@
   <div class="wrap">
     <span class="eyebrow">Good libraries, built in the open</span>
     <h1 style="margin-top:14px">Code got <span class="strike">expensive</span> cheap.<br>Judgment didn't.</h1>
-    <p class="lede">AI can write a thousand lines before your coffee cools. What it can't do is stand behind them: keep an interface stable for years, catch the failure the emulator never shows, ship an artifact a stranger can depend on. That takes <b>judgment</b>, and libraries are where judgment collects. EnrichMeAI builds them in the open.</p>
+    <p class="lede">AI can write a thousand lines in a minute. What it can't do is stand behind them: keep an interface stable for years, catch the failure the emulator never shows, ship an artifact a stranger can depend on. That takes <b>judgment</b>, and libraries are where judgment collects. EnrichMeAI builds them in the open.</p>
   </div>
 </div>
 
@@ -125,7 +125,7 @@
       <h2>Why libraries, when anyone can generate code?</h2>
       <div class="prose">
         <p>Systems rarely break in the middle of a function. They break at the <b>seams</b>: between your logic and the cloud SDK, between the schema Terraform provisioned and the schema the code writes, between what passed on your laptop and what runs on a serialised worker with real IAM. Generated code adds more seams. It doesn't harden any of them.</p>
-        <p>A good library is where the hardening collects: a stable contract, a conformance suite every implementation has to pass, honest notes about what <i>doesn't</i> work, and a signed, versioned artifact. None of that is typing. We build our own libraries with AI agents, and it only works because the agents are held to the same contracts and gates.</p>
+        <p>A good library is where the hardening lives: a stable contract, a conformance suite every implementation has to pass, honest notes about what <i>doesn't</i> work, and a signed, versioned artifact. None of that is typing. We build our own libraries with AI agents, and it only works because the agents are held to the same contracts and gates.</p>
       </div>
       <div class="thesis">
         <div class="cheap">
@@ -155,13 +155,13 @@
       <span class="eyebrow">Products</span>
       <h2 style="margin-top:14px">Software shouldn't be hard.</h2>
       <div class="prose" style="margin-bottom:26px">
-        <p>Most of what makes software hard is the same plumbing, rebuilt badly on every project. We build libraries that take that plumbing off your plate: libraries for data pipelines, libraries for messaging systems, libraries for microservices. Data pipelines shipped first. The rest are on the way.</p>
+        <p>Most of what makes software hard is the same plumbing, rebuilt badly on every project. We build libraries that solve that plumbing once, so you never rebuild it again: libraries for data pipelines, libraries for messaging systems, libraries for microservices. Data pipelines shipped first. The rest are on the way.</p>
       </div>
       <div class="product" style="margin-top:8px">
         <div>
           <h3>Culvert</h3>
           <div class="mono-sub">cloud-agnostic data-pipeline framework · Java + Python</div>
-          <p>Data pipelines defined once against a language-neutral contract set, then run on any cloud by swapping adapters instead of rewriting logic. Sixteen interfaces, implemented in Java and Python. GCP today, AWS alongside it, Azure on the roadmap. Everything runs on real infrastructure before it ships.</p>
+          <p>Data pipelines defined once against a language-neutral contract set, then run on any cloud by swapping adapters instead of rewriting logic. Sixteen interfaces, implemented in Java and Python. GCP today, AWS alongside it, Azure on the roadmap.</p>
           <div class="btns">
             <a class="btn primary" href="culvert/">Explore Culvert →</a>
             <a class="btn" href="https://pypi.org/project/culvert/">PyPI ↗</a>


### PR DESCRIPTION
Four one-line copy fixes from the cold re-read of the live homepage — the flaws called out in the editorial pass, nothing else touched:

1. **Hero**: "before your coffee cools" → "in a minute". The coffee metaphor was the most stock-AI phrase left on the page; plainer is stronger.
2. **Thesis**: "where the hardening collects" → "where the hardening lives". The hero already uses "where judgment collects" — once is an image, twice is a template.
3. **Products intro**: "take that plumbing off your plate" → "solve that plumbing once, so you never rebuild it again". Fixes the mixed metaphor and says something sharper.
4. **Culvert card**: dropped "Everything runs on real infrastructure before it ships." The house rule was stated three times on one page; it stays in the product-two teaser and the creed, and the receipts box next to this card already proves it with the 8-bugs line.

Merging republishes the site automatically via `pages.yml` (path-filtered on `site/**`) — no GCP workflows involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)