### PR TITLE
chore(license): relicense from MIT to Apache License 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the Culvert data pipeline framework. See [DEV_PROCESS.md](docs/framework-evolution/03-dev-process.md) for the sprint workflow.
 
+## [Unreleased]
+
+### Changed
+
+- **Relicensed from MIT to Apache License 2.0** (2026-08-20). Rationale: an
+  explicit patent grant from every contributor (and patent-retaliation
+  termination) that enterprise dependency review expects of infrastructure
+  code; built-in contribution licensing (§5); an explicit trademark
+  reservation (§6); and one license posture across EnrichMeAI projects
+  (Cistern is Apache-2.0). All code to date is the copyright of Good Shepherd
+  Software Consultancy Limited, so no contributor consent was required.
+  Versions already published under MIT (PyPI `culvert` 0.1.0, Maven Central
+  `com.enrichmeai.culvert:*` 0.1.0) remain MIT — that grant is irrevocable;
+  the next release is the first to ship Apache-2.0 metadata. Added the
+  canonical `LICENSE` text and a `NOTICE` file; updated license metadata in
+  every `pyproject.toml`, the parent POM, and docs.
+
 ## [0.1.0] — 2026-07-15
 
 **RELEASED — both ecosystems. Python: `culvert` 0.1.0 on PyPI (2026-07-11). Java:

--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -1,6 +1,6 @@
 # Commercial use & support
 
-Culvert is free for commercial use under its open-source [MIT license](LICENSE).
+Culvert is free for commercial use under its open-source [Apache-2.0 license](LICENSE).
 No strings: use it in proprietary systems, modify it, ship it. You never need a
 commercial licence to run Culvert.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,202 @@
-MIT License
 
-Copyright (c) 2026 Good Shepherd Software Consultancy Limited (trading as EnrichMeAI)
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+   1. Definitions.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+Culvert
+Copyright 2026 Good Shepherd Software Consultancy Limited (trading as EnrichMeAI)
+
+This product includes software developed at
+EnrichMeAI (https://enrichmeai.com/).

--- a/README.md
+++ b/README.md
@@ -129,6 +129,6 @@ Culvert grew out of an earlier GCP-only internal iteration; that code is fully r
 
 ## License
 
-MIT — see [LICENSE](LICENSE). Copyright Good Shepherd Software Consultancy Limited
+Apache-2.0 — see [LICENSE](LICENSE). Copyright Good Shepherd Software Consultancy Limited
 (trading as EnrichMeAI). Free for commercial use; for enterprise support,
 integration engagements, or sponsored features, see [COMMERCIAL.md](COMMERCIAL.md).

--- a/data-pipeline-libraries-java/data-pipeline-core-java/README.md
+++ b/data-pipeline-libraries-java/data-pipeline-core-java/README.md
@@ -346,4 +346,4 @@ behaves exactly as before (the no-policy path is unchanged and still tested).
 
 ## License
 
-MIT — see [LICENSE](../../LICENSE) at the repository root.
+Apache-2.0 — see [LICENSE](../../LICENSE) at the repository root.

--- a/data-pipeline-libraries-java/pom.xml
+++ b/data-pipeline-libraries-java/pom.xml
@@ -34,8 +34,8 @@
 
     <licenses>
         <license>
-            <name>MIT License</name>
-            <url>https://opensource.org/licenses/MIT</url>
+            <name>Apache License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0</url>
             <distribution>repo</distribution>
         </license>
     </licenses>

--- a/data-pipeline-libraries/data-pipeline-contract-tests/pyproject.toml
+++ b/data-pipeline-libraries/data-pipeline-contract-tests/pyproject.toml
@@ -8,12 +8,12 @@ version = "0.1.0"
 description = "Abstract pytest contract tests that every Culvert framework implementation must pass. Test-library — pytest + the data-pipeline-core Protocols are compile-time deps."
 readme = "README.md"
 requires-python = ">=3.10"
-license = { text = "MIT" }
+license = { text = "Apache-2.0" }
 authors = [{ name = "Joseph Aruja", email = "joseph.a.aruja@googlemail.com" }]
 keywords = ["data", "pipeline", "framework", "culvert", "contract-tests"]
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/data-pipeline-libraries/data-pipeline-core/README.md
+++ b/data-pipeline-libraries/data-pipeline-core/README.md
@@ -54,4 +54,4 @@ Eleven Protocols are the entire framework-to-cloud seam:
 
 ## License
 
-MIT — see [LICENSE](../../LICENSE) at the repository root.
+Apache-2.0 — see [LICENSE](../../LICENSE) at the repository root.

--- a/data-pipeline-libraries/data-pipeline-core/pyproject.toml
+++ b/data-pipeline-libraries/data-pipeline-core/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Cloud-neutral contracts for the Culvert data pipeline framework. The framework-agnostic kernel: Protocols, dataclasses, and types. Zero GCP/AWS/Azure SDK dependencies."
 readme = "README.md"
 requires-python = ">=3.10"
-license = { text = "MIT" }
+license = { text = "Apache-2.0" }
 authors = [
     { name = "Joseph Aruja", email = "joseph.a.aruja@googlemail.com" },
 ]
@@ -16,7 +16,7 @@ keywords = ["data", "pipeline", "framework", "cloud-neutral", "culvert"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",

--- a/data-pipeline-libraries/data-pipeline-gcp-bigquery/pyproject.toml
+++ b/data-pipeline-libraries/data-pipeline-gcp-bigquery/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Google Cloud BigQuery adapter for the Culvert data pipeline framework. Implements the cloud-neutral Warehouse contract from data-pipeline-core."
 readme = "README.md"
 requires-python = ">=3.10"
-license = { text = "MIT" }
+license = { text = "Apache-2.0" }
 authors = [
     { name = "Joseph Aruja", email = "joseph.a.aruja@googlemail.com" },
 ]
@@ -16,7 +16,7 @@ keywords = ["data", "pipeline", "framework", "culvert", "bigquery", "gcp"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",

--- a/data-pipeline-libraries/data-pipeline-gcp-gcs/pyproject.toml
+++ b/data-pipeline-libraries/data-pipeline-gcp-gcs/pyproject.toml
@@ -8,14 +8,14 @@ version = "0.1.0"
 description = "Google Cloud Storage adapter for the Culvert data pipeline framework. Implements the cloud-neutral BlobStore contract from data-pipeline-core."
 readme = "README.md"
 requires-python = ">=3.10"
-license = { text = "MIT" }
+license = { text = "Apache-2.0" }
 authors = [
     { name = "Joseph Aruja", email = "joseph.a.aruja@googlemail.com" },
 ]
 keywords = ["data", "pipeline", "framework", "culvert", "gcs", "gcp"]
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/data-pipeline-libraries/data-pipeline-gcp-observability/pyproject.toml
+++ b/data-pipeline-libraries/data-pipeline-gcp-observability/pyproject.toml
@@ -8,14 +8,14 @@ version = "0.1.0"
 description = "GCP observability adapter for the Culvert data pipeline framework. Implements ObservabilityHook (Cloud Trace/OTel), StageMetricsHook (Cloud Monitoring), LineageEmitter (Data Catalog), and CulvertMdcPopulator log-correlation helper."
 readme = "README.md"
 requires-python = ">=3.10"
-license = { text = "MIT" }
+license = { text = "Apache-2.0" }
 authors = [
     { name = "Joseph Aruja", email = "joseph.a.aruja@googlemail.com" },
 ]
 keywords = ["data", "pipeline", "framework", "culvert", "gcp", "observability", "tracing", "metrics", "lineage"]
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/data-pipeline-libraries/data-pipeline-gcp-pubsub/pyproject.toml
+++ b/data-pipeline-libraries/data-pipeline-gcp-pubsub/pyproject.toml
@@ -8,14 +8,14 @@ version = "0.1.0"
 description = "Google Cloud Pub/Sub adapter for the Culvert data pipeline framework. Implements the cloud-neutral Source/Sink contracts from data-pipeline-core."
 readme = "README.md"
 requires-python = ">=3.10"
-license = { text = "MIT" }
+license = { text = "Apache-2.0" }
 authors = [
     { name = "Joseph Aruja", email = "joseph.a.aruja@googlemail.com" },
 ]
 keywords = ["data", "pipeline", "framework", "culvert", "pubsub", "gcp"]
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/data-pipeline-libraries/data-pipeline-gcp-secrets/pyproject.toml
+++ b/data-pipeline-libraries/data-pipeline-gcp-secrets/pyproject.toml
@@ -8,14 +8,14 @@ version = "0.1.0"
 description = "Google Cloud Secret Manager adapter for the Culvert data pipeline framework. Implements the cloud-neutral SecretProvider contract from data-pipeline-core."
 readme = "README.md"
 requires-python = ">=3.10"
-license = { text = "MIT" }
+license = { text = "Apache-2.0" }
 authors = [
     { name = "Joseph Aruja", email = "joseph.a.aruja@googlemail.com" },
 ]
 keywords = ["data", "pipeline", "framework", "culvert", "secret-manager", "gcp"]
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/data-pipeline-libraries/data-pipeline-orchestration/pyproject.toml
+++ b/data-pipeline-libraries/data-pipeline-orchestration/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Orchestration library for the Culvert data pipeline framework. Airflow DAG factory, operators, sensors, and callbacks. Cloud-coupled to Composer/Airflow — Airflow is Python-only and is not being polyglot-ported."
 readme = "README.md"
 requires-python = ">=3.10"
-license = { text = "MIT" }
+license = { text = "Apache-2.0" }
 authors = [
     { name = "Joseph Aruja", email = "joseph.a.aruja@googlemail.com" },
 ]
@@ -16,7 +16,7 @@ keywords = ["data", "pipeline", "framework", "culvert", "airflow", "composer", "
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",

--- a/data-pipeline-libraries/data-pipeline-tester/pyproject.toml
+++ b/data-pipeline-libraries/data-pipeline-tester/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Testing framework for the Culvert data pipeline framework. Base test classes, builders, assertions, BDD steps, mocks, and fixtures for Source/Sink/Transform pipelines and their cloud-specific implementations."
 readme = "README.md"
 requires-python = ">=3.10"
-license = { text = "MIT" }
+license = { text = "Apache-2.0" }
 authors = [
     { name = "Joseph Aruja", email = "joseph.a.aruja@googlemail.com" },
 ]
@@ -16,7 +16,7 @@ keywords = ["data", "pipeline", "framework", "testing", "culvert", "mocks", "fix
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",

--- a/data-pipeline-libraries/data-pipeline-transform/pyproject.toml
+++ b/data-pipeline-libraries/data-pipeline-transform/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "dbt macro library for the Culvert data pipeline framework (audit columns, PII masking, data-quality checks). dbt-SQL only — no Apache Beam, no Airflow."
 readme = "README.md"
 requires-python = ">=3.10"
-license = { text = "MIT" }
+license = { text = "Apache-2.0" }
 authors = [
     { name = "Joseph Aruja", email = "joseph.a.aruja@googlemail.com" },
 ]
@@ -16,7 +16,7 @@ keywords = ["data", "pipeline", "framework", "culvert", "dbt", "bigquery", "pii-
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",

--- a/deployments/bigquery-to-mapped-product/pyproject.toml
+++ b/deployments/bigquery-to-mapped-product/pyproject.toml
@@ -7,14 +7,14 @@ name = "data-pipeline-ref-transform"
 version = "1.0.29"
 description = "GCP Pipeline Reference: Generic FDP Transformation — dbt models for ODP to FDP (JOIN + MAP patterns)"
 readme = "README.md"
-license = {text = "MIT"}
+license = {text = "Apache-2.0"}
 requires-python = ">=3.9"
 keywords = ["gcp", "bigquery", "dbt", "transformation", "reference", "example"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Libraries :: Application Frameworks",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/deployments/data-pipeline-orchestrator/pyproject.toml
+++ b/deployments/data-pipeline-orchestrator/pyproject.toml
@@ -7,14 +7,14 @@ name = "data-pipeline-ref-orchestration"
 version = "0.1.0"
 description = "Culvert reference: Generic Orchestration - Airflow DAGs for Cloud Composer (JOIN + MAP patterns)"
 readme = "README.md"
-license = {text = "MIT"}
+license = {text = "Apache-2.0"}
 requires-python = ">=3.9"
 keywords = ["gcp", "airflow", "composer", "orchestration", "reference", "example"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Libraries :: Application Frameworks",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/deployments/fdp-to-consumable-product/pyproject.toml
+++ b/deployments/fdp-to-consumable-product/pyproject.toml
@@ -7,14 +7,14 @@ name = "data-pipeline-ref-cdp"
 version = "1.0.29"
 description = "GCP Pipeline Reference: Generic CDP Transformation — dbt models for FDP to CDP (JOIN pattern across all 3 FDP tables)"
 readme = "README.md"
-license = {text = "MIT"}
+license = {text = "Apache-2.0"}
 requires-python = ">=3.9"
 keywords = ["gcp", "bigquery", "dbt", "cdp", "transformation", "reference", "example"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Libraries :: Application Frameworks",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/python-culvert/README.md
+++ b/python-culvert/README.md
@@ -53,4 +53,4 @@ the source.
 Docs, architecture, worked example deployments, and the engineering story:
 **https://github.com/enrichmeai/culvert**
 
-MIT licensed.
+Apache-2.0 licensed.

--- a/python-culvert/pyproject.toml
+++ b/python-culvert/pyproject.toml
@@ -22,14 +22,14 @@ name = "culvert"
 version = "0.2.0.dev0"
 description = "Cloud-agnostic, polyglot data-pipeline framework: one contract set, adapters per cloud. Python side of Culvert (Java twin on Maven Central: com.enrichmeai.culvert)."
 readme = "README.md"
-license = { text = "MIT" }
+license = { text = "Apache-2.0" }
 requires-python = ">=3.10"
 authors = [{ name = "Joseph Aruja" }]
 keywords = ["data-pipeline", "framework", "cloud-agnostic", "gcp", "bigquery", "dbt", "airflow", "contracts"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
Swap the root LICENSE for the canonical Apache-2.0 text and add a NOTICE file. Update license metadata everywhere it is declared: all 16 pyproject.toml files (license field + trove classifier), the parent POM's <licenses> block, and the license lines in README.md, COMMERCIAL.md, and the per-module READMEs.

Why: an explicit patent grant and retaliation clause that enterprise dependency review expects of infrastructure code; contribution licensing built into the license (s5); an explicit trademark reservation (s6); and a single license posture across EnrichMeAI projects (Cistern is already Apache-2.0).

All code to date is the copyright of Good Shepherd Software Consultancy Limited, so no contributor consent is required. Artifacts already published under MIT (PyPI culvert 0.1.0, Maven Central com.enrichmeai.culvert:* 0.1.0) remain MIT irrevocably; the next release is the first to carry Apache-2.0 metadata.